### PR TITLE
Implement disconnect on ExtensionProvider and test content script message routing

### DIFF
--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -32,3 +32,23 @@ test('connect sends init message and emits connected', async () => {
   expect(ep.isConnected).toBe(true);
   expect(emitted).toHaveBeenCalledTimes(1);
 });
+
+test('disconnect sends disconnect message and emits disconnected', async () => {
+  const ep = new ExtensionProvider('test', 'test-chain');
+  const emitted = jest.fn();
+  await ep.connect();
+
+  ep.on('disconnected', emitted);
+  await ep.disconnect();
+
+  const expectedMessage = {
+    appName: 'test',
+    chainName: 'test-chain',
+    message: 'disconnect',
+    origin: 'extension-provider'
+  };
+  expect(window.postMessage).toHaveBeenCalledTimes(2);
+  expect(window.postMessage).toHaveBeenNthCalledWith(2, expectedMessage, '*');
+  expect(ep.isConnected).toBe(false);
+  expect(emitted).toHaveBeenCalledTimes(1);
+});

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -21,6 +21,7 @@ test('connect sends init message and emits connected', async () => {
   const expectedMessage = {
     appName: 'test',
     chainName: 'test-chain',
+    action: 'forward',
     message: {
       type: 'associate',
       payload: 'test-chain'
@@ -44,7 +45,7 @@ test('disconnect sends disconnect message and emits disconnected', async () => {
   const expectedMessage = {
     appName: 'test',
     chainName: 'test-chain',
-    message: 'disconnect',
+    action: 'disconnect',
     origin: 'extension-provider'
   };
   expect(window.postMessage).toHaveBeenCalledTimes(2);

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
@@ -191,7 +191,14 @@ export class ExtensionProvider implements ProviderInterface {
    */
   // eslint-disable-next-line @typescript-eslint/require-await
   public async disconnect(): Promise<void> {
-    console.log('this not yet implemented');
+    window.postMessage({
+      appName: this.#appName,
+      chainName: this.#chainName,
+      message: 'disconnect',
+      origin: EXTENSION_PROVIDER_ORIGIN
+    }, '*');
+    this.#isConnected = false;
+    this.emit('disconnected');
   }
 
   /**

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
@@ -167,6 +167,7 @@ export class ExtensionProvider implements ProviderInterface {
     const initMsg = {
       appName: this.#appName,
       chainName: this.#chainName,
+      action: 'forward',
       message: {
         type: 'associate',
         payload: this.#chainName
@@ -194,7 +195,7 @@ export class ExtensionProvider implements ProviderInterface {
     window.postMessage({
       appName: this.#appName,
       chainName: this.#chainName,
-      message: 'disconnect',
+      action: 'disconnect',
       origin: EXTENSION_PROVIDER_ORIGIN
     }, '*');
     this.#isConnected = false;
@@ -261,6 +262,7 @@ export class ExtensionProvider implements ProviderInterface {
       window.postMessage({
         appName: this.#appName,
         chainName: this.#chainName,
+        action: 'forward',
         message: {
           type: 'rpc',
           payload: json,

--- a/projects/extension/.eslintignore
+++ b/projects/extension/.eslintignore
@@ -4,5 +4,7 @@ node_modules
 dist
 # don't lint .cache
 .cache
-src/background/*.test.ts
-src/background/mocks.ts
+src/**/*.test.ts
+src/mocks.ts
+jest-setup.js
+jest.config.ts

--- a/projects/extension/jest-setup.js
+++ b/projects/extension/jest-setup.js
@@ -1,0 +1,3 @@
+import { chrome } from 'jest-chrome';
+
+Object.assign(window, { chrome });

--- a/projects/extension/jest.config.ts
+++ b/projects/extension/jest.config.ts
@@ -1,8 +1,8 @@
 export default {
-  preset: "ts-jest",
-  testEnvironment: 'node',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['./jest-setup.js'],
   transform: {
-     "\\.[jt]sx?$": "babel-jest"
+     '\.[jt]sx?$': 'babel-jest'
   },
   globals: {
     'ts-jest': {
@@ -10,5 +10,5 @@ export default {
     }
   },
   verbose: true,
-  testURL: "http://localhost/"
+  testURL: 'http://localhost/'
 };

--- a/projects/extension/package.json
+++ b/projects/extension/package.json
@@ -47,6 +47,7 @@
     "file-loader": "^6.2.0",
     "html-minimizer-webpack-plugin": "^2.1.0",
     "jest": "^26.6.3",
+    "jest-chrome": "^0.7.0",
     "jest-styled-components": "^7.0.3",
     "style-loader": "^2.0.0",
     "ts-loader": "^8.0.17",

--- a/projects/extension/package.json
+++ b/projects/extension/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "pretest": "yarn clean && tsc",
-    "test": "node --experimental-vm-modules $(yarn bin)/jest --env=node --colors --coverage dist/",
+    "test": "node --experimental-vm-modules $(yarn bin)/jest --colors --coverage dist/",
     "build": "yarn run clean && webpack --config webpack.prod.js",
     "dev": "yarn run clean && webpack --node-env development --config webpack.dev.js",
     "start": "web-ext run --source-dir ./dist -t chromium",

--- a/projects/extension/src/background/AppMediator.test.ts
+++ b/projects/extension/src/background/AppMediator.test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { ExtensionMessage } from '../types';
 import { AppMediator } from './AppMediator';
 import { MockPort, MockConnectionManager } from '../mocks';

--- a/projects/extension/src/background/AppMediator.test.ts
+++ b/projects/extension/src/background/AppMediator.test.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import { ExtensionMessage } from '../types';
 import { AppMediator } from './AppMediator';
 import { MockPort, MockConnectionManager } from '../mocks';

--- a/projects/extension/src/background/AppMediator.test.ts
+++ b/projects/extension/src/background/AppMediator.test.ts
@@ -1,6 +1,6 @@
 import { ExtensionMessage } from '../types';
 import { AppMediator } from './AppMediator';
-import { MockPort, MockConnectionManager } from './mocks';
+import { MockPort, MockConnectionManager } from '../mocks';
 import { JsonRpcResponse } from './types';
 
 test('initialises correctly', () => {

--- a/projects/extension/src/background/ConnectionManager.test.ts
+++ b/projects/extension/src/background/ConnectionManager.test.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import { jest } from '@jest/globals';
 import { ConnectionManager } from './ConnectionManager';
 import westend from '../assets/westend.json';

--- a/projects/extension/src/background/ConnectionManager.test.ts
+++ b/projects/extension/src/background/ConnectionManager.test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { jest } from '@jest/globals';
 import { ConnectionManager } from './ConnectionManager';
 import westend from '../assets/westend.json';

--- a/projects/extension/src/background/ConnectionManager.test.ts
+++ b/projects/extension/src/background/ConnectionManager.test.ts
@@ -2,7 +2,7 @@ import { jest } from '@jest/globals';
 import { ConnectionManager } from './ConnectionManager';
 import westend from '../assets/westend.json';
 import kusama from '../assets/kusama.json';
-import { MockPort } from './mocks';
+import { MockPort } from '../mocks';
 
 const  connectApp = (manager: ConnectionManager, tabId: number, name: string, network: string): MockPort => {
   const port = new MockPort(`${name}::${network}`);

--- a/projects/extension/src/content/ExtensionMessageRouter.test.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.test.ts
@@ -1,5 +1,6 @@
 import { jest } from '@jest/globals';
 import { ExtensionMessageRouter } from './ExtensionMessageRouter';
+import { ExtensionMessage } from '../types';
 import { MockPort } from '../mocks';
 import { chrome } from 'jest-chrome';
 
@@ -15,106 +16,118 @@ afterEach(() => {
   router.stop();
 });
 
-test('associate establishes a port', done => {
+function waitForMessageToBePosted(): Promise<null> {
+  // window.postMessge is async so we must do a short setTimeout to yield to
+  // the event loop
+  return new Promise(resolve => setTimeout(resolve, 10, null));
+}
+
+test('associate establishes a port', async () => {
   chrome.runtime.connect.mockImplementation(_ => new MockPort('test-app::westend'));
-  window.postMessage({ 
-      appName: 'test-app', 
-      chainName: 'westend', 
-      message: {
-        type: 'associate',
-        payload: 'westend'
-      },
-      origin: 'extension-provider'
-    }, '*');
-
-    // window.postMessage is async we have to yield to the event loop for it
-    // to reach the router
-    setTimeout(() => {
-      expect(chrome.runtime.connect).toHaveBeenCalledTimes(1);
-      expect(router.connections.length).toBe(1);
-      expect(router.connections[0]).toBe('westend');
-      done();
-    }, 10);
-});
-
-test('incorrect origin does nothing to connections', done => {
-  window.postMessage({ 
-      origin: 'something-else'
-    }, '*');
-
-    // window.postMessage is async we have to yield to the event loop for it
-    // to reach the router
-    setTimeout(() => {
-      expect(chrome.runtime.connect).not.toHaveBeenCalled();
-      expect(router.connections.length).toBe(0);
-      done();
-    }, 10);
-});
-
-test('disconnect disconnects established connection', done => {
-  const port = new MockPort('test-app::westend');
-  chrome.runtime.connect.mockImplementation(_ => port);
-  window.postMessage({ 
-      appName: 'test-app', 
-      chainName: 'westend', 
-      message: {
-        type: 'associate',
-        payload: 'westend'
-      },
-      origin: 'extension-provider'
-    }, '*');
-  window.postMessage({ 
-      appName: 'test-app', 
-      chainName: 'westend', 
-      message: 'disconnect',
-      origin: 'extension-provider'
-    }, '*');
-
-
-    // window.postMessage is async we have to yield to the event loop for it
-    // to reach the router
-    setTimeout(() => {
-      expect(chrome.runtime.connect).toHaveBeenCalledTimes(1);
-      expect(port.disconnect).toHaveBeenCalledTimes(1);
-      expect(router.connections.length).toBe(0);
-      done();
-    }, 10);
-});
-
-test('forwards rpc message from extension provider', done => {
-  const port = new MockPort('test-app::westend');
-  chrome.runtime.connect.mockImplementation(_ => port);
-  // connect
-  window.postMessage({ 
-    appName: 'test-app', 
-    chainName: 'westend', 
-    message: {
-      type: 'associate',
-      payload: 'westend'
-    },
+  window.postMessage({
+    appName: 'test-app',
+    chainName: 'westend',
+    message: { type: 'associate', payload: 'westend' },
     origin: 'extension-provider'
   }, '*');
 
+  await waitForMessageToBePosted();
+  expect(chrome.runtime.connect).toHaveBeenCalledTimes(1);
+  expect(router.connections.length).toBe(1);
+  expect(router.connections[0]).toBe('westend');
+});
+
+test('incorrect origin does nothing to connections', async () => {
+  window.postMessage({
+    origin: 'something-else'
+  }, '*');
+
+  await waitForMessageToBePosted();
+  expect(chrome.runtime.connect).not.toHaveBeenCalled();
+  expect(router.connections.length).toBe(0);
+});
+
+test('disconnect disconnects established connection', async () => {
+  const port = new MockPort('test-app::westend');
+  chrome.runtime.connect.mockImplementation(_ => port);
+  window.postMessage({
+    appName: 'test-app',
+    chainName: 'westend',
+    message: { type: 'associate', payload: 'westend' },
+    origin: 'extension-provider'
+  }, '*');
+  await waitForMessageToBePosted();
+
+  window.postMessage({
+    appName: 'test-app',
+    chainName: 'westend',
+    message: 'disconnect',
+    origin: 'extension-provider'
+  }, '*');
+  await waitForMessageToBePosted();
+
+
+  expect(chrome.runtime.connect).toHaveBeenCalledTimes(1);
+  expect(port.disconnect).toHaveBeenCalledTimes(1);
+  expect(router.connections.length).toBe(0);
+});
+
+test('forwards rpc message from app -> extension', async () => {
+  const port = new MockPort('test-app::westend');
+  chrome.runtime.connect.mockImplementation(_ => port);
+  // connect
+  window.postMessage({
+    appName: 'test-app',
+    chainName: 'westend',
+    message: { type: 'associate', payload: 'westend' },
+    origin: 'extension-provider'
+  }, '*');
+  await waitForMessageToBePosted();
+
   // rpc
-  const rpcMessage = { 
-    appName: 'test-app', 
-    chainName: 'westend', 
+  const rpcMessage = {
+    appName: 'test-app',
+    chainName: 'westend',
     message: {
       type: 'rpc',
-      payload: '{"id":1,"jsonrpc":"2.0","method":"state_getStorage","params":["<hash>"]}' 
+      payload: '{"id":1,"jsonrpc":"2.0","method":"state_getStorage","params":["<hash>"]}'
     },
     origin: 'extension-provider'
   };
-
   window.postMessage(rpcMessage, '*');
+  await waitForMessageToBePosted();
 
-  // window.postMessage is async we have to yield to the event loop for it
-  // to reach the router
-  setTimeout(() => {
-    expect(chrome.runtime.connect).toHaveBeenCalledTimes(1);
-    expect(port.disconnect).not.toHaveBeenCalled();
-    expect(port.postMessage).toHaveBeenCalledWith(rpcMessage.message);
-    done();
-  }, 10);
+  expect(chrome.runtime.connect).toHaveBeenCalledTimes(1);
+  expect(port.disconnect).not.toHaveBeenCalled();
+  expect(port.postMessage).toHaveBeenCalledWith(rpcMessage.message);
+});
+
+test('forwards rpc message from extension -> app', async () => {
+  const port = new MockPort('test-app::westend');
+  chrome.runtime.connect.mockImplementation(_ => port);
+  // connect
+  window.postMessage({
+    appName: 'test-app',
+    chainName: 'westend',
+    message: { type: 'associate', payload: 'westend' },
+    origin: 'extension-provider'
+  }, '*');
+  await waitForMessageToBePosted();
+
+  const handler = jest.fn();
+  window.addEventListener('message', handler);
+  const message: ExtensionMessage = { type: 'rpc', payload: '{"id:":1,"jsonrpc:"2.0","result":666}' };
+  port.triggerMessage(message);
+  await waitForMessageToBePosted();
+
+  interface RouterMessage {
+    data: ExtensionMessage
+  }
+
+  expect(chrome.runtime.connect).toHaveBeenCalledTimes(1);
+  expect(port.disconnect).not.toHaveBeenCalled();
+  expect(handler).toHaveBeenCalled();
+  const forwarded = handler.mock.calls[0][0] as RouterMessage;
+  expect(forwarded.data).toEqual({ origin: 'content-script', message: message.payload });
 });
 

--- a/projects/extension/src/content/ExtensionMessageRouter.test.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.test.ts
@@ -27,6 +27,7 @@ test('associate establishes a port', async () => {
   window.postMessage({
     appName: 'test-app',
     chainName: 'westend',
+    action: 'forward'.
     message: { type: 'associate', payload: 'westend' },
     origin: 'extension-provider'
   }, '*');
@@ -53,6 +54,7 @@ test('disconnect disconnects established connection', async () => {
   window.postMessage({
     appName: 'test-app',
     chainName: 'westend',
+    action: 'forward',
     message: { type: 'associate', payload: 'westend' },
     origin: 'extension-provider'
   }, '*');
@@ -61,7 +63,7 @@ test('disconnect disconnects established connection', async () => {
   window.postMessage({
     appName: 'test-app',
     chainName: 'westend',
-    message: 'disconnect',
+    action: 'disconnect',
     origin: 'extension-provider'
   }, '*');
   await waitForMessageToBePosted();
@@ -79,6 +81,7 @@ test('forwards rpc message from app -> extension', async () => {
   window.postMessage({
     appName: 'test-app',
     chainName: 'westend',
+    action: 'forward',
     message: { type: 'associate', payload: 'westend' },
     origin: 'extension-provider'
   }, '*');
@@ -88,6 +91,7 @@ test('forwards rpc message from app -> extension', async () => {
   const rpcMessage = {
     appName: 'test-app',
     chainName: 'westend',
+    action: 'forward',
     message: {
       type: 'rpc',
       payload: '{"id":1,"jsonrpc":"2.0","method":"state_getStorage","params":["<hash>"]}'
@@ -109,6 +113,7 @@ test('forwards rpc message from extension -> app', async () => {
   window.postMessage({
     appName: 'test-app',
     chainName: 'westend',
+    action: 'forward',
     message: { type: 'associate', payload: 'westend' },
     origin: 'extension-provider'
   }, '*');

--- a/projects/extension/src/content/ExtensionMessageRouter.test.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.test.ts
@@ -1,0 +1,32 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals';
+import { ExtensionMessageRouter } from './ExtensionMessageRouter';
+import { MockPort } from '../mocks';
+import { chrome } from 'jest-chrome';
+
+test('associate establishes a port', done => {
+  const router = new ExtensionMessageRouter();
+  router.listen();
+  chrome.runtime.connect.mockImplementation(_ => new MockPort('test-app::westend'));
+  window.postMessage({ 
+      appName: 'test-app', 
+      chainName: 'westend', 
+      message: {
+        type: 'associate',
+        payload: 'westend'
+      },
+      origin: 'extension-provider'
+    }, '*');
+
+    // window.postMessage is async we have to yield to the event loop for it
+    // to reach the router
+    setTimeout(() => {
+      expect(chrome.runtime.connect).toHaveBeenCalledTimes(1);
+      expect(router.connections.length).toBe(1);
+      expect(router.connections[0]).toBe('westend');
+      done();
+    }, 10);
+});

--- a/projects/extension/src/content/ExtensionMessageRouter.test.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.test.ts
@@ -49,5 +49,35 @@ test('incorrect origin does nothing to connections', done => {
       expect(router.connections.length).toBe(0);
       done();
     }, 10);
-
 });
+
+test('disconnect disconnects established connection', done => {
+  const port = new MockPort('test-app::westend');
+  chrome.runtime.connect.mockImplementation(_ => port);
+  window.postMessage({ 
+      appName: 'test-app', 
+      chainName: 'westend', 
+      message: {
+        type: 'associate',
+        payload: 'westend'
+      },
+      origin: 'extension-provider'
+    }, '*');
+  window.postMessage({ 
+      appName: 'test-app', 
+      chainName: 'westend', 
+      message: 'disconnect',
+      origin: 'extension-provider'
+    }, '*');
+
+
+    // window.postMessage is async we have to yield to the event loop for it
+    // to reach the router
+    setTimeout(() => {
+      expect(chrome.runtime.connect).toHaveBeenCalledTimes(1);
+      expect(port.disconnect).toHaveBeenCalledTimes(1);
+      expect(router.connections.length).toBe(0);
+      done();
+    }, 10);
+});
+

--- a/projects/extension/src/content/ExtensionMessageRouter.test.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.test.ts
@@ -1,15 +1,21 @@
-/**
- * @jest-environment jsdom
- */
-
 import { jest } from '@jest/globals';
 import { ExtensionMessageRouter } from './ExtensionMessageRouter';
 import { MockPort } from '../mocks';
 import { chrome } from 'jest-chrome';
 
-test('associate establishes a port', done => {
-  const router = new ExtensionMessageRouter();
+let router: ExtensionMessageRouter;
+
+beforeEach(() => {
+  chrome.runtime.connect.mockClear();
+  router = new ExtensionMessageRouter();
   router.listen();
+});
+
+afterEach(() => {
+  router.stop();
+});
+
+test('associate establishes a port', done => {
   chrome.runtime.connect.mockImplementation(_ => new MockPort('test-app::westend'));
   window.postMessage({ 
       appName: 'test-app', 
@@ -29,4 +35,19 @@ test('associate establishes a port', done => {
       expect(router.connections[0]).toBe('westend');
       done();
     }, 10);
+});
+
+test('incorrect origin does nothing to connections', done => {
+  window.postMessage({ 
+      origin: 'something-else'
+    }, '*');
+
+    // window.postMessage is async we have to yield to the event loop for it
+    // to reach the router
+    setTimeout(() => {
+      expect(chrome.runtime.connect).not.toHaveBeenCalled();
+      expect(router.connections.length).toBe(0);
+      done();
+    }, 10);
+
 });

--- a/projects/extension/src/content/ExtensionMessageRouter.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.ts
@@ -66,9 +66,7 @@ export class ExtensionMessageRouter {
 
       this.#ports[data.chainName] = port;
       debug(`SENDING ASSOCIATE MESSAGE TO ${data.chainName} PORT`, data.message);
-      // TODO(rem): do we actually need to send the origin to the background
-      // can we not just forward the message?
-      port.postMessage({ ...data.message, origin: EXTENSION_PROVIDER_ORIGIN});
+      port.postMessage(data.message);
       return;
     }
 
@@ -79,8 +77,8 @@ export class ExtensionMessageRouter {
       return;
     }
 
-    debug(`SENDING MESSAGE TO ${data.chainName} PORT`, data.message);
-    port.postMessage({ ...data.message, origin: EXTENSION_PROVIDER_ORIGIN});
+    debug(`SENDING RPC MESSAGE TO ${data.chainName} PORT`, data.message);
+    port.postMessage(data.message);
   }
 
 }

--- a/projects/extension/src/content/ExtensionMessageRouter.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.ts
@@ -26,8 +26,12 @@ export class ExtensionMessageRouter {
   }
 
   listen(): void {
-    // Receive from ExtensionProvider the App "subscription"
     window.addEventListener('message', this.#handleMessage);
+  }
+
+  stop(): void {
+    window.removeEventListener('message', this.#handleMessage);
+
   }
 
   #handleMessage = ({ data }: ExtensionProviderMessage): void => {

--- a/projects/extension/src/content/ExtensionMessageRouter.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.ts
@@ -1,0 +1,79 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import type { ExtensionProviderMessage } from '../types';
+import { debug } from '../utils/debug';
+
+const ports: Record<string, chrome.runtime.Port> = {};
+
+const CONTENT_SCRIPT_ORIGIN = 'content-script';
+const EXTENSION_PROVIDER_ORIGIN ='extension-provider';
+
+/* ExtensionMessageRouter is the part of the content script that listens for
+ * messages that the ExtensionProvider in an app sends using `window.postMessage`.
+ * It establishes connections to the extension background on behalf of the app,
+ * forwards RPC requests for the app to the extension background and disconnects
+ * the port when the app requests it.
+ *
+ * Conversely it listens for messages sent through the port from the extension
+ * background and forwards them to the app via `window.postMessage`
+ *
+ * This router exists because the app does not have access to the chrome APIs
+ * to establish the connection with the background itself.
+ */
+export class ExtensionMessageRouter {
+  listen(): void {
+    // Receive from ExtensionProvider the App "subscription"
+    window.addEventListener('message', this.#handleMessage);
+  }
+
+  #handleMessage = ({ data }: ExtensionProviderMessage): void => {
+    if (!data.origin || data.origin !== EXTENSION_PROVIDER_ORIGIN) {
+      return;
+    }
+    debug(`RECEIEVED MESSAGE FROM ${EXTENSION_PROVIDER_ORIGIN}`, data);
+
+    let port: chrome.runtime.Port;
+
+    if (data.message === 'disconnect') {
+      port = ports[data.chainName];
+      port.disconnect();
+      debug(`DISCONNECTED ${data.chainName} PORT`, port);
+      delete ports[data.chainName];
+      return;
+    }
+
+    if (data.message.type === 'associate') {
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      port = chrome.runtime.connect({ name: `${data.appName}::${data.chainName}` });
+      debug(`CONNECTED ${data.chainName} PORT`, port);
+      // forward any messages: extension -> page
+      const chainName = data.chainName;
+      port.onMessage.addListener((data): void => {
+        debug(`RECIEVED MESSGE FROM ${chainName} PORT`, data);
+        window.postMessage({ 
+          message: data.payload, 
+          origin: CONTENT_SCRIPT_ORIGIN 
+        }, '*');
+      });
+
+      ports[data.chainName] = port;
+      debug(`SENDING ASSOCIATE MESSAGE TO ${data.chainName} PORT`, data.message);
+      // TODO(rem): do we actually need to send the origin to the background
+      // can we not just forward the message?
+      port.postMessage({ ...data.message, origin: EXTENSION_PROVIDER_ORIGIN});
+      return;
+    }
+
+    port = ports[data.chainName];
+    if (!port) {
+      // this is probably someone trying to abuse the extension.
+      console.warn(`App requested to send message to ${data.chainName} - no port found`);
+      return;
+    }
+
+    debug(`SENDING MESSAGE TO ${data.chainName} PORT`, data.message);
+    port.postMessage({ ...data.message, origin: EXTENSION_PROVIDER_ORIGIN});
+  }
+
+}
+

--- a/projects/extension/src/content/index.ts
+++ b/projects/extension/src/content/index.ts
@@ -1,7 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import type { ExtensionProviderMessage } from '../types';
-import { debug } from '../utils/debug';
 import { ExtensionMessageRouter } from './ExtensionMessageRouter';
 
 const router = new ExtensionMessageRouter();

--- a/projects/extension/src/content/index.ts
+++ b/projects/extension/src/content/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import type { ExtensionProviderMessage } from './types';
-import { debug } from './utils/debug';
+import type { ExtensionProviderMessage } from '../types';
+import { debug } from '../utils/debug';
 
 const ports: Record<string, chrome.runtime.Port> = {};
 

--- a/projects/extension/src/content/index.ts
+++ b/projects/extension/src/content/index.ts
@@ -2,62 +2,10 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import type { ExtensionProviderMessage } from '../types';
 import { debug } from '../utils/debug';
+import { ExtensionMessageRouter } from './ExtensionMessageRouter';
 
-const ports: Record<string, chrome.runtime.Port> = {};
-
-const CONTENT_SCRIPT_ORIGIN = 'content-script';
-const EXTENSION_PROVIDER_ORIGIN ='extension-provider';
-
-// Receive from ExtensionProvider the App "subscription"
-window.addEventListener('message', ({ data }: ExtensionProviderMessage): void => {
-  if (!data.origin || data.origin !== EXTENSION_PROVIDER_ORIGIN) {
-    return;
-  }
-  debug(`RECEIEVED MESSAGE FROM ${EXTENSION_PROVIDER_ORIGIN}`, data);
-
-  let port: chrome.runtime.Port;
-
-  if (data.message === 'disconnect') {
-    port = ports[data.chainName];
-    port.disconnect();
-    debug(`DISCONNECTED ${data.chainName} PORT`, port);
-    delete ports[data.chainName];
-    return;
-  }
-
-  if (data.message.type === 'associate') {
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-    port = chrome.runtime.connect({ name: `${data.appName}::${data.chainName}` });
-    debug(`CONNECTED ${data.chainName} PORT`, port);
-    // forward any messages: extension -> page
-    const chainName = data.chainName;
-    port.onMessage.addListener((data): void => {
-      debug(`RECIEVED MESSGE FROM ${chainName} PORT`, data);
-      window.postMessage({ 
-        message: data.payload, 
-        origin: CONTENT_SCRIPT_ORIGIN 
-      }, '*');
-    });
-
-    ports[data.chainName] = port;
-    debug(`SENDING ASSOCIATE MESSAGE TO ${data.chainName} PORT`, data.message);
-    // TODO(rem): do we actually need to send the origin to the background
-    // can we not just forward the message?
-    port.postMessage({ ...data.message, origin: EXTENSION_PROVIDER_ORIGIN});
-    return;
-  }
-
-  port = ports[data.chainName];
-  if (!port) {
-    // this is probably someone trying to abuse the extension.
-    console.warn(`App requested to send message to ${data.chainName} - no port found`);
-    return;
-  }
-
-  debug(`SENDING MESSAGE TO ${data.chainName} PORT`, data.message);
-  port.postMessage({ ...data.message, origin: EXTENSION_PROVIDER_ORIGIN});
-});
-
+const router = new ExtensionMessageRouter();
+router.listen();
 
 // inject page.ts to the tab
 const script = document.createElement('script');

--- a/projects/extension/src/mocks.ts
+++ b/projects/extension/src/mocks.ts
@@ -1,7 +1,7 @@
 import { jest } from '@jest/globals';
 import { AppMediator } from './background/AppMediator';
 import { ConnectionManagerInterface } from './background/types';
-import { AppMessage } from './types';
+import { AppMessage, ExtensionMessage } from './types';
 
 export class MockPort implements chrome.runtime.Port {
   sender: any;
@@ -18,13 +18,13 @@ export class MockPort implements chrome.runtime.Port {
     this.sender.tab.id = id;
   }
 
-  triggerMessage(message: AppMessage) {
+  triggerMessage(message: AppMessage | ExtensionMessage): void {
     this.#messageListeners.forEach((l: any) => {
       l(message);
     });
   }
 
-  triggerDisconnect() {
+  triggerDisconnect(): void {
     this.#disconnectListeners.forEach((l: any) => {
       l();
     });

--- a/projects/extension/src/mocks.ts
+++ b/projects/extension/src/mocks.ts
@@ -1,7 +1,7 @@
 import { jest } from '@jest/globals';
-import { AppMediator } from './AppMediator';
-import { ConnectionManagerInterface } from './types';
-import { AppMessage } from '../types';
+import { AppMediator } from './background/AppMediator';
+import { ConnectionManagerInterface } from './background/types';
+import { AppMessage } from './types';
 
 export class MockPort implements chrome.runtime.Port {
   sender: any;

--- a/projects/extension/src/mocks.ts
+++ b/projects/extension/src/mocks.ts
@@ -31,7 +31,8 @@ export class MockPort implements chrome.runtime.Port {
   }
 
   postMessage = jest.fn();
-  disconnect = () => {};
+  disconnect = jest.fn();
+
   onMessage = {
     addListener: (listener: never) => {
       this.#messageListeners.push(listener);

--- a/projects/extension/src/types/index.ts
+++ b/projects/extension/src/types/index.ts
@@ -59,7 +59,8 @@ export interface ExtensionProviderMessage {
     appName: string;
     chainName: string;
     origin: string;
-    message: AppMessage | 'disconnect';
+    action: 'forward' | 'disconnect';
+    message?: AppMessage;
   }
 }
 

--- a/projects/extension/src/types/index.ts
+++ b/projects/extension/src/types/index.ts
@@ -32,24 +32,34 @@ export type ExtensionMessageType = 'error' | 'rpc';
 
 export interface ExtensionMessage {
   type: ExtensionMessageType;
-  payload: string;
+  payload: string; // JSON encoded RPC response or an error message
 }
 
 // Messages that come from the app
 export type AppMessageType = 'associate' | 'rpc';
 
+/* The inner message that was received by the content script to be sent on to
+ * the extension background.
+ */
 export interface AppMessage {
   type: AppMessageType;
-  payload: string; // smoldot name / json / message_id / subscription_id
+  payload: string; // smoldot name or JSON encoded RPC message
   subscription?: boolean;
 }
 
-export interface Message {
+/* A message that is sent by the `ExtenionProvider` calling `window.postMessage`
+ * that is received by the content script.
+ *
+ * The `message` property will either be an `AppMessage` for sending through the
+ * port to the background script or the string 'disconnect' to tell the content
+ * script to disconnect the port.
+ */
+export interface ExtensionProviderMessage {
   data: {
     appName: string;
     chainName: string;
     origin: string;
-    message: AppMessage
+    message: AppMessage | 'disconnect';
   }
 }
 

--- a/projects/extension/webpack.config.js
+++ b/projects/extension/webpack.config.js
@@ -9,7 +9,7 @@ const config = {
   entry: {
     popup: path.resolve("src/popup.tsx"),
     options: path.resolve("src/options.tsx"),
-    content: path.resolve("src/content.ts"),
+    content: path.resolve("src/content/index.ts"),
     page: path.resolve("src/page.ts"),
     background: path.resolve("src/background/index.ts")
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2928,6 +2928,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/chrome@^0.0.114":
+  version "0.0.114"
+  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.114.tgz#8ceb33fa261f4b9e307fa7344ba8182d8d410d4e"
+  integrity sha512-i7qRr74IrxHtbnrZSKUuP5Uvd5EOKwlwJq/yp7+yTPihOXnPhNQO4Z5bqb1XTnrjdbUKEJicaVVbhcgtRijmLA==
+  dependencies:
+    "@types/filesystem" "*"
+    "@types/har-format" "*"
+
 "@types/chrome@^0.0.132":
   version "0.0.132"
   resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.132.tgz#8134139bf18ca38374bfc3dcac4a596b014c1946"
@@ -8656,6 +8664,13 @@ jest-changed-files@^26.6.2:
     execa "^4.0.0"
     throat "^5.0.0"
 
+jest-chrome@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/jest-chrome/-/jest-chrome-0.7.0.tgz#4a2105370f916abf20cf5f389d0818698c28b05a"
+  integrity sha512-afOzmTh3Nzr1FDKU/nsfIi/OmyScl6Pd6+jdqaBoRNwdGdYnMEWgZKW73KesdcywnLBEHRCKO4ftY+VTbqgPww==
+  dependencies:
+    "@types/chrome" "^0.0.114"
+
 jest-cli@^26.6.3:
   version "26.6.3"
   resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-26.6.3.tgz#43117cfef24bc4cd691a174a8796a532e135e92a"
@@ -13204,7 +13219,7 @@ style-loader@^2.0.0:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-styled-components@^5.2.1:
+styled-components@^5, styled-components@^5.2.1:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.2.3.tgz#752669fd694aac10de814d96efc287dde0d11385"
   integrity sha512-BlR+KrLW3NL1yhvEB+9Nu9Dt51CuOnHoxd+Hj+rYPdtyR8X11uIW9rvhpy3Dk4dXXBsiW1u5U78f00Lf/afGoA==


### PR DESCRIPTION
This implements disconnect in the extension provider (fixes #168) which will now send a message to the content script telling it to disconnect the port to the background and emits the `disconnected` event on the provider.

I took the opportunity to add a full suite of tests for the content script message routing behaviours.  I had to refactor the routing out to make it easier to test.