### PR TITLE
Unsubscribe from all subscriptions when a UApp disconnects

### DIFF
--- a/projects/extension/src/background/AppMediator.test.ts
+++ b/projects/extension/src/background/AppMediator.test.ts
@@ -15,6 +15,14 @@ describe('AppMediator setup', () => {
 
 });
 
+function associateWithNetwork(am: AppMediator, port: MockPort, network: string) {
+  port.triggerMessage({ type: 'associate', payload: network });
+  expect(am.state).toBe('ready');
+  expect(am.smoldotName).toBe(network);
+
+  // TODO: check that an info message is sent back to the UApp on success
+}
+
 describe('AppMediator - protocol with content script', () => {
 
   it('becomes ready after associating with a client and can send messages', () => {
@@ -22,8 +30,7 @@ describe('AppMediator - protocol with content script', () => {
     const manager = new MockConnectionManager(true);
     const am = new AppMediator('test', port,manager);
 
-    port.triggerMessage({ type: 'associate', payload: 'westend' });
-    expect(am.state).toBe('ready');
+    associateWithNetwork(am, port, 'westend');
 
     port.triggerMessage({ type: 'rpc', payload: '{ "id": 1 }'});
     expect(am.requests.length).toBe(1);
@@ -46,8 +53,7 @@ describe('AppMediator - protocol with content script', () => {
   it('emits error when recieves RPC message before associated', () => {
     const port = new MockPort('test');
     const manager = new MockConnectionManager(false);
-    const am = new AppMediator('test', port,manager);
-    const network = 'westend';
+    const am = new AppMediator('test', port, manager);
 
     port.triggerMessage({ type: 'rpc', payload: '' });
     expect(port.postMessage).toBeCalledTimes(1);
@@ -55,22 +61,19 @@ describe('AppMediator - protocol with content script', () => {
       type: 'error', 
       payload: `The app is not associated with a blockchain client`
     });
-
-
-    // TODO - test receiving RPC message when state is 'disconnecting' | 'disconnected'
   });
 
+  // TODO - test receiving RPC message when state is 'disconnecting' | 'disconnected'
 });
 
 describe('AppMediator regular message processing', () => {
 
   it('does nothing when it has sent no requests', () => {
     const port = new MockPort('test');
-    const manager = new MockConnectionManager(false);
-    const am = new AppMediator('test', port,manager);
-    // asociate
-    const network = 'westend';
-    port.triggerMessage({ type: 'associate', payload: network });
+    const manager = new MockConnectionManager(true);
+    const am = new AppMediator('test', port, manager);
+
+    associateWithNetwork(am, port, 'polkadot');
 
     const message: JsonRpcResponse = { id: 1, jsonrpc: '2.0', result: {} };
 
@@ -80,79 +83,91 @@ describe('AppMediator regular message processing', () => {
   it('remaps the id to the apps id', () => {
     const port = new MockPort('test');
     const manager = new MockConnectionManager(true);
-    const am = new AppMediator('test', port,manager);
-    // asociate
-    const network = 'westend';
-    port.triggerMessage({ type: 'associate', payload: network });
+    const am = new AppMediator('test', port, manager);
 
-    // send RPC request
+    associateWithNetwork(am, port, 'kusama');
+
+    // Fake getting a request from UApp to send an RPC message
     port.triggerMessage({ 
       type: 'rpc', 
-      payload: '{ "id": 1, "jsonrpc": "2.0", "method": "system_health", "params": [] }' 
+      payload: '{"id":1,"jsonrpc":"2.0","method":"state_getStorage","params":["<hash>"]}' 
     });
-    // RPC response
-    const message: JsonRpcResponse = { id: 42, jsonrpc: '2.0', result: {} };
     // should have a request mapping
     expect(am.cloneRequests().length).toBe(1);
 
+    // Fake an RPC response to the request
+    const message: JsonRpcResponse = { id: 42, jsonrpc: '2.0', result: {} };
     expect(am.processSmoldotMessage(message)).toBe(true);
     // should have removed request mapping
     expect(am.cloneRequests().length).toBe(0);
+    // should have posted the message back to the UApp with the mapped ID
     expect(port.postMessage.mock.calls[0][0].payload)
       .toEqual('{"id":1,"jsonrpc":"2.0","result":{}}');
   });
 });
+
+function setupAppMediatorWithSubscription(am: AppMediator, port: MockPort, subID: number) {
+  const prevRequestCount = am.cloneRequests().length;
+  const prevSubCount = am.cloneSubscriptions().length;
+
+  // Fake a message with an RPC request to add a subscription
+  port.triggerMessage({ 
+    type: 'rpc', 
+    payload: '{ "id": 1, "jsonrpc": "2.0", "method": "system_health", "params": [] }' ,
+    subscription: true
+  });
+
+  // should have a request mapping and a subscription mapping with no mapped subID yet
+  expect(am.cloneRequests().length).toBe(prevRequestCount + 1);
+  expect(am.cloneSubscriptions().length).toBe(prevSubCount + 1);
+  expect(am.cloneSubscriptions()[0])
+    .toEqual({ appIDForRequest: 1, subID: undefined, method: 'system_health' });
+
+  // Fake receiving an RPC response to the subscription request
+  const message: JsonRpcResponse = { id: 42, jsonrpc: '2.0', result: subID };
+  am.processSmoldotMessage(message);
+
+  // Should have removed the request mapping and updated the subscription
+  expect(am.cloneRequests().length).toBe(prevRequestCount);
+  expect(am.cloneSubscriptions()[0])
+    .toEqual({ appIDForRequest: 1, subID: 2, method: 'system_health' });
+
+  // should send the acknowledgement of the subscription request back to the UApp
+  const msgCalls = port.postMessage.mock.calls;
+  const lastMsg = msgCalls[msgCalls.length - 1][0];
+  expect(lastMsg.payload).toEqual(`{"id":1,"jsonrpc":"2.0","result":${subID}}`);
+}
 
 describe('Appmediator subscription message processing', () => {
   
   it('tracks and forwards subscriptions', () => {
     const port = new MockPort('test');
     const manager = new MockConnectionManager(true);
-    const am = new AppMediator('test', port,manager);
-    // asociate
-    const network = 'westend';
-    port.triggerMessage({ type: 'associate', payload: network });
+    const am = new AppMediator('test', port, manager);
 
-    // send RPC sub request
-    port.triggerMessage({ 
-      type: 'rpc', 
-      payload: '{ "id": 1, "jsonrpc": "2.0", "method": "system_health", "params": [] }' ,
-      subscription: true
-    });
-    // should have a request mapping and a subscription mapping
-    expect(am.cloneRequests().length).toBe(1);
-    expect(am.cloneSubscriptions().length).toBe(1);
-    // has sub with no subID
-    expect(am.cloneSubscriptions()[0]).toEqual({ appIDForRequest: 1, subID: undefined, method: 'system_health' });
+    associateWithNetwork(am, port, 'westend');
 
-    // RPC response with sub id
-    const message: JsonRpcResponse = { id: 42, jsonrpc: '2.0', result: 2 };
-    am.processSmoldotMessage(message);
+    const subscriptionId = 2;
+    setupAppMediatorWithSubscription(am, port, subscriptionId);
 
-    // updates sub with sub id
-    expect(am.cloneSubscriptions()[0]).toEqual({ appIDForRequest: 1, subID: 2, method: 'system_health' });
-
-    // should send sub response back to app
-    expect(port.postMessage.mock.calls[0][0].payload)
-      .toEqual('{"id":1,"jsonrpc":"2.0","result":2}');
-
-    // RPC subcription message
+    // Fake receiving an RPC message for the subscription
     const subMessage = { 
       jsonrpc: '2.0', 
       method: 'system_health',
-      params: { subscription: 2, result: 2 }
+      params: { subscription: subscriptionId, result: "subscription value" }
     };
     expect(am.processSmoldotMessage(subMessage)).toBe(true);
 
-    // should send subcription message back to app
+    // should send subcription message back to the UApp unchanged
     expect(port.postMessage.mock.calls[1][0].payload)
-      .toEqual('{"jsonrpc":"2.0","method":"system_health","params":{"subscription":2,"result":2}}');
+      .toEqual(JSON.stringify(subMessage));
 
-    // RPC subcription message not for us
+    // Fake receiving an RPC message with a subscription ID that is not one of
+    // our subscriptions
     const subMessage2 = { 
       jsonrpc: '2.0', 
       method: 'system_health',
-      params: { subscription: 666, result: 2 }
+      params: { subscription: 666, result: "subscription value" }
     };
     // shouldnt process it
     expect(am.processSmoldotMessage(subMessage2)).toBe(false);

--- a/projects/extension/src/background/AppMediator.ts
+++ b/projects/extension/src/background/AppMediator.ts
@@ -92,8 +92,7 @@ export class AppMediator {
         if (this.requests.length === 0) {
           // All our unsubscription messages have been replied to
           this.#state = 'disconnected';
-          // TODO: remove this AppMediator from ConnectionManager and SmoldotMediator
-          // TODO: send notifications
+          this.#manager.unregisterApp(this, this.#smoldotName as string);
         }
 
         return true;

--- a/projects/extension/src/background/AppMediator.ts
+++ b/projects/extension/src/background/AppMediator.ts
@@ -187,7 +187,7 @@ export class AppMediator {
       this.#sendError(`Extension does not have client for ${name}`);
       return;
     }
-    this.#manager.registerAppWithSmoldot(this, name);
+    this.#manager.registerApp(this, name);
     this.#smoldotName = name;
     this.#state = 'ready';
     return;

--- a/projects/extension/src/background/AppMediator.ts
+++ b/projects/extension/src/background/AppMediator.ts
@@ -78,7 +78,7 @@ export class AppMediator {
     if (this.#state === 'disconnected') {
       // Shouldn't happen - we remove the AppMediator from the smoldot's apps
       // when we disconnect (below).
-      console.warn(`Asked a disconnected UApp (${this.name}) to process a message from ${this.#smoldotName}`);
+      console.warn(`Asked a disconnected UApp (${this.name}) to process a message from ${this.#smoldotName as string}`);
       return false;
     }
 
@@ -210,7 +210,7 @@ export class AppMediator {
     this.#handleDisconnect(true);
   }
 
-  #sendUnsubscribe = (sub: SubscriptionMapping, subIndex: number) => {
+  #sendUnsubscribe = (sub: SubscriptionMapping): void => {
     // use one higher than we've seen before from the UApp.  The UApp is now
     // disconnnecting so this won't ever be reused as we no longer
     // accept incoming RPC send requests

--- a/projects/extension/src/background/AppMediator.ts
+++ b/projects/extension/src/background/AppMediator.ts
@@ -23,6 +23,8 @@ export class AppMediator {
   #state: AppState = 'connected';
   readonly subscriptions: SubscriptionMapping[];
   readonly requests: MessageIDMapping[];
+  highestUAppRequestId = 0;
+  #notifyOnDisconnected = false;
 
   constructor(name: string, port: chrome.runtime.Port, manager: ConnectionManagerInterface) {
     this.subscriptions = [];
@@ -40,6 +42,10 @@ export class AppMediator {
 
   get name(): string {
     return this.#name;
+  }
+
+  get smoldotName(): string | undefined {
+    return this.#smoldotName;
   }
 
   get tabId(): number | undefined {
@@ -69,6 +75,31 @@ export class AppMediator {
   }
 
   processSmoldotMessage(message: JsonRpcResponse): boolean {
+    if (this.#state === 'disconnected') {
+      // Shouldn't happen - we remove the AppMediator from the smoldot's apps
+      // when we disconnect (below).
+      console.warn(`Asked a disconnected UApp (${this.name}) to process a message from ${this.#smoldotName}`);
+      return false;
+    }
+
+    if (this.#state === 'disconnecting') {
+      // Handle responses to our unsubscription messages
+      const request = this.requests.find(r => r.smoldotID === message.id);
+      if (request !== undefined) {
+        // We don't forward the RPC message to the UApp - it's not there any more
+        const idx = this.requests.indexOf(request);
+        this.requests.splice(idx, 1);
+        if (this.requests.length === 0) {
+          // All our unsubscription messages have been replied to
+          this.#state = 'disconnected';
+          // TODO: remove this AppMediator from ConnectionManager and SmoldotMediator
+          // TODO: send notifications
+        }
+
+        return true;
+      }
+    }
+
     // subscription message
     if (message.method) {
       if(!(message as JsonRpcResponseSubscription).params?.subscription) {
@@ -96,7 +127,7 @@ export class AppMediator {
     const idx = this.requests.indexOf(request);
     this.requests.splice(idx, 1);
 
-    // is this a response telling us the subID for a subcscription?
+    // is this a response telling us the subID for a subscription?
     const sub = this.subscriptions.find(s => s.appIDForRequest == request.appID);
     if (sub) {
       if (sub.subID) {
@@ -129,7 +160,9 @@ export class AppMediator {
     }
 
     const parsed =  JSON.parse(message) as JsonRpcRequest;
-    const appID = parsed.id;
+    const appID = parsed.id as number;
+    this.highestUAppRequestId = appID;
+
     if (subscription) {
       // register a new sub that is waiting for a sub ID
       this.subscriptions.push({ 
@@ -138,6 +171,9 @@ export class AppMediator {
         method: parsed.method 
       });
     }
+
+    // TODO: what about unsubscriptions requested by the UApp - we need to remove
+    // the subscription from our subscriptions state
 
     const smoldotID = this.#manager.sendRpcMessageTo(this.#smoldotName, parsed);
     this.requests.push({ appID, smoldotID });
@@ -174,10 +210,33 @@ export class AppMediator {
     this.#handleDisconnect(true);
   }
 
+  #sendUnsubscribe = (sub: SubscriptionMapping, subIndex: number) => {
+    // use one higher than we've seen before from the UApp.  The UApp is now
+    // disconnnecting so this won't ever be reused as we no longer
+    // accept incoming RPC send requests
+    const appID = ++this.highestUAppRequestId;
+    const unsubRequest = {
+      id: appID,
+      jsonrpc: '2.0',
+      method: sub.method,
+      params: [ sub.subID ]
+    }
+
+    // send the unsubscribe message
+    const smoldotID = this.#manager.sendRpcMessageTo(this.#smoldotName as string,  unsubRequest);
+    // track the request so we know when its completed
+    this.requests.push({ appID, smoldotID });
+  };
+
   #handleDisconnect = (notify: boolean): void => {
-    console.log(`Disconnecting and notify is set to ${notify.toString()}`);
+    if (this.#state === 'disconnecting' || this.#state === 'disconnected') {
+      throw new Error('Cannot disconnect - already disconnecting / disconnected');
+    }
+
     this.#state = 'disconnecting';
-    // TODO: clean up subs
-    // TODO: send disconnected message if it was requested 
+    this.#notifyOnDisconnected = notify;
+    this.subscriptions.forEach(this.#sendUnsubscribe);
+    // remove all the subscriptions
+    this.subscriptions.splice(0, this.subscriptions.length);
   }
 }

--- a/projects/extension/src/background/AppMediator.ts
+++ b/projects/extension/src/background/AppMediator.ts
@@ -78,7 +78,7 @@ export class AppMediator {
     if (this.#state === 'disconnected') {
       // Shouldn't happen - we remove the AppMediator from the smoldot's apps
       // when we disconnect (below).
-      console.warn(`Asked a disconnected UApp (${this.name}) to process a message from ${this.#smoldotName as string}`);
+      console.error(`Asked a disconnected UApp (${this.name}) to process a message from ${this.#smoldotName as string}`);
       return false;
     }
 

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -62,6 +62,18 @@ export class ConnectionManager implements ConnectionManagerInterface {
     sm.addApp(app);
   }
 
+  unregisterApp(app: AppMediator, smoldotName: string): void {
+    const sm = this.#smoldots.find(s => s.name === smoldotName);
+    if (!sm) {
+      throw new Error('Tried to remove an app from smoldot that does not exist.');
+    }
+
+    sm.removeApp(app);
+    const idx = this.#apps.findIndex(a => a.name === app.name);
+    this.#apps.splice(idx, 1);
+  }
+
+
   async addSmoldot(name: string,  chainSpec: string, testSmoldot?: smoldot.Smoldot): Promise<void> {
     const client = testSmoldot || smoldot;
     if (this.#smoldots.find(s => s.name === name)) {

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -54,7 +54,7 @@ export class ConnectionManager implements ConnectionManagerInterface {
     return sm.sendRpcMessage(message);
   }
 
-  registerAppWithSmoldot(app: AppMediator, smoldotName: string): void {
+  registerApp(app: AppMediator, smoldotName: string): void {
     const sm = this.#smoldots.find(s => s.name === smoldotName);
     if (!sm) {
       throw new Error('Tried to add app to smoldot that does not exist.');

--- a/projects/extension/src/background/SmoldotMediator.ts
+++ b/projects/extension/src/background/SmoldotMediator.ts
@@ -23,6 +23,11 @@ export class SmoldotMediator {
     this.#apps.push(app);
   }
 
+  removeApp(app: AppMediator): void {
+    const idx = this.#apps.findIndex(a => a.name === app.name);
+    this.#apps.splice(idx, 1);
+  }
+
   sendRpcMessage(message: JsonRpcRequest): number {
     const nextID = ++this.#id;
     /* eslint-disable @typescript-eslint/no-unsafe-member-access */

--- a/projects/extension/src/background/mocks.ts
+++ b/projects/extension/src/background/mocks.ts
@@ -19,7 +19,7 @@ export class MockPort implements chrome.runtime.Port {
   }
 
   triggerDisconnect() {
-    this.#messageListeners.forEach((l: any) => {
+    this.#disconnectListeners.forEach((l: any) => {
       l();
     });
   }
@@ -40,6 +40,8 @@ export class MockPort implements chrome.runtime.Port {
 
 export class MockConnectionManager implements ConnectionManagerInterface {
   readonly #willFindClient: boolean;
+  lastId = 0;
+
 
   constructor(willFindClient: boolean) {
     this.#willFindClient = willFindClient;
@@ -54,7 +56,7 @@ export class MockConnectionManager implements ConnectionManagerInterface {
   };
 
   sendRpcMessageTo = (name: string, message: any) => {
-    return 42;
+    return ++this.lastId;
   };
 }
 

--- a/projects/extension/src/background/mocks.ts
+++ b/projects/extension/src/background/mocks.ts
@@ -47,7 +47,7 @@ export class MockConnectionManager implements ConnectionManagerInterface {
     this.#willFindClient = willFindClient;
   }
 
-  registerAppWithSmoldot(app: AppMediator, name: string): void {
+  registerApp(app: AppMediator, name: string): void {
     return;
   }
 

--- a/projects/extension/src/background/mocks.ts
+++ b/projects/extension/src/background/mocks.ts
@@ -47,15 +47,19 @@ export class MockConnectionManager implements ConnectionManagerInterface {
     this.#willFindClient = willFindClient;
   }
 
-  registerAppWithSmoldot(app: AppMediator, name: string) {
+  registerAppWithSmoldot(app: AppMediator, name: string): void {
     return;
   }
 
-  hasClientFor = (name: string) => {
+  unregisterApp(app: AppMediator, name: string): void {
+    return;
+  }
+
+  hasClientFor = (name: string): boolean => {
     return this.#willFindClient;
   };
 
-  sendRpcMessageTo = (name: string, message: any) => {
+  sendRpcMessageTo = (name: string, message: any): number => {
     return ++this.lastId;
   };
 }

--- a/projects/extension/src/background/types.ts
+++ b/projects/extension/src/background/types.ts
@@ -52,6 +52,7 @@ export interface ConnectionManagerInterface {
   hasClientFor: (name: string) => boolean;
   sendRpcMessageTo: (name: string, message: JsonRpcRequest) => number;
   registerAppWithSmoldot: (app: AppMediator, name: string) => void;
+  unregisterApp: (app: AppMediator, name: string) => void;
 }
 
 export interface JsonRpcObject {

--- a/projects/extension/src/background/types.ts
+++ b/projects/extension/src/background/types.ts
@@ -51,7 +51,7 @@ export interface SubscriptionMapping {
 export interface ConnectionManagerInterface {
   hasClientFor: (name: string) => boolean;
   sendRpcMessageTo: (name: string, message: JsonRpcRequest) => number;
-  registerAppWithSmoldot: (app: AppMediator, name: string) => void;
+  registerApp: (app: AppMediator, name: string) => void;
   unregisterApp: (app: AppMediator, name: string) => void;
 }
 

--- a/projects/extension/src/background/types.ts
+++ b/projects/extension/src/background/types.ts
@@ -51,7 +51,7 @@ export interface SubscriptionMapping {
 export interface ConnectionManagerInterface {
   hasClientFor: (name: string) => boolean;
   sendRpcMessageTo: (name: string, message: JsonRpcRequest) => number;
-  registerAppWithSmoldot(app: AppMediator, name: string);
+  registerAppWithSmoldot: (app: AppMediator, name: string) => void;
 }
 
 export interface JsonRpcObject {


### PR DESCRIPTION
When the port for a UApp disconnects we put its `AppMediator` into the `disconnecting` state and send an unsubscribe message for all the active susbcriptions.  There is an additional check in the smoldot message processing to see if we're disconnecting and to change the state to `disconnected` once all those unsubscribe messages have been responded to by the smoldot.

The test for disconnecting adds some subscriptions; calls disconnect; simulates the unsub repsonses and checks the state of the UApp at all stages.

I also refactored the unit tests to make them more readable and reusable and to add better assertion coverage of all the behaviours.

#### Still needed

* Handling unsubscribe messages from the UApp - I need to coordinate with you after we've merged this and your work to get the `ExtensionProvider` to tell the background about unsubscriptions.
* I also added a note about sending an info message back to the UApp to tell it that the associate request was successful... you had this logic in your branch but it does not exist on master.
* ~Remove the `AppMediator` from the `ConnectionManager` when the state has become `disconnected`~ :heavy_check_mark: 