### PR TITLE
Implement disconnectTab to gracefully disconnect all connections from a tab

### DIFF
--- a/packages/connect-extension-protocol/package.json
+++ b/packages/connect-extension-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@substrate/connect-extension-protocol",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Protocol for connect message passing with the extension",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -21,8 +21,10 @@ export interface ExtensionMessage { data: ExtensionMessageData}
 export interface ExtensionMessageData {
   /** origin is used to determine which side sent the message **/
   origin: 'content-script';
+  /** message is telling the `ExtensionProvider` the port has been closed **/
+  disconnect?: boolean;
   /** message is the message from the manager to be forwarded to the app **/
-  message: MessageFromManager
+  message?: MessageFromManager
 }
 
 /**

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@substrate/connect",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Substrate-connect to Smoldot clients. Using either substrate extension with predefined clients or an internal smoldot client based on chainSpecs provided.",
   "author": "Parity Team <admin@parity.io>",
   "license": "GPL-3.0-only",
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@polkadot/rpc-provider": "^3.7.3",
-    "@substrate/connect-extension-protocol": "^0.1.0",
+    "@substrate/connect-extension-protocol": "^0.2.0",
     "browserify-fs": "^1.0.0",
     "eventemitter3": "^4.0.7",
     "file-entry-cache": "^6.0.1",

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -3,6 +3,7 @@ import {
   ExtensionProvider, 
 } from './ExtensionProvider';
 import {
+  MessageFromManager,
   ProviderMessage,
   ProviderMessageData,
   ExtensionMessageData,
@@ -77,6 +78,22 @@ test('disconnect sends disconnect message and emits disconnected', async () => {
   expect(emitted).toHaveBeenCalledTimes(1);
 });
 
+test('disconnects and emits disconnected when it receives a disconnect message', async () => {
+  const ep = new ExtensionProvider('test', 'test-chain');
+  const emitted = jest.fn();
+  await ep.connect();
+
+  ep.on('disconnected', emitted);
+  await waitForMessageToBePosted();
+  extension.send({
+    origin: 'content-script',
+    disconnect: true
+  });
+  await waitForMessageToBePosted();
+  expect(emitted).toHaveBeenCalled();
+  expect(ep.isConnected).toBe(false);
+});
+
 test('emits error when it receives an error message', async () => {
   const ep = new ExtensionProvider('test', 'test-chain');
   await ep.connect();
@@ -95,5 +112,6 @@ test('emits error when it receives an error message', async () => {
 
   expect(errorHandler).toHaveBeenCalled();
   const error = errorHandler.mock.calls[0][0] as Error;
-  expect(error.message).toEqual(errorMessage.message.payload);
+  const innerMessage = errorMessage.message as MessageFromManager;
+  expect(error.message).toEqual(innerMessage.payload);
 });

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
@@ -46,6 +46,12 @@ const ANGLICISMS: { [index: string]: string } = {
   chain_unsubscribeFinalisedHeads: 'chain_unsubscribeFinalizedHeads'
 };
 
+/**
+ * The ExtensionProvider allows interacting with a smoldot-based WASM light
+ * client running in a browser extension.  It is not designed to be used
+ * directly.  You should use the `\@substrate/connect` package.
+ * ```
+ */
 export class ExtensionProvider implements ProviderInterface {
   readonly #coder: RpcCoder = new RpcCoder();
   readonly #eventemitter: EventEmitter = new EventEmitter();

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
@@ -61,25 +61,43 @@ export class ExtensionProvider implements ProviderInterface {
     this.#chainName = chainName;
   }
 
+  /**
+   * name
+   *
+   * @returns the name of this app to be used by the extension for display
+   * purposes.  
+   *
+   * @remarks Apps are expected to make efforts to make this name reasonably 
+   * unique.
+   */
   public get name(): string {
     return this.#appName;
   }
 
+  /**
+   * chainName
+   *
+   * @returns the name of the chain this `ExtensionProvider` is talking to.
+   */
   public get chainName(): string {
     return this.#chainName;
   }
 
   /**
-   * @description Lets polkadot-js know we support subscriptions
-   * @summary `true`
+   * Lets polkadot-js know we support subscriptions
+   *
+   * @remarks Always returns `true` - this provider supports subscriptions.
+   * PolkadotJS uses this internally.
    */
   public get hasSubscriptions(): boolean {
     return true;
   }
 
   /**
-   * @description Returns a clone of the object
-   * @summary throws an error as this is not supported.
+   * clone
+   *
+   * @remarks This method is not supported
+   * @throws {@link Error}
    */
   public clone(): ExtensionProvider {
     throw new Error('clone() is not supported.');
@@ -166,7 +184,11 @@ export class ExtensionProvider implements ProviderInterface {
   }
 
   /**
-   * @description "Connect" the WASM client - starts the smoldot WASM client
+   * "Connect" to the extension - sends a message to the `ExtensionMessageRouter`
+   * asking it to connect to the extension background.
+   *
+   * @returns a resolved Promise 
+   * @remarks this is async to fulfill the interface with PolkadotJS
    */
   public connect(): Promise<void> {
     const initMsg: ProviderMessageData = {
@@ -193,7 +215,8 @@ export class ExtensionProvider implements ProviderInterface {
   }
 
   /**
-   * @description Manually "disconnect" - drops the reference to the WASM client
+   * Manually "disconnect" - sends a message to the `ExtensionMessageRouter`
+   * telling it to disconnect the port with the background manager.
    */
   // eslint-disable-next-line @typescript-eslint/require-await
   public async disconnect(): Promise<void> {
@@ -211,7 +234,7 @@ export class ExtensionProvider implements ProviderInterface {
 
   /**
    * @summary Whether the node is connected or not.
-   * @return {boolean} true if connected
+   * @return true if connected otherwise false
    */
   public get isConnected (): boolean {
     return this.#isConnected;
@@ -236,10 +259,11 @@ export class ExtensionProvider implements ProviderInterface {
   }
 
   /**
-   * @summary Send an RPC request  the wasm client
-   * @param method The RPC methods to execute
-   * @param params Encoded paramaters as applicable for the method
-   * @param subscription Subscription details (internally used by `subscribe`)
+   * Send an RPC request  the wasm client
+   *
+   * @param method - The RPC methods to execute
+   * @param params - Encoded paramaters as applicable for the method
+   * @param subscription - Subscription details (internally used by `subscribe`)
    */
   public async send(
     method: string,
@@ -282,13 +306,13 @@ export class ExtensionProvider implements ProviderInterface {
   }
 
   /**
-   * @name subscribe
-   * @summary Allows subscribing to a specific event.
-   * @param  {string}                     type     Subscription type
-   * @param  {string}                     method   Subscription method
-   * @param  {any[]}                      params   Parameters
-   * @param  {ProviderInterfaceCallback}  callback Callback
-   * @return {Promise<number|string>}     Promise resolving to the id of the subscription you can use with [[unsubscribe]].
+   * Allows subscribing to a specific event.
+   *
+   * @param type     - Subscription type
+   * @param method   - Subscription method
+   * @param params   - Parameters
+   * @param callback - Callback
+   * @returns Promise  - resolves to the id of the subscription you can use with [[unsubscribe]].
    *
    * @example
    * <BR>
@@ -318,7 +342,12 @@ export class ExtensionProvider implements ProviderInterface {
   }
 
   /**
-   * @summary Allows unsubscribing to subscriptions made with [[subscribe]].
+   * Allows unsubscribing to subscriptions made with [[subscribe]].
+   *
+   * @param type
+   * @param method
+   * @param id
+   * @returns Promise resolving to whether the unsunscribe request was successful.
    */
   public async unsubscribe(
     type: string,

--- a/projects/burnr/package.json
+++ b/projects/burnr/package.json
@@ -38,7 +38,7 @@
     "@polkadot/ui-settings": "^0.68.1",
     "@polkadot/util": "^5.5.2",
     "@polkadot/util-crypto": "^5.5.2",
-    "@substrate/connect": "^0.3.2",
+    "@substrate/connect": "^0.3.3",
     "qrcode.react": "^1.0.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/projects/extension/package.json
+++ b/projects/extension/package.json
@@ -65,7 +65,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/styles": "^4.11.3",
     "@polkadot/rpc-provider": "^3.10.2",
-    "@substrate/connect-extension-protocol": "^0.1.0",
+    "@substrate/connect-extension-protocol": "^0.2.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-hot-loader": "^4.13.0",

--- a/projects/extension/src/background/ConnectionManager.test.ts
+++ b/projects/extension/src/background/ConnectionManager.test.ts
@@ -83,5 +83,9 @@ test('adding and removing apps changes state', async () => {
   });
 
 
+  handler.mockClear();
+  manager.disconnectTab(42);
+  expect(handler).toHaveBeenCalledTimes(2);
+  expect(manager.getState()).toEqual({ apps: [ ] });
   manager.shutdown();
 });

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -22,6 +22,16 @@ interface State {
   apps: AppState[];
 }
 
+/**
+ * ConnectionManager is the main class involved in managing connections from
+ * apps and smoldots.  It keeps track of apps in {@link AppMediator} instances
+ * and smoldot clients in {@link SmoldotMediator} instances.  It is also
+ * responsible for triggering events when the state changes for the UI to update
+ * accordingly. 
+ *
+ * The 3 classes act in concert to multiples requests from various apps to
+ * smoldot clients and to clean up all an app's subscriptions when disconnected.
+ */
 export class ConnectionManager extends (EventEmitter as { new(): StateEmitter }) implements ConnectionManagerInterface {
   readonly #smoldots: SmoldotMediator[] = [];
   readonly #apps:  AppMediator[] = [];
@@ -29,22 +39,45 @@ export class ConnectionManager extends (EventEmitter as { new(): StateEmitter })
 
   readonly #networks: Network[] = [];
 
+  /** registeredApps
+   *
+   * @returns a list of the names of apps that are currently connected
+   */
   get registeredApps(): string[] {
     return this.#apps.map(a => a.name);
   }
 
+  /** registeredClients
+   *
+   * @returns a list of the networks that are currently connected
+   */
   get registeredClients(): string[] {
     return this.#smoldots.map(s => s.name);
   }
 
+  /**
+   * apps
+   *
+   * @returns all the connected apps.
+   */
   get apps(): AppMediator[] {
     return this.#apps;
   }
 
+  /**
+   * networks
+   *
+   * @returns all the connected networks
+   */
   get networks(): Network[] {
     return this.#networks;
   }
 
+  /**
+   * getState
+   *
+   * @returns a view of the current state of the connection manager
+   */
   getState(): State {
     const state: State = { apps: [] };
     return this.#apps.reduce((result, app) => {
@@ -62,6 +95,12 @@ export class ConnectionManager extends (EventEmitter as { new(): StateEmitter })
     }, state);
   }
 
+  /**
+   * addApp registers a new app to be tracked by the background.
+   *
+   * @param port - a port for a fresh connection that was made to the background
+   * by a content script.
+   */
   addApp(port: chrome.runtime.Port): void {
     const app = this.#apps.find(s => s.name === port.name);
     if (app) {
@@ -74,10 +113,24 @@ export class ConnectionManager extends (EventEmitter as { new(): StateEmitter })
     }
   }
 
+  /**
+   * hasClientFor
+   *
+   * @param name - the name of the network.
+   * @returns whether the ConnectionManager has a smoldot client for the network.
+   */
   hasClientFor(name: string): boolean {
     return this.#smoldots.find(s => s.name === name) !== undefined;
   }
 
+  /**
+   * sendRpcMessageTo is used by the {@link AppMediator} instances to send an
+   * RPC message to a smoldot client.
+   *
+   * @param name - the name of the network.
+   * @param message - the RPC message to send.
+   * @returns the actual (remapped) ID of the message that was sent.
+   */
   sendRpcMessageTo(name: string, message: JsonRpcRequest): number {
     const sm = this.#smoldots.find(s => s.name === name);
     if (!sm) {
@@ -86,6 +139,13 @@ export class ConnectionManager extends (EventEmitter as { new(): StateEmitter })
     return sm.sendRpcMessage(message);
   }
 
+  /**
+   * registerApp is used by the {@link AppMediator} instances to associate an
+   * app with a network
+   *
+   * @param app - The app
+   * @param smoldotName - The name of the network
+   */
   registerApp(app: AppMediator, smoldotName: string): void {
     const sm = this.#smoldots.find(s => s.name === smoldotName);
     if (!sm) {
@@ -94,6 +154,13 @@ export class ConnectionManager extends (EventEmitter as { new(): StateEmitter })
     sm.addApp(app);
   }
 
+  /**
+   * unregisterApp is used after an app has finished processing any unsubscribe
+   * messages and disconnected to fully unregister itself.
+   *
+   * @param app - The app
+   * @param smoldotName = The name of the network the app was connected to.
+   */
   unregisterApp(app: AppMediator, smoldotName: string): void {
     const sm = this.#smoldots.find(s => s.name === smoldotName);
     if (!sm) {
@@ -107,6 +174,13 @@ export class ConnectionManager extends (EventEmitter as { new(): StateEmitter })
   }
 
 
+  /**
+   * addSmoldot connects and adds a new smoldot client.
+   *
+   * @param name - The name of the network.
+   * @param chainSpec - The chain spec for the network.
+   * @returns a Promise
+   */
   async addSmoldot(name: string,  chainSpec: string): Promise<void> {
     if (this.#smoldots.find(s => s.name === name)) {
       throw new Error(`Extension already has a smoldot client named ${name}`);
@@ -144,6 +218,7 @@ export class ConnectionManager extends (EventEmitter as { new(): StateEmitter })
     }
   }
 
+  /** shutdown shuts down all the connected smoldot clients. */
   shutdown(): void {
     for (const sm of this.#smoldots) {
       sm.shutdown();

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -96,6 +96,16 @@ export class ConnectionManager extends (EventEmitter as { new(): StateEmitter })
   }
 
   /**
+   * disconnectTab disconnects all instances of {@link AppMediator} connected
+   * from the supplied tabId
+   *
+   * @param tabId - the id of the tab to disconnect
+   */
+  disconnectTab(tabId: number): void {
+    this.#apps.filter(a => a.tabId && a.tabId === tabId).forEach(a => a.disconnect());
+  }
+
+  /**
    * addApp registers a new app to be tracked by the background.
    *
    * @param port - a port for a fresh connection that was made to the background

--- a/projects/extension/src/content/ExtensionMessageRouter.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.ts
@@ -35,19 +35,14 @@ export class ExtensionMessageRouter {
     return Object.keys(this.#ports);
   }
 
-  /**
-   * listen starts listening for messages sent by an app.
-   */
+  /** listen starts listening for messages sent by an app.  */
   listen(): void {
     extension.listen(this.#handleMessage);
   }
 
-  /**
-   * stop stops listening for messages sent by apps.
-   */
+  /** stop stops listening for messages sent by apps.  */
   stop(): void {
     window.removeEventListener('message', this.#handleMessage);
-
   }
 
   #establishNewConnection = (message: ProviderMessage): void => {

--- a/projects/extension/src/content/ExtensionMessageRouter.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.ts
@@ -56,9 +56,15 @@ export class ExtensionMessageRouter {
     debug(`CONNECTED ${data.chainName} PORT`, port);
     // forward any messages: extension -> page
     const chainName = data.chainName;
+
     port.onMessage.addListener((data): void => {
       debug(`RECIEVED MESSGE FROM ${chainName} PORT`, data);
       extension.send({ message: data, origin: CONTENT_SCRIPT_ORIGIN });
+    });
+
+    port.onDisconnect.addListener(() => {
+      extension.send({ origin: 'content-script', disconnect: true });
+      delete this.#ports[data.chainName];
     });
 
     this.#ports[data.chainName] = port;

--- a/projects/extension/src/content/ExtensionMessageRouter.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.ts
@@ -25,14 +25,26 @@ const EXTENSION_PROVIDER_ORIGIN ='extension-provider';
 export class ExtensionMessageRouter {
   #ports: Record<string, chrome.runtime.Port> = {};
 
+  /**
+   * connections returns the names of all the ports this `ExtensionMessageRouter`
+   * is managing for the app.
+   *
+   * @returns A list of strings
+   */
   get connections(): string[] {
     return Object.keys(this.#ports);
   }
 
+  /**
+   * listen starts listening for messages sent by an app.
+   */
   listen(): void {
     extension.listen(this.#handleMessage);
   }
 
+  /**
+   * stop stops listening for messages sent by apps.
+   */
   stop(): void {
     window.removeEventListener('message', this.#handleMessage);
 

--- a/projects/multiple-network-demo/package.json
+++ b/projects/multiple-network-demo/package.json
@@ -34,7 +34,7 @@
     "typescript": "^4.1.5"
   },
   "dependencies": {
-    "@substrate/connect": "^0.3.2",
+    "@substrate/connect": "^0.3.3",
     "regenerator-runtime": "^0.13.7"
   },
   "eslintConfig": {

--- a/projects/smoldot-browser-demo/package.json
+++ b/projects/smoldot-browser-demo/package.json
@@ -36,7 +36,7 @@
     "typescript": "^4.1.5"
   },
   "dependencies": {
-    "@substrate/connect": "^0.3.2",
+    "@substrate/connect": "^0.3.3",
     "regenerator-runtime": "^0.13.7"
   },
   "eslintConfig": {


### PR DESCRIPTION
This fixes #234 - The UI can now specifiy a tab and have all the connections from that tab gracefully disconnected.  All the ports will be closed, all active subscriptions will be unsubscribed and the content script will notify the `ExtensionProvider` in the app that the connection was closed so that it can raise its disconnect event for the UApp to handle as it sees fit.

```javascript
manager.disconnectTab(42);
```