### PR TITLE
Handle errors sent from the extension background to the app properly

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@substrate/connect",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Substrate-connect to Smoldot clients. Using either substrate extension with predefined clients or an internal smoldot client based on chainSpecs provided.",
   "author": "Parity Team <admin@parity.io>",
   "license": "GPL-3.0-only",

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -8,7 +8,7 @@ import {
   ExtensionMessageData
 } from './types';
 
-function waitForMessageToBePosted(): Promise<null> {
+const waitForMessageToBePosted = (): Promise<null> => {
   // window.postMessge is async so we must do a short setTimeout to yield to
   // the event loop
   return new Promise(resolve => setTimeout(resolve, 10, null));

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -1,8 +1,27 @@
 import {jest} from '@jest/globals'
-import { ExtensionProvider } from './ExtensionProvider';
+import { 
+  ExtensionProvider, 
+} from './ExtensionProvider';
+import {
+  ProviderMessage,
+  ProviderMessageData,
+  ExtensionMessageData
+} from './types';
 
+function waitForMessageToBePosted(): Promise<null> {
+  // window.postMessge is async so we must do a short setTimeout to yield to
+  // the event loop
+  return new Promise(resolve => setTimeout(resolve, 10, null));
+}
+
+let handler = jest.fn();
 beforeEach(() => {
-  window.postMessage = jest.fn();
+  handler = jest.fn();
+  window.addEventListener('message', handler);
+});
+
+afterEach(() => {
+  window.removeEventListener('message', handler);
 });
 
 test('constructor sets properties', async () => {
@@ -16,9 +35,9 @@ test('connect sends init message and emits connected', async () => {
   const emitted = jest.fn();
   ep.on('connected', emitted);
   await ep.connect();
+  await waitForMessageToBePosted();
 
-
-  const expectedMessage = {
+  const expectedMessage: ProviderMessageData = {
     appName: 'test',
     chainName: 'test-chain',
     action: 'forward',
@@ -28,8 +47,9 @@ test('connect sends init message and emits connected', async () => {
     },
     origin: 'extension-provider'
   };
-  expect(window.postMessage).toHaveBeenCalledTimes(1);
-  expect(window.postMessage).toHaveBeenCalledWith(expectedMessage, '*');
+  expect(handler).toHaveBeenCalledTimes(1);
+  const { data } = handler.mock.calls[0][0] as ProviderMessage;
+  expect(data).toEqual(expectedMessage);
   expect(ep.isConnected).toBe(true);
   expect(emitted).toHaveBeenCalledTimes(1);
 });
@@ -41,15 +61,38 @@ test('disconnect sends disconnect message and emits disconnected', async () => {
 
   ep.on('disconnected', emitted);
   await ep.disconnect();
+  await waitForMessageToBePosted();
 
-  const expectedMessage = {
+  const expectedMessage: ProviderMessageData = {
     appName: 'test',
     chainName: 'test-chain',
     action: 'disconnect',
     origin: 'extension-provider'
   };
-  expect(window.postMessage).toHaveBeenCalledTimes(2);
-  expect(window.postMessage).toHaveBeenNthCalledWith(2, expectedMessage, '*');
+  expect(handler).toHaveBeenCalledTimes(2);
+  const { data } = handler.mock.calls[1][0] as ProviderMessage;
+  expect(data).toEqual(expectedMessage);
   expect(ep.isConnected).toBe(false);
   expect(emitted).toHaveBeenCalledTimes(1);
+});
+
+test('emits error when it receives an error message', async () => {
+  const ep = new ExtensionProvider('test', 'test-chain');
+  await ep.connect();
+  await waitForMessageToBePosted();
+  const errorMessage: ExtensionMessageData = {
+    origin: 'content-script',
+    message: {
+      type: 'error',
+      payload: 'Boom!'
+    }
+  };
+  const errorHandler = jest.fn();
+  ep.on('error', errorHandler);
+  window.postMessage(errorMessage, '*');
+  await waitForMessageToBePosted();
+
+  expect(errorHandler).toHaveBeenCalled();
+  const error = errorHandler.mock.calls[0][0] as Error;
+  expect(error.message).toEqual(errorMessage.message.payload);
 });

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
@@ -1,8 +1,3 @@
-// Copyright 2018-2021 @paritytech/substrate-connect authors & contributors
-// This software may be modified and distributed under the terms
-// of the Apache-2.0 license. See the LICENSE file for details.
-
-import * as smoldot from 'smoldot';
 import {RpcCoder} from '@polkadot/rpc-provider/coder';
 import {
   JsonRpcResponse,
@@ -14,18 +9,17 @@ import {
 import { logger } from '@polkadot/util';
 import EventEmitter from 'eventemitter3';
 import { isUndefined } from '../utils';
+import {
+  ExtensionMessage,
+  ExtensionMessageData,
+  ProviderMessageData
+} from './types';
 
 const CONTENT_SCRIPT_ORIGIN = 'content-script';
 const EXTENSION_PROVIDER_ORIGIN = 'extension-provider';
 
 const l = logger(EXTENSION_PROVIDER_ORIGIN);
 
-interface ExtensionMessage {
-  data: {
-    origin: string;
-    message: string;
-  }
-}
 
 interface RpcStateAwaiting {
   callback: ProviderInterfaceCallback;
@@ -56,7 +50,6 @@ export class ExtensionProvider implements ProviderInterface {
   readonly #handlers: Record<string, RpcStateAwaiting> = {};
   readonly #subscriptions: Record<string, StateSubscription> = {};
   readonly #waitingForId: Record<string, JsonRpcResponse> = {};
-  #client: smoldot.SmoldotClient | undefined = undefined;
   #isConnected = false;
 
   #appName: string;
@@ -91,13 +84,24 @@ export class ExtensionProvider implements ProviderInterface {
     throw new Error('clone() is not supported.');
   }
 
-  #handleRpcReponse = (res: string): void => {
-    l.debug(() => ['received', res]);
-    const response = JSON.parse(res) as JsonRpcResponse;
+  #handleMessage = (data: ExtensionMessageData): void => {
+    const type = data.message.type;
+    if (type === 'error') {
+      return this.emit('error', new Error(data.message.payload));
+    }
 
-    return isUndefined(response.method)
-      ? this.#onMessageResult(response)
-      : this.#onMessageSubscribe(response);
+    if (type === 'rpc') {
+      const rpcString = data.message.payload;
+      l.debug(() => ['received', rpcString]);
+      const response = JSON.parse(rpcString) as JsonRpcResponse;
+
+      return isUndefined(response.method)
+        ? this.#onMessageResult(response)
+        : this.#onMessageSubscribe(response);
+    }
+
+    const errorMessage =`Unrecognised message type from extension ${type}`;
+    return this.emit('error', new Error(errorMessage));
   }
 
   #onMessageResult = (response: JsonRpcResponse): void => {
@@ -164,7 +168,7 @@ export class ExtensionProvider implements ProviderInterface {
    * @description "Connect" the WASM client - starts the smoldot WASM client
    */
   public connect(): Promise<void> {
-    const initMsg = {
+    const initMsg: ProviderMessageData = {
       appName: this.#appName,
       chainName: this.#chainName,
       action: 'forward',
@@ -178,7 +182,7 @@ export class ExtensionProvider implements ProviderInterface {
     window.addEventListener('message', ({data}: ExtensionMessage) => {
       if (data.origin && data.origin === CONTENT_SCRIPT_ORIGIN) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        this.#handleRpcReponse(data.message);
+        this.#handleMessage(data);
       }
     });
     this.#isConnected = true;
@@ -192,12 +196,14 @@ export class ExtensionProvider implements ProviderInterface {
    */
   // eslint-disable-next-line @typescript-eslint/require-await
   public async disconnect(): Promise<void> {
-    window.postMessage({
+    const disconnectMsg: ProviderMessageData = {
       appName: this.#appName,
       chainName: this.#chainName,
       action: 'disconnect',
       origin: EXTENSION_PROVIDER_ORIGIN
-    }, '*');
+    };
+
+    window.postMessage(disconnectMsg, '*');
     this.#isConnected = false;
     this.emit('disconnected');
   }
@@ -259,7 +265,7 @@ export class ExtensionProvider implements ProviderInterface {
         subscription
       };
 
-      window.postMessage({
+      const rpcMsg: ProviderMessageData = {
         appName: this.#appName,
         chainName: this.#chainName,
         action: 'forward',
@@ -269,7 +275,8 @@ export class ExtensionProvider implements ProviderInterface {
           subscription: !!subscription
         },
         origin: EXTENSION_PROVIDER_ORIGIN
-      }, '*');
+      }
+      window.postMessage(rpcMsg, '*');
     });
   }
 

--- a/packages/connect/src/ExtensionProvider/types.ts
+++ b/packages/connect/src/ExtensionProvider/types.ts
@@ -1,0 +1,30 @@
+/**
+ * @description ExtensionMessage represents messages sent via 
+ * `window.postMessage` from ExtensionProvider -> ExtensionMessageRouter
+ */
+export interface ExtensionMessage { data: ExtensionMessageData}
+export interface ExtensionMessageData {
+  origin: 'content-script';
+  message: {
+    type: 'error' | 'rpc',
+    payload: string;
+  }
+}
+
+/**
+ * @description ProviderMessage represents messages sent via 
+ * `window.postMessage` from ExtensionMessageRouter -> ExtensionProvider
+ */
+export interface ProviderMessage { data: ProviderMessageData }
+export interface ProviderMessageData {
+  origin: 'extension-provider';
+  appName: string;
+  chainName: string;
+  action: 'forward' | 'disconnect';
+  message?: {
+    type: 'associate' | 'rpc',
+    payload: string;
+    subscription?: boolean;
+  }
+}
+

--- a/packages/connect/src/SmoldotProvider/SmoldotProvider.ts
+++ b/packages/connect/src/SmoldotProvider/SmoldotProvider.ts
@@ -1,7 +1,3 @@
-// Copyright 2018-2021 @paritytech/substrate-connect authors & contributors
-// This software may be modified and distributed under the terms
-// of the Apache-2.0 license. See the LICENSE file for details.
-
 import {RpcCoder} from '@polkadot/rpc-provider/coder';
 import {
   JsonRpcResponse,
@@ -40,7 +36,6 @@ interface HealthResponse {
   peers: number;
   shouldHavePeers: boolean;
 }
-
 
 const ANGLICISMS: { [index: string]: string } = {
   chain_finalisedHead: 'chain_finalizedHead',

--- a/projects/burnr/package.json
+++ b/projects/burnr/package.json
@@ -36,7 +36,7 @@
     "@polkadot/ui-settings": "^0.68.1",
     "@polkadot/util": "^5.5.2",
     "@polkadot/util-crypto": "^5.5.2",
-    "@substrate/connect": "^0.3.0",
+    "@substrate/connect": "^0.3.1",
     "qrcode.react": "^1.0.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/projects/extension/src/content/ExtensionMessageRouter.test.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.test.ts
@@ -20,7 +20,7 @@ afterEach(() => {
   router.stop();
 });
 
-function waitForMessageToBePosted(): Promise<null> {
+const waitForMessageToBePosted = (): Promise<null> => {
   // window.postMessge is async so we must do a short setTimeout to yield to
   // the event loop
   return new Promise(resolve => setTimeout(resolve, 10, null));

--- a/projects/extension/src/content/ExtensionMessageRouter.test.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.test.ts
@@ -4,6 +4,10 @@ import { ExtensionMessage } from '../types';
 import { MockPort } from '../mocks';
 import { chrome } from 'jest-chrome';
 
+interface RouterMessage {
+  data: ExtensionMessage
+}
+
 let router: ExtensionMessageRouter;
 
 beforeEach(() => {
@@ -125,14 +129,34 @@ test('forwards rpc message from extension -> app', async () => {
   port.triggerMessage(message);
   await waitForMessageToBePosted();
 
-  interface RouterMessage {
-    data: ExtensionMessage
-  }
-
   expect(chrome.runtime.connect).toHaveBeenCalledTimes(1);
   expect(port.disconnect).not.toHaveBeenCalled();
   expect(handler).toHaveBeenCalled();
   const forwarded = handler.mock.calls[0][0] as RouterMessage;
-  expect(forwarded.data).toEqual({ origin: 'content-script', message: message.payload });
+  expect(forwarded.data).toEqual({ origin: 'content-script', message: message });
+});
+
+test('forwards error message from extension -> app', async () => {
+  const port = new MockPort('test-app::westend');
+  chrome.runtime.connect.mockImplementation(_ => port);
+  // connect
+  window.postMessage({
+    appName: 'test-app',
+    chainName: 'westend',
+    action: 'forward',
+    message: { type: 'associate', payload: 'westend' },
+    origin: 'extension-provider'
+  }, '*');
+  await waitForMessageToBePosted();
+
+  const handler = jest.fn();
+  window.addEventListener('message', handler);
+  const errorMessage: ExtensionMessage = { type: 'error', payload: 'Boom!' };
+  port.triggerMessage(errorMessage);
+  await waitForMessageToBePosted();
+
+  expect(handler).toHaveBeenCalled();
+  const forwarded = handler.mock.calls[0][0] as RouterMessage;
+  expect(forwarded.data).toEqual({ origin: 'content-script', message: errorMessage });
 });
 

--- a/projects/extension/src/content/ExtensionMessageRouter.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.ts
@@ -35,7 +35,7 @@ export class ExtensionMessageRouter {
   }
 
   #establishNewConnection = (message: ExtensionProviderMessage): void => {
-     const data = message.data;
+    const data = message.data;
     const port = chrome.runtime.connect({ name: `${data.appName}::${data.chainName}` });
     debug(`CONNECTED ${data.chainName} PORT`, port);
     // forward any messages: extension -> page
@@ -43,7 +43,7 @@ export class ExtensionMessageRouter {
     port.onMessage.addListener((data): void => {
       debug(`RECIEVED MESSGE FROM ${chainName} PORT`, data);
       window.postMessage({
-        message: data.payload,
+        message: data,
         origin: CONTENT_SCRIPT_ORIGIN
       }, '*');
     });

--- a/projects/multiple-network-demo/package.json
+++ b/projects/multiple-network-demo/package.json
@@ -33,7 +33,7 @@
     "typescript": "^4.1.5"
   },
   "dependencies": {
-    "@substrate/connect": "^0.3.0",
+    "@substrate/connect": "^0.3.1",
     "regenerator-runtime": "^0.13.7"
   },
   "eslintConfig": {

--- a/projects/smoldot-browser-demo/package.json
+++ b/projects/smoldot-browser-demo/package.json
@@ -34,7 +34,7 @@
     "typescript": "^4.1.5"
   },
   "dependencies": {
-    "@substrate/connect": "^0.3.0",
+    "@substrate/connect": "^0.3.1",
     "regenerator-runtime": "^0.13.7"
   },
   "eslintConfig": {


### PR DESCRIPTION
This fixes #228.  In the `ExtensionMessageRouter` when we received a message through the port from the background we were only sending its `payload` via `window.postMessage` on to the app.  The background could send either an `rpc` message where the payload was a JSON string or an `error` where the payload would be an error message.  I adjusted the `ExtensionMessageRouter` to send the whole message and not just the `payload`.  I also adjusted the `ExtensionProvider` to check for `error` message types and emit an error event instead of trying to process it as if it was an RPC message.