### PR TITLE
Fixed manifest warning in FF extension

### DIFF
--- a/projects/smoldot-extension/src/assets/manifest.json
+++ b/projects/smoldot-extension/src/assets/manifest.json
@@ -18,7 +18,9 @@
     "default_title": "Substrate Connect",
     "default_popup": "popup.html"
   },
-  "options_page": "options.html",
+  "options_ui": {
+    "page": "options.html"
+  },
   "content_scripts": [{
     "js": ["content.js"],
     "matches": ["http://*/*", "https://*/*"],


### PR DESCRIPTION
fixes this:

<img width="699" alt="Screenshot 2021-02-19 at 16 28 17" src="https://user-images.githubusercontent.com/8782596/108524643-89c33300-72cf-11eb-9f17-38eccf21b943.png">
