### PR TITLE
Issue #53 - alter scripts on projects/burnr/package.json that was not allowing 'y…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 yarn-error.log
+dist

--- a/projects/burnr/package.json
+++ b/projects/burnr/package.json
@@ -13,8 +13,8 @@
     "build:server": "tsc -b src",
     "dev:client": "NODE_ENV=development cross-env webpack-dev-server -w",
     "dev:server": "NODE_ENV=development tsc-watch --noClear -b ./src/tsconfig.json --onSuccess \"node --enable-source-maps index.js\"",
-    "dev": "NODE_ENV=development yarn run dev-server & yarn run dev-client",
-    "build": "yarn run build-server & yarn run build-client"
+    "dev": "NODE_ENV=development yarn run dev:server & yarn run dev:client",
+    "build": "yarn run build:server & yarn run build:client"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- alter scripts on projects/burnr/package.json that was not allowing 'yarn run dev:burnr' to execute due to a typo. 
- Add dist to .gitignore in order to avoid pushing dist dirs to repo