### PR TITLE
Enable linting and fix issues for SmoldotProvider

### DIFF
--- a/packages/smoldot-provider/.eslintignore
+++ b/packages/smoldot-provider/.eslintignore
@@ -4,3 +4,6 @@ node_modules
 dist
 # don't lint .cache
 .chains
+# don't lint examples and tests
+src/examples
+src/*.test.ts

--- a/packages/smoldot-provider/package.json
+++ b/packages/smoldot-provider/package.json
@@ -17,7 +17,7 @@
     "clean": "rm -rf dist/",
     "pretest": "yarn build",
     "test": "ava --config ava.config.js --verbose",
-    "lint": "echo \"No lint yet for @smoldot/provider: actual command -> yarn eslint . --ext .js,.ts\"",
+    "lint": "yarn eslint . --ext .js,.ts",
     "examples": "ava --config ava.examples.config.js",
     "prepack": "yarn test && yarn examples",
     "postinstall": "yarn test"

--- a/packages/smoldot-provider/src/BrowserDatabase.ts
+++ b/packages/smoldot-provider/src/BrowserDatabase.ts
@@ -17,11 +17,11 @@ export class BrowserDatabase implements Database {
     return window.localStorage.getItem(this.#name) || '';
   }
 
-  save(state: string) {
+  save(state: string): void {
     window.localStorage.setItem(this.#name, state);
   }
 
-  delete() {
+  delete(): void {
     window.localStorage.removeItem(this.#name);
   }
 }

--- a/packages/smoldot-provider/src/FsDatabase.ts
+++ b/packages/smoldot-provider/src/FsDatabase.ts
@@ -25,9 +25,9 @@ export class FsDatabase implements Database {
   load(): string {
     try {
       statSync(this.#path);
-    } catch (error: any) { 
+    } catch (error: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
       // Typescript does not allow type annotations on catch blocks :(
-      if (error.code === 'ENOENT') {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
         return '';
       }
 
@@ -37,11 +37,11 @@ export class FsDatabase implements Database {
     return readFileSync(this.#path, { encoding: 'utf-8' });
   }
 
-  save(state: string) {
+  save(state: string): void {
     writeFileSync(this.#path, state);
   }
 
-  delete() {
+  delete(): void {
       unlinkSync(this.#path);
   }
 }

--- a/packages/smoldot-provider/src/FsDatabase.ts
+++ b/packages/smoldot-provider/src/FsDatabase.ts
@@ -25,7 +25,7 @@ export class FsDatabase implements Database {
   load(): string {
     try {
       statSync(this.#path);
-    } catch (error: any) { // eslint-disable-line @typescript-eslint/no-explicit-any
+    } catch (error: unknown) {
       // Typescript does not allow type annotations on catch blocks :(
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
         return '';

--- a/packages/smoldot-provider/src/errors.ts
+++ b/packages/smoldot-provider/src/errors.ts
@@ -1,11 +1,11 @@
 export class HealthCheckError extends Error {
-  readonly #cause: any;
+  readonly #cause: unknown;
 
-  getCause() {
+  getCause(): unknown {
     return this.#cause;
   }
 
-  constructor(response: any, message = "Got error response asking for system health") {
+  constructor(response: unknown, message = "Got error response asking for system health") {
     super(message); 
     this.#cause = response;
     // 'Error' breaks the prototype chain - restore it


### PR DESCRIPTION
I ignored quite a few rules because we have intentionally copied from the PolkadotJS api package which uses `any` in its provider in quite a few ways.  Ideally we should resolve this at some point but at least for now this means we actually have linting in this project and we should catch any future linting problems if we make changes.

This fixes #136 although I have not added linting to the test-utils, I dont think that project should be linted ... we actually want to be loose on our definitions of things for test helpers. We're intentionally faking / hidding / not providing implementations of things to test functionality.