### PR TITLE
Fix extension provider malformed message warnings and bump @substrate/connect version

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@substrate/connect",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Substrate-connect to Smoldot clients. Using either substrate extension with predefined clients or an internal smoldot client based on chainSpecs provided.",
   "author": "Parity Team <admin@parity.io>",
   "license": "GPL-3.0-only",

--- a/projects/burnr/package.json
+++ b/projects/burnr/package.json
@@ -36,7 +36,7 @@
     "@polkadot/ui-settings": "^0.68.1",
     "@polkadot/util": "^5.5.2",
     "@polkadot/util-crypto": "^5.5.2",
-    "@substrate/connect": "^0.2.0",
+    "@substrate/connect": "^0.3.0",
     "qrcode.react": "^1.0.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/projects/extension/src/content/ExtensionMessageRouter.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.ts
@@ -42,9 +42,9 @@ export class ExtensionMessageRouter {
     const chainName = data.chainName;
     port.onMessage.addListener((data): void => {
       debug(`RECIEVED MESSGE FROM ${chainName} PORT`, data);
-      window.postMessage({ 
-        message: data.payload, 
-        origin: CONTENT_SCRIPT_ORIGIN 
+      window.postMessage({
+        message: data.payload,
+        origin: CONTENT_SCRIPT_ORIGIN
       }, '*');
     });
 
@@ -90,13 +90,19 @@ export class ExtensionMessageRouter {
 
     debug(`RECEIEVED MESSAGE FROM ${EXTENSION_PROVIDER_ORIGIN}`, data);
 
+    if (!data.action) {
+      return console.warn('Malformed message - missing action', message);
+    }
+
     if (data.action === 'disconnect') {
       return this.#disconnectPort(message);
-    } else if (data.action === 'forward') {
+    }
+
+    if (data.action === 'forward') {
       const innerMessage = data.message as AppMessage;
       if (!innerMessage.type) {
         // probably someone abusing the extension
-        console.warn('Malformed message received', data);
+        console.warn('Malformed message - missing message.type', data);
         return;
       }
 
@@ -109,11 +115,11 @@ export class ExtensionMessageRouter {
       }
 
       // probably someone abusing the extension
-      return console.warn('Unrecognised action', data);
+      return console.warn('Malformed message - unrecognised message.type', data);
     }
 
     // probably someone abusing the extension
-    return console.warn('Unrecognised message type', data);
+    return console.warn('Malformed message - unrecognised action', data);
   }
 }
 

--- a/projects/multiple-network-demo/package.json
+++ b/projects/multiple-network-demo/package.json
@@ -33,7 +33,7 @@
     "typescript": "^4.1.5"
   },
   "dependencies": {
-    "@substrate/connect": "^0.2.0",
+    "@substrate/connect": "^0.3.0",
     "regenerator-runtime": "^0.13.7"
   },
   "eslintConfig": {

--- a/projects/smoldot-browser-demo/package.json
+++ b/projects/smoldot-browser-demo/package.json
@@ -34,7 +34,7 @@
     "typescript": "^4.1.5"
   },
   "dependencies": {
-    "@substrate/connect": "^0.2.0",
+    "@substrate/connect": "^0.3.0",
     "regenerator-runtime": "^0.13.7"
   },
   "eslintConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13219,7 +13219,7 @@ style-loader@^2.0.0:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-styled-components@^5, styled-components@^5.2.1:
+styled-components@^5.2.1:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.2.3.tgz#752669fd694aac10de814d96efc287dde0d11385"
   integrity sha512-BlR+KrLW3NL1yhvEB+9Nu9Dt51CuOnHoxd+Hj+rYPdtyR8X11uIW9rvhpy3Dk4dXXBsiW1u5U78f00Lf/afGoA==


### PR DESCRIPTION
I have made the warnings more explicit.  Added a specific warning for the case where there is no `action` and standardised the formatting.  

I also bumped the @substrate/connect version with a minor version number change as it affects the API between @substate/connect and the demos. (Although [the version numbers don't mean anything](https://semver.org/#spec-item-4) for a major version of "0")