### PR TITLE
Move creation of account in localstorage to App level and make reusab…

### DIFF
--- a/projects/burnr/src/App.tsx
+++ b/projects/burnr/src/App.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { BrowserRouter, Route, Switch } from 'react-router-dom'; // Pages
 import { makeStyles } from '@material-ui/core/styles';
 
 import { ApiContext } from './utils/contexts';
-import { useApiCreate } from './hooks';
+import { useApiCreate, useLocalStorage } from './hooks';
+import { createLocalStorageAccount } from './utils/utils';
 
 import Home from './Home';
 
@@ -22,13 +23,23 @@ const useStyles = makeStyles(theme => ({
 	},
 	main: {
 		width: '100%',
-		maxWidth: theme.spacing(3) + 600 + 'px',
+		maxWidth: theme.spacing(3) + 650 + 'px',
 		padding: theme.spacing(2),
 		flex: 1,
 	},
 }));
 
-const  App: React.FunctionComponent<Props> = ({ className }: Props) => {
+const App: React.FunctionComponent<Props> = ({ className }: Props) => {
+	const [endpoint] = useLocalStorage('endpoint');
+	const [localStorageAccount, setLocalStorageAccount] = useLocalStorage(endpoint?.split('-')[0]?.toLowerCase());
+	
+	useEffect((): void => {
+		if (!localStorageAccount) {
+			const userTmp = createLocalStorageAccount();
+			setLocalStorageAccount(JSON.stringify(userTmp));
+		}
+	}, [localStorageAccount]);
+
 	const api = useApiCreate();
 	const classes = useStyles();
 

--- a/projects/burnr/src/Home.tsx
+++ b/projects/burnr/src/Home.tsx
@@ -1,11 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 import { Grid, Paper, Divider, IconButton, Box, makeStyles, Theme } from '@material-ui/core';
 import VisibilityIcon from '@material-ui/icons/Visibility';
-
-import { uniqueNamesGenerator, Config, starWars } from 'unique-names-generator';
-import { Keyring } from '@polkadot/api';
-import { mnemonicGenerate } from '@polkadot/util-crypto';
 import { LocalStorageUserAccount } from './utils/types';
 
 import { NavTabs, AccountCard, BalanceValue, Bg } from './components';
@@ -18,38 +14,15 @@ const useStyles = makeStyles((theme: Theme) => ({
 		},
 	})
 );
-
-const config: Config = {
-	dictionaries: [starWars]
-}
-
 // @TODO read balance
 // @TODO account name
 function Home ():  React.ReactElement {
 	const classes = useStyles();
 	const [endpoint] = useLocalStorage('endpoint');
-	const [localStorageAccount, setLocalStorageAccount] = useLocalStorage(endpoint?.split('-')[0]?.toLowerCase());
-	const [user, setUser] = useState<LocalStorageUserAccount>();
+	const [localStorageAccount] = useLocalStorage(endpoint?.split('-')[0]?.toLowerCase());
+	const [user, setUser] = useState<LocalStorageUserAccount>(JSON.parse(localStorageAccount));
 
-	useEffect((): void => {
-		if (!localStorageAccount) {
-			const mnemonic = mnemonicGenerate(12);
-			const pair = new Keyring({ type: 'sr25519' })
-				.addFromUri(mnemonic, { name: uniqueNamesGenerator(config) }, 'sr25519');
-			const userTmp = {
-				address: pair.address,
-				name: pair.meta.name || '____ _____',
-				seed: mnemonic,	// just saving the mnemonic for now - will drop if not needed
-				json: pair.toJson()
-			}
-			setLocalStorageAccount(JSON.stringify(userTmp));
-			setUser(userTmp);
-		} else {
-			setUser(JSON.parse(localStorageAccount));
-		}
-	}, [localStorageAccount]);
-
-	const userInfo = useUserInfo(localStorageAccount && JSON.parse(localStorageAccount).address);
+	const userInfo = useUserInfo(user.address);
 
 	return (
 		<>
@@ -94,7 +67,7 @@ function Home ():  React.ReactElement {
 				</Box>
 			</Paper>
 			<Divider/>
-			<NavTabs />
+			<NavTabs setUser={setUser} />
 		</>
 	);
 }

--- a/projects/burnr/src/components/AccountMenu.tsx
+++ b/projects/burnr/src/components/AccountMenu.tsx
@@ -6,7 +6,8 @@ import LanguageIcon from '@material-ui/icons/Language';
 import GetAppIcon from '@material-ui/icons/GetApp';
 import WhatshotIcon from '@material-ui/icons/Whatshot';
 
-import { openInNewTab, downloadFile } from '../utils/utils';
+import { LocalStorageUserAccount } from '../utils/types';
+import { openInNewTab, downloadFile, createLocalStorageAccount } from '../utils/utils';
 import { POLKA_ACCOUNT_ENDPOINTS } from '../utils/constants';
 import { useLocalStorage } from '../hooks';
 
@@ -20,17 +21,27 @@ const useStyles = makeStyles((theme: Theme) =>
 
 const { polkastats, polkascan } = POLKA_ACCOUNT_ENDPOINTS;
 
-const AccountMenu: React.FunctionComponent = () => {
+interface Props {
+	setUser: (arg0: LocalStorageUserAccount) => void;
+}
+
+const AccountMenu: React.FunctionComponent<Props> = ({ setUser }: Props) => {
 	const classes = useStyles();
 	const [endpoint] = useLocalStorage('endpoint');
 	const minEndpoint = endpoint?.split('-')[0]?.toLowerCase();
-	const [localStorage] = useLocalStorage(minEndpoint);
+	const [lclStorage, setLclStorage] = useLocalStorage(minEndpoint);
 	const [polkastatsUri] = useState(
 		`https://${minEndpoint}.${polkastats}`
 	);
 	const [polkascanUri] = useState(`https://${polkascan}/${minEndpoint}`);
+	const { address, json, seed } = JSON.parse(lclStorage);
 
-	const { address, json, seed } = JSON.parse(localStorage);
+	const burnAndCreate = (): void => {
+		localStorage.removeItem(minEndpoint);
+		const userTmp = createLocalStorageAccount();
+		setLclStorage(JSON.stringify(userTmp));
+		setUser(userTmp);
+	  };
 	return (
 		<Grid
 			container
@@ -76,7 +87,10 @@ const AccountMenu: React.FunctionComponent = () => {
 				</Grid>
 			</Grid>
 			<Grid item className={classes.section}>
-				<Button style={{ color: red[500] }} startIcon={<WhatshotIcon />}>
+				<Button
+					style={{ color: red[500] }}
+					startIcon={<WhatshotIcon />}
+					onClick={() => burnAndCreate()}>
           Burn
 				</Button>
 			</Grid>

--- a/projects/burnr/src/components/NavTabs.tsx
+++ b/projects/burnr/src/components/NavTabs.tsx
@@ -3,7 +3,10 @@ import React from 'react';
 import { Tabs, Tab, Typography, Box, Paper, Divider, makeStyles, Theme } from '@material-ui/core';
 import SwapHorizSharpIcon from '@material-ui/icons/SwapHorizSharp';
 import CallMadeSharpIcon from '@material-ui/icons/CallMadeSharp';
+import CallReceivedSharpIcon from '@material-ui/icons/CallReceivedSharp';
 import WhatshotSharpIcon from '@material-ui/icons/WhatshotSharp';
+
+import { LocalStorageUserAccount } from '../utils/types';
 
 import { HistoryTable, AccountMenu } from './index';
 import SendFundsForm from './SendFundsForm';
@@ -12,6 +15,10 @@ interface TabPanelProps {
   children?: React.ReactNode;
   index: number;
   value: number;
+}
+
+interface Props {
+	setUser: (arg0: LocalStorageUserAccount) => void;
 }
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -42,7 +49,7 @@ const TabPanel: React.FunctionComponent<TabPanelProps> = ({ children, value, ind
 	);
 };
 
-const NavTabs: React.FunctionComponent = () => {
+const NavTabs: React.FunctionComponent<Props> = ({ setUser }: Props) => {
 	const classes = useStyles();
 	const [value, setValue] = React.useState(0);
 	const handleChange = (event: React.ChangeEvent<{}>, newValue: number) => {
@@ -60,6 +67,7 @@ const NavTabs: React.FunctionComponent = () => {
 					<Tab label="Account" icon={<WhatshotSharpIcon/>} style={{ minHeight: 64, paddingTop: 0 }} />
 					<Tab label="History" icon={<SwapHorizSharpIcon/>} style={{ minHeight: 64, paddingTop: 0 }}  />
 					<Tab label="Send" icon={<CallMadeSharpIcon/>} style={{ minHeight: 64, paddingTop: 0 }}  />
+					<Tab label="Receive" icon={<CallReceivedSharpIcon/>} style={{ minHeight: 64, paddingTop: 0 }}  />
 				</Tabs>
 			</Paper>
 
@@ -70,7 +78,7 @@ const NavTabs: React.FunctionComponent = () => {
 					<Typography variant='h2'>
 						Account Controls
 					</Typography>
-					<AccountMenu />
+					<AccountMenu setUser={setUser} />
 				</TabPanel>
 				<TabPanel value={value} index={1}>
 					<Typography variant='h2'>
@@ -83,6 +91,15 @@ const NavTabs: React.FunctionComponent = () => {
 						Send Funds
 					</Typography>
 					<SendFundsForm />
+				</TabPanel>
+				<TabPanel value={value} index={3}>
+					<Typography variant='h2'>
+						Receive Funds
+					</Typography>
+					{/*  TO-DO:
+						Need to create the <ReceiveFundsFrom />
+						Needs some more brainstorming/research on what will be put here
+					*/}
 				</TabPanel>
 			</Paper>
 		</>

--- a/projects/burnr/src/utils/utils.ts
+++ b/projects/burnr/src/utils/utils.ts
@@ -1,4 +1,11 @@
-import { Account } from './types';
+import { Account, LocalStorageUserAccount } from './types';
+import { uniqueNamesGenerator, Config, starWars } from 'unique-names-generator';
+import { mnemonicGenerate } from '@polkadot/util-crypto';
+import { Keyring } from '@polkadot/api';
+
+const config: Config = {
+	dictionaries: [starWars]
+}
 
 export const getName = (account: Account): string => `${account.name}`;
 
@@ -20,4 +27,16 @@ export const downloadFile = (fileName: string, data: string, type: string): void
     anchor.click();
     document.body.removeChild(anchor);
     window.URL.revokeObjectURL(anchor.href);
+  }
+
+  export const createLocalStorageAccount = (): LocalStorageUserAccount => {
+    const mnemonic = mnemonicGenerate(12);
+    const pair = new Keyring({ type: 'sr25519' })
+        .addFromUri(mnemonic, { name: uniqueNamesGenerator(config) }, 'sr25519');
+    return {
+        address: pair.address,
+        name: pair.meta.name || '____ _____',
+        seed: mnemonic,
+        json: pair.toJson()
+    }
   }


### PR DESCRIPTION
- Move creation of account in localstorage to App level and make reusable utils function for actual creation;
- Fix Burn funtionality to recreate user and rerender the name; 
- Add the Receive Tab with empty tab

Solves https://github.com/paritytech/substrate-connect/issues/64