### PR TITLE
Improve SmoldotProvider event emitting

### DIFF
--- a/packages/smoldot-provider/package.json
+++ b/packages/smoldot-provider/package.json
@@ -15,7 +15,7 @@
     "prebuild": "yarn test && yarn clean",
     "build": "tsc --build src",
     "clean": "rm -rf dist/",
-    "test": "ava --config ava.config.js",
+    "test": "ava --config ava.config.js --verbose",
     "examples": "ava --config ava.examples.config.js",
     "prepack": "yarn build",
     "postinstall": "yarn build"

--- a/packages/smoldot-provider/src/SmoldotProvider.test.ts
+++ b/packages/smoldot-provider/src/SmoldotProvider.test.ts
@@ -160,21 +160,6 @@ test('emits error when system_health responds with error', async t => {
   });
 });
 
-test('emits error when it does not receive peers > 0', async t => {
-  const ms = mockSmoldot(respondWith([]), unhealthyResponder);
-  const provider = new SmoldotProvider(EMPTY_CHAIN_SPEC, testDb(), ms);
-
-  // we don't want the test to be slow
-  provider.healthPingerInterval = 1;
-  await provider.connect();
-  return new Promise<void>((resolve, reject) => {
-    provider.on('error', error => {
-      t.is(error.message, 'Timed out waiting for smoldot to connect to peers');
-      return provider.disconnect().then(() => resolve());
-    });
-  });
-});
-
 test('emits events when it connects then disconnects', async t => {
   const ms = mockSmoldot(respondWith([]), customHealthResponder([true, false]));
   const provider = new SmoldotProvider(EMPTY_CHAIN_SPEC, testDb(), ms);

--- a/packages/smoldot-provider/src/SmoldotProvider.test.ts
+++ b/packages/smoldot-provider/src/SmoldotProvider.test.ts
@@ -320,8 +320,7 @@ test('subscribe', async t => {
       }
 
       t.deepEqual(result, { dummy: "state" });
-      provider.disconnect();
-      resolve();
+      provider.disconnect().then(() => resolve());
     }).then(reply => {
       t.is(reply, "SUBSCRIPTIONID");
     });
@@ -411,5 +410,5 @@ test('unsubscribe removes subscriptions', async t => {
   const id = await provider.subscribe('test', 'test_subscribe', [], () => {});
   const reply =  await provider.unsubscribe('test', 'test_unsubscribe', id);
   t.true(reply);
-  provider.disconnect();
+  await provider.disconnect();
 });

--- a/packages/smoldot-provider/src/SmoldotProvider.ts
+++ b/packages/smoldot-provider/src/SmoldotProvider.ts
@@ -14,7 +14,7 @@ import { assert, isUndefined, logger } from '@polkadot/util';
 import EventEmitter from 'eventemitter3';
 import * as smoldot from 'smoldot';
 import database, { Database } from './Database';
-import { PeerTimeoutError, HealthCheckError } from './errors';
+import { HealthCheckError } from './errors';
 
 const l = logger('smoldot-provider');
 

--- a/packages/smoldot-provider/src/SmoldotProvider.ts
+++ b/packages/smoldot-provider/src/SmoldotProvider.ts
@@ -206,6 +206,20 @@ export class SmoldotProvider implements ProviderInterface {
   }
 
   #simulateLifecycle = health => {
+    // development chains should not have peers so we only emit connected
+    // once and never disconnect
+    if (health.shouldHavePeers == false) {
+      
+      if (!this.#isConnected) {
+        this.#isConnected = true;
+        this.emit('connected');
+        l.debug(`emitted CONNECTED`);
+        return;
+      }
+
+      return;
+    }
+
     const peerCount = health.peers;
 
     l.debug(`Simulating lifecylce events from system_health`);

--- a/packages/smoldot-provider/src/errors.ts
+++ b/packages/smoldot-provider/src/errors.ts
@@ -13,7 +13,7 @@ export class HealthCheckError extends Error {
     return this.#cause;
   }
 
-  constructor(response: any, message = "Got error reponse asking for system health") {
+  constructor(response: any, message = "Got error response asking for system health") {
     super(message); 
     this.#cause = response;
     // 'Error' breaks the prototype chain - restore it

--- a/packages/smoldot-provider/src/errors.ts
+++ b/packages/smoldot-provider/src/errors.ts
@@ -1,11 +1,3 @@
-export class PeerTimeoutError extends Error {
-  constructor(message = "Timed out waiting for smoldot to connect to peers") {
-    super(message); 
-    // 'Error' breaks the prototype chain - restore it
-    Object.setPrototypeOf(this, new.target.prototype);
-  }
-}
-
 export class HealthCheckError extends Error {
   readonly #cause: any;
 

--- a/packages/smoldot-provider/src/errors.ts
+++ b/packages/smoldot-provider/src/errors.ts
@@ -1,0 +1,23 @@
+export class PeerTimeoutError extends Error {
+  constructor(message = "Timed out waiting for smoldot to connect to peers") {
+    super(message); 
+    // 'Error' breaks the prototype chain - restore it
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class HealthCheckError extends Error {
+  readonly #cause: any;
+
+  getCause() {
+    return this.#cause;
+  }
+
+  constructor(response: any, message = "Got error reponse asking for system health") {
+    super(message); 
+    this.#cause = response;
+    // 'Error' breaks the prototype chain - restore it
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+


### PR DESCRIPTION
This is the implementation of lifecycle events outlined in #60.  I have deviated from the initially planned implementation.

After extensive testing against Westend and  comparing with the `WSProvider`, I discovered that the length of time to get peers is highly variable.  It can be almost instant but it can take over 10 seconds.  The client is still usable with no peers but it will not respond to certain queries.  Therefore it doesn't makes sense to simulate the "error if we don't connect behaviour" unless we get errors from the `system_health` request. 

Also after discussing with Gav and Pierre on element, there is another property on the health response that is relevant: `shouldHavePeers`. This is set to `false` for development chains which are not expected to have any peers and the `system_health` response is never expected to respond with `peers > 0`. (we haven't encountered such a scenario yet but will do later on).

So the final implementation is as follows:

1. When `connect` is called start an interval pinger asking for the `system_health`.
2. If we see `shouldHavePeers` is false emit the `connected` event and never emit `disconnected`
3. Otherwise .. 
  * if we're not connected and `peers > 0` emit the `connected` event
  * if we're connected and `peers === 0` emit the `disconnected` event
4. If we ever get an error response from `system_health` emit the `error` event

Previously we always emitted `connected` when successfully calling `connect` and only emitted `disconnected` if we called `disconnect`

I've kept the steps I took in the commit history experimenting with different event implementations so you can see what i tried if you're interested but if we're happy with the final outcome this PR should be squashed