### PR TITLE
Fetch chainspec json with cache busting headers

### DIFF
--- a/projects/smoldot-browser-demo/src/index.ts
+++ b/projects/smoldot-browser-demo/src/index.ts
@@ -12,7 +12,12 @@ window.onload = () => {
 
   (async () => {
     try {
-      const response =  await fetch('./assets/westend.json')
+      const headers = new Headers();
+      headers.append('pragma', 'no-cache');
+      headers.append('cache-control', 'no-cache');
+      const options = { method: 'GET', headers };
+      const request = new Request('./assets/westend.json');
+      const response =  await fetch(request, options);
       if (!response.ok) {
         ui.error(new Error('Error downloading chain spec'));
       }


### PR DESCRIPTION
Add headers to ask browser and proxies to return uncached versions of the westend.json in the smoldot-browser-demo.  This should solve issues where we update the chainspec but when we refresh the smoldot-browser-demo we still get the old version.

Fixes #113