### PR TITLE
Add editorconfig to enforce whitespace rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+charset = utf-8


### PR DESCRIPTION
Does what it says on the tin.  Enforces:
* 2 spaces for tabs (company policy)
* UTF-8 (common sense)
* Trailing new line in files [to avoid "No newline at end of file" warnings in git diffs](https://thoughtbot.com/blog/no-newline-at-end-of-file) *TIL: this isn't the default in vscode ... why?!* :confounded:
* Unix line endings (none of us use windows)