### PR TITLE
Rm test extension background

### DIFF
--- a/projects/extension/src/background/AppMediator.test.ts
+++ b/projects/extension/src/background/AppMediator.test.ts
@@ -105,7 +105,7 @@ describe('AppMediator regular message processing', () => {
 
 describe('Appmediator subscription message processing', () => {
   
-  it.only('tracks and forwards subscriptions', () => {
+  it('tracks and forwards subscriptions', () => {
     const port = new MockPort('test');
     const manager = new MockConnectionManager(true);
     const am = new AppMediator('test', port, manager);

--- a/projects/extension/src/background/AppMediator.ts
+++ b/projects/extension/src/background/AppMediator.ts
@@ -156,6 +156,8 @@ export class AppMediator {
       return;
     }
 
+    this.#manager.registerAppWithSmoldot(this, name);
+
     this.#smoldotName = name;
     this.#state = 'ready';
     return;

--- a/projects/extension/src/background/AppMediator.ts
+++ b/projects/extension/src/background/AppMediator.ts
@@ -55,6 +55,15 @@ export class AppMediator {
     return this.#state;
   }
 
+  // State helpers that return clones of the internal state - useful for testing
+  cloneRequests(): MessageIDMapping[] { 
+    return JSON.parse(JSON.stringify(this.requests)) as MessageIDMapping[];
+  }
+
+  cloneSubscriptions(): SubscriptionMapping[] { 
+    return JSON.parse(JSON.stringify(this.subscriptions)) as SubscriptionMapping[];
+  }
+
   #sendError = (message: string): void => {
     const error: ExtensionMessage = { type: 'error', payload: message };
     this.#port.postMessage(error);
@@ -63,11 +72,11 @@ export class AppMediator {
   processSmoldotMessage(message: JsonRpcResponse): boolean {
     // subscription message
     if (message.method) {
-      if(!(message as JsonRpcResponseSubscription).params.subscription) {
+      if(!(message as JsonRpcResponseSubscription).params?.subscription) {
         throw new Error('Got a subscription message without a subscription id');
       }
 
-      const sub = this.subscriptions.find(s => s.subID == message.params.subscription);
+      const sub = this.subscriptions.find(s => s.subID == message.params?.subscription);
       if (!sub) {
         // not our subscription
         return false;

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -15,7 +15,7 @@ export class ConnectionManager implements ConnectionManagerInterface {
     });
   }
 
-  get registedApps(): string[] {
+  get registeredApps(): string[] {
     return this.#apps.map(a => a.name);
   }
 
@@ -48,6 +48,15 @@ export class ConnectionManager implements ConnectionManagerInterface {
     return sm.sendRpcMessage(message);
   }
 
+  registerAppWithSmoldot(app: AppMediator, smoldotName: string): void {
+    const sm = this.#smoldots.find(s => s.name === smoldotName);
+    if (!sm) {
+      throw new Error('Tried to add app to smoldot that does not exist.');
+    }
+
+    sm.addApp(app);
+  }
+
   async addSmoldot(name: string,  chainSpec: string, testSmoldot?: smoldot.Smoldot): Promise<void> {
     const client = testSmoldot || smoldot;
     if (this.#smoldots.find(s => s.name == name)) {
@@ -63,7 +72,7 @@ export class ConnectionManager implements ConnectionManagerInterface {
         max_log_level: 3,
         json_rpc_callback: (message: string) => {
           const parsed = JSON.parse(message) as JsonRpcResponse;
-          for (const app of this.#apps) {
+          for (const app of sm.apps) {
             if (app.processSmoldotMessage(parsed)) {
               break;
             }

--- a/projects/extension/src/background/SmoldotMediator.ts
+++ b/projects/extension/src/background/SmoldotMediator.ts
@@ -1,15 +1,26 @@
+import { AppMediator } from './AppMediator';
 import { JsonRpcRequest } from './types';
 import { SmoldotClient } from 'smoldot';
 
 export class SmoldotMediator {
   readonly name: string;
   readonly #smoldot: SmoldotClient;
+  readonly #apps: AppMediator[];
   #id: number;
 
   constructor(name: string, smoldot: SmoldotClient) {
     this.name = name;
     this.#smoldot = smoldot;
     this.#id = 0;
+    this.#apps = [];
+  }
+
+  get apps(): AppMediator[] {
+    return this.#apps;
+  }
+
+  addApp(app: AppMediator): void {
+    this.#apps.push(app);
   }
 
   sendRpcMessage(message: JsonRpcRequest): number {

--- a/projects/extension/src/background/mocks.ts
+++ b/projects/extension/src/background/mocks.ts
@@ -1,3 +1,4 @@
+import { AppMediator } from './AppMediator';
 import { AppMessage, ConnectionManagerInterface } from './types';
 
 export class MockPort implements chrome.runtime.Port {
@@ -42,6 +43,10 @@ export class MockConnectionManager implements ConnectionManagerInterface {
 
   constructor(willFindClient: boolean) {
     this.#willFindClient = willFindClient;
+  }
+
+  registerAppWithSmoldot(app: AppMediator, name: string) {
+    return;
   }
 
   hasClientFor = (name: string) => {

--- a/projects/extension/src/background/types.ts
+++ b/projects/extension/src/background/types.ts
@@ -1,3 +1,4 @@
+import { AppMediator } from './AppMediator';
 // Messages that come from the app
 export type AppMessageType = 'associate' | 'rpc';
 
@@ -18,12 +19,12 @@ export interface ExtensionMessage {
 export type AppState = 'connected' | 'ready' | 'disconnecting' | 'disconnected';
 
 export interface MessageIDMapping {
-  readonly appID: number;
+  readonly appID: number | undefined;
   readonly smoldotID: number;
 }
 
 export interface SubscriptionMapping {
-  readonly appIDForRequest: number;
+  readonly appIDForRequest: number | undefined;
   subID: number | string  | undefined;
   method: string;
 }
@@ -31,6 +32,7 @@ export interface SubscriptionMapping {
 export interface ConnectionManagerInterface {
   hasClientFor: (name: string) => boolean;
   sendRpcMessageTo: (name: string, message: JsonRpcRequest) => number;
+  registerAppWithSmoldot(app: AppMediator, name: string);
 }
 
 export interface JsonRpcObject {

--- a/projects/extension/src/background/types.ts
+++ b/projects/extension/src/background/types.ts
@@ -4,6 +4,7 @@ export type AppMessageType = 'associate' | 'rpc';
 export interface AppMessage {
   type: AppMessageType;
   payload: string; // smoldot name / json / message_id / subscription_id
+  subscription?: boolean;
 }
 
 // Messages that we send to the app
@@ -24,6 +25,7 @@ export interface MessageIDMapping {
 export interface SubscriptionMapping {
   readonly appIDForRequest: number;
   subID: number | string  | undefined;
+  method: string;
 }
 
 export interface ConnectionManagerInterface {
@@ -32,8 +34,8 @@ export interface ConnectionManagerInterface {
 }
 
 export interface JsonRpcObject {
-  id: number;
-  jsonrpc: '2.0';
+  id?: number;
+  jsonrpc: string;
 }
 
 export interface JsonRpcRequest extends JsonRpcObject {

--- a/projects/extension/src/background/types.ts
+++ b/projects/extension/src/background/types.ts
@@ -54,7 +54,7 @@ export interface JsonRpcResponseSingle {
 
 export interface JsonRpcResponseSubscription {
   method?: string;
-  params: {
+  params?: {
     error?: JsonRpcResponseBaseError;
     result: unknown;
     subscription: number | string;


### PR DESCRIPTION
* Tests for the message multiplexing - both regular messages and subscriptions.

* Fixes the messages being send to all apps regardless of the smoldot they came from by registering the app with a particular smoldot

* Expects to be told when a message is a subscription in the message posted through the port.  This means when the `subscription` parameter in the `send()` function on the provider is passed you must add a `subscription: true` property to the message you post send through the port.