### PR TITLE
Fix 40

### DIFF
--- a/packages/smoldot-provider/package.json
+++ b/packages/smoldot-provider/package.json
@@ -12,11 +12,13 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
+    "prebuild": "yarn test && yarn clean",
     "build": "tsc --build src",
     "clean": "rm -rf dist/",
     "test": "ava --config ava.config.js",
     "examples": "ava --config ava.examples.config.js",
-    "prepack": "yarn test && yarn clean && yarn build"
+    "prepack": "yarn build",
+    "postinstall": "yarn build"
   },
   "release": [
     "dist/**"

--- a/packages/smoldot-provider/tsconfig.json
+++ b/packages/smoldot-provider/tsconfig.json
@@ -6,6 +6,7 @@
     "esModuleInterop": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
+    "skipLibCheck": true,
     "composite": true,
     "module": "ES2020",
     "target": "ES2018"


### PR DESCRIPTION
This pull request fixes #40 The following first run experience for smoldot-browser-demo now works:

```
git clone https://github.com/paritytech/substrate-connect
cd substrate-connect
yarn install
cd projects/smoldot-browser-demo
yarn run dev
```

I.e. No need to build smoldot-provider first as it builds post install and no errors building it as it skips the typescript lib check of typings.

I'd like to get rid of those warnings too when you run `yarn install` but I figured you're working on burnr @Stefie so I left them.

