### PR TITLE
Check for existing state and pass it to the smoldot client

### DIFF
--- a/packages/smoldot-provider/src/BrowserDatabase.ts
+++ b/packages/smoldot-provider/src/BrowserDatabase.ts
@@ -10,15 +10,19 @@ export class BrowserDatabase implements Database {
   #name: string;
 
   constructor(name: string) {
-      this.#name = `smoldot::chainstate::${name}`;
+    this.#name = `smoldot::chainstate::${name}`;
+  }
+
+  load(): string {
+    return window.localStorage.getItem(this.#name) || '';
   }
 
   save(state: string) {
-      window.localStorage.setItem(this.#name, state);
+    window.localStorage.setItem(this.#name, state);
   }
 
   delete() {
-      window.localStorage.removeItem(this.#name);
+    window.localStorage.removeItem(this.#name);
   }
 }
 

--- a/packages/smoldot-provider/src/Database.ts
+++ b/packages/smoldot-provider/src/Database.ts
@@ -27,6 +27,10 @@ let create: any = undefined;
  */
 export interface Database {
   /**
+   * @description Load existing chain state
+   */
+    load: () => string;
+  /**
    * @description Save the provided chain state
    */
     save: (state: string) => void;

--- a/packages/smoldot-provider/src/FsDatabase.test.ts
+++ b/packages/smoldot-provider/src/FsDatabase.test.ts
@@ -16,3 +16,21 @@ test('saves and deletes state', t=> {
   const error: NodeJS.ErrnoException = t.throws(() => stat(testDatabase), {instanceOf: Error});
   t.is(error.code, 'ENOENT');
 });
+
+test('load: loads previously saved state', t=> {
+  const db = new FsDatabase('test');
+  const state = '{ "test": "state" }';
+  db.save(state);
+  const loaded = db.load();
+  t.is(state, loaded);
+  db.delete();
+
+  const error: NodeJS.ErrnoException = t.throws(() => stat(testDatabase), {instanceOf: Error});
+  t.is(error.code, 'ENOENT');
+});
+
+test('load: returns empty string when there is no state', t=> {
+  const db = new FsDatabase('test');
+  const loaded = db.load();
+  t.is(loaded, '');
+});

--- a/packages/smoldot-provider/src/FsDatabase.ts
+++ b/packages/smoldot-provider/src/FsDatabase.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, unlinkSync } from 'fs';
+import { writeFileSync, readFileSync, statSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import mkdirp from 'mkdirp';
 import { Database } from './Database';
@@ -20,6 +20,21 @@ export class FsDatabase implements Database {
     mkdirp.sync(dbDir);
 
     this.#path = join(dbDir, `${name}.json`);
+  }
+
+  load(): string {
+    try {
+      statSync(this.#path);
+    } catch (error: any) { 
+      // Typescript does not allow type annotations on catch blocks :(
+      if (error.code === 'ENOENT') {
+        return '';
+      }
+
+      throw error;
+    }
+
+    return readFileSync(this.#path, { encoding: 'utf-8' });
   }
 
   save(state: string) {

--- a/packages/smoldot-provider/src/SmoldotProvider.test.ts
+++ b/packages/smoldot-provider/src/SmoldotProvider.test.ts
@@ -70,6 +70,7 @@ const respondWith = (jsonResponses: string[]) => {
 }
 
 class TestDatabase implements Database {
+  load(): string  { return ''; }
   save(state: string) {}
   delete() {}
 }

--- a/packages/smoldot-provider/src/SmoldotProvider.ts
+++ b/packages/smoldot-provider/src/SmoldotProvider.ts
@@ -83,7 +83,7 @@ export class SmoldotProvider implements ProviderInterface {
   readonly #waitingForId: Record<string, JsonRpcResponse> = {};
   #isConnected = false;
   #client: smoldot.SmoldotClient | undefined = undefined;
-  #db: Database | undefined;
+  #db: Database;
   // reference to the smoldot module so we can defer loading the wasm client
   // until connect is called
   #smoldot: smoldot.Smoldot;
@@ -198,6 +198,7 @@ export class SmoldotProvider implements ProviderInterface {
     assert(!this.#client && !this.#isConnected, 'Client is already connected');
 
     return this.#smoldot.start({
+        database_content: this.#db.load(),
         chain_spec: this.#chainSpec,
         json_rpc_callback: (response: string) => {
             this.#handleRpcReponse(response);

--- a/packages/smoldot-provider/types/smoldot/index.d.ts
+++ b/packages/smoldot-provider/types/smoldot/index.d.ts
@@ -10,6 +10,7 @@ export type SmoldotJsonRpcCallback = (response: string) => void;
 export type SmoldotDatabaseSaveCallback = (response: string) => void;
 
 export interface SmoldotOptions {
+  database_content: string;
   chain_spec: string;
   json_rpc_callback: SmoldotJsonRpcCallback;
   database_save_callback: SmoldotDatabaseSaveCallback;


### PR DESCRIPTION
This adds functionality to check if an existing database exists (either saved to disk in node or in the local storage in the browser) and provides it to the smoldot client when `connect` is called on the `SmoldotProvider`.  There are no user facing changes, it should just now do the right thing.