### PR TITLE
Change connect-extension-protocol version to v0.1.0

### DIFF
--- a/packages/connect-extension-protocol/package.json
+++ b/packages/connect-extension-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@substrate/connect-extension-protocol",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "Protocol for connect message passing with the extension",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@polkadot/rpc-provider": "^3.7.3",
-    "@substrate/connect-extension-protocol": "1.0.0",
+    "@substrate/connect-extension-protocol": "^0.1.0",
     "browserify-fs": "^1.0.0",
     "eventemitter3": "^4.0.7",
     "file-entry-cache": "^6.0.1",

--- a/projects/extension/package.json
+++ b/projects/extension/package.json
@@ -64,7 +64,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/styles": "^4.11.3",
     "@polkadot/rpc-provider": "^3.10.2",
-    "@substrate/connect-extension-protocol": "1.0.0",
+    "@substrate/connect-extension-protocol": "^0.1.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-hot-loader": "^4.13.0",


### PR DESCRIPTION
Regardless of wether we do #242 I think it is preferable not to commit to v1.0.0 before we are ready to launch publicly.  You never know we may discover the need to make breaking changes between then and now.