### PR TITLE
Remove associate message and ready state

### DIFF
--- a/packages/connect-extension-protocol/package.json
+++ b/packages/connect-extension-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@substrate/connect-extension-protocol",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Protocol for connect message passing with the extension",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -69,7 +69,7 @@ export interface ProviderMessageData {
   /** The name of the blockchain network the app is talking to **/
   chainName: string;
   /** What action the `ExtensionMessageRouter` should take **/
-  action: 'forward' | 'disconnect';
+  action: 'forward' | 'connect' | 'disconnect';
   /** The message the `ExtensionMessageRouter` should forward to the background **/
   message?: MessageToManager
 }

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@substrate/connect",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Substrate-connect to Smoldot clients. Using either substrate extension with predefined clients or an internal smoldot client based on chainSpecs provided.",
   "author": "Parity Team <admin@parity.io>",
   "license": "GPL-3.0-only",
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@polkadot/rpc-provider": "^3.7.3",
-    "@substrate/connect-extension-protocol": "^0.2.0",
+    "@substrate/connect-extension-protocol": "^0.3.0",
     "browserify-fs": "^1.0.0",
     "eventemitter3": "^4.0.7",
     "file-entry-cache": "^6.0.1",

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -32,7 +32,7 @@ test('constructor sets properties', async () => {
   expect(ep.chainName).toBe('kusama');
 });
 
-test('connect sends init message and emits connected', async () => {
+test('connect sends connect message and emits connected', async () => {
   const ep = new ExtensionProvider('test', 'test-chain');
   const emitted = jest.fn();
   ep.on('connected', emitted);
@@ -42,11 +42,7 @@ test('connect sends init message and emits connected', async () => {
   const expectedMessage: ProviderMessageData = {
     appName: 'test',
     chainName: 'test-chain',
-    action: 'forward',
-    message: {
-      type: 'associate',
-      payload: 'test-chain'
-    },
+    action: 'connect',
     origin: 'extension-provider'
   };
   expect(handler).toHaveBeenCalledTimes(1);

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
@@ -204,17 +204,13 @@ export class ExtensionProvider implements ProviderInterface {
    * @remarks this is async to fulfill the interface with PolkadotJS
    */
   public connect(): Promise<void> {
-    const initMsg: ProviderMessageData = {
+    const connectMsg: ProviderMessageData = {
       appName: this.#appName,
       chainName: this.#chainName,
-      action: 'forward',
-      message: {
-        type: 'associate',
-        payload: this.#chainName
-      },
+      action: 'connect',
       origin: EXTENSION_PROVIDER_ORIGIN
     }
-    provider.send(initMsg);
+    provider.send(connectMsg);
     provider.listen(({data}: ExtensionMessage) => {
       if (data.origin && data.origin === CONTENT_SCRIPT_ORIGIN) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access

--- a/projects/burnr/package.json
+++ b/projects/burnr/package.json
@@ -38,7 +38,7 @@
     "@polkadot/ui-settings": "^0.68.1",
     "@polkadot/util": "^5.5.2",
     "@polkadot/util-crypto": "^5.5.2",
-    "@substrate/connect": "^0.3.3",
+    "@substrate/connect": "^0.3.4",
     "qrcode.react": "^1.0.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/projects/extension/package.json
+++ b/projects/extension/package.json
@@ -65,7 +65,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/styles": "^4.11.3",
     "@polkadot/rpc-provider": "^3.10.2",
-    "@substrate/connect-extension-protocol": "^0.2.0",
+    "@substrate/connect-extension-protocol": "^0.3.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-hot-loader": "^4.13.0",

--- a/projects/extension/src/background/AppMediator.ts
+++ b/projects/extension/src/background/AppMediator.ts
@@ -39,7 +39,7 @@ export class AppMediator extends (EventEmitter as { new(): StateEmitter }) {
     this.#url = port.sender?.url;
     this.#manager = manager;
     // Open listeners for the incoming rpc messages
-    this.#port.onMessage.addListener(this.#handlePortMessage);
+    this.#port.onMessage.addListener(this.#handleRpcRequest);
     this.#port.onDisconnect.addListener(() => { this.#handleDisconnect() });
   }
 
@@ -157,16 +157,13 @@ export class AppMediator extends (EventEmitter as { new(): StateEmitter }) {
     return true;
   }
 
-  #handleRpcRequest = (message: string, subscription?: boolean): void => {
-    if (this.#state !== 'ready' || this.#smoldotName === undefined) {
-      const message = this.#state === 'connected'
-        ? `The app is not associated with a blockchain client`
-        : `The app is ${this.#state}`;
-
-      const error: MessageFromManager = { type: 'error', payload: message };
-      this.#port.postMessage(error);
+  #handleRpcRequest = (msg: MessageToManager): void => {
+    if (msg.type !== 'rpc') {
+      console.warn(`Unrecognised message type ${msg.type} received from content script`);
       return;
     }
+
+    const { payload: message, subscription } = msg;
 
     const parsed =  JSON.parse(message) as JsonRpcRequest;
     const appID = parsed.id as number;
@@ -184,36 +181,27 @@ export class AppMediator extends (EventEmitter as { new(): StateEmitter }) {
     // TODO: what about unsubscriptions requested by the UApp - we need to remove
     // the subscription from our subscriptions state
 
-    const smoldotID = this.#manager.sendRpcMessageTo(this.#smoldotName, parsed);
+    const smoldotID = this.#manager.sendRpcMessageTo(this.#smoldotName as string, parsed);
     this.requests.push({ appID, smoldotID });
   }
 
-  #handleAssociateRequest = (name: string): void => {
-    if (this.#state !== 'connected' && this.#smoldotName) {
-      this.#sendError(`Cannot reassociate, app is already associated with ${this.#smoldotName}`);
-      return;
+  public associate(): boolean {
+    const splitIdx = this.#port.name.indexOf('::');
+    if (splitIdx === -1) {
+      this.#sendError(`Invalid port name ${this.#port.name} expected <app_name>::<chain_name>`);
+      this.#port.disconnect();
+      return false;
     }
-    if (!this.#manager.hasClientFor(name)) {
-      this.#sendError(`Extension does not have client for ${name}`);
-      return;
-    }
-    this.#manager.registerApp(this, name);
-    this.#smoldotName = name;
-    this.#state = 'ready';
-    this.emit('stateChanged');
-    return;
-  }
+    this.#smoldotName = this.#port.name.substr(splitIdx + 2, this.#port.name.length);
 
-  #handlePortMessage = (message: MessageToManager): void => {
-    if (message.type == 'associate') {
-      this.#handleAssociateRequest(message.payload);
-      return;
+    if (!this.#manager.hasClientFor(this.#smoldotName)) {
+      this.#sendError(`Extension does not have client for ${this.#smoldotName}`);
+      this.#port.disconnect();
+      return false;
     }
 
-    if (message.type === 'rpc') {
-      this.#handleRpcRequest(message.payload, message.subscription);
-      return;
-    }
+    this.#manager.registerApp(this, this.#smoldotName);
+    return true;
   }
 
   disconnect(): void {

--- a/projects/extension/src/background/ConnectionManager.test.ts
+++ b/projects/extension/src/background/ConnectionManager.test.ts
@@ -8,7 +8,6 @@ const  connectApp = (manager: ConnectionManager, tabId: number, name: string, ne
   const port = new MockPort(`${name}::${network}`);
   port.setTabId(tabId);
   manager.addApp(port);
-  port.triggerMessage({ type: 'associate', payload: network });
   return port;
 }
 
@@ -23,8 +22,8 @@ test('adding and removing apps changes state', async () => {
   manager.on('stateChanged', handler);
 
   // app connects to first network
-  const port1 = connectApp(manager, 42, 'test-app', 'westend');
-  expect(handler).toHaveBeenCalledTimes(2);
+  connectApp(manager, 42, 'test-app', 'westend');
+  expect(handler).toHaveBeenCalledTimes(1);
   expect(manager.getState()).toEqual({
     apps: [
       { 
@@ -37,8 +36,8 @@ test('adding and removing apps changes state', async () => {
 
   // app connects to second network
   handler.mockClear();
-  const port2 = connectApp(manager, 42, 'test-app', 'kusama');
-  expect(handler).toHaveBeenCalledTimes(2);
+  connectApp(manager, 42, 'test-app', 'kusama');
+  expect(handler).toHaveBeenCalledTimes(1);
   expect(manager.getState()).toEqual({
     apps: [
       { 
@@ -51,8 +50,8 @@ test('adding and removing apps changes state', async () => {
 
   // different app connects to second network
   handler.mockClear();
-  const port3 = connectApp(manager, 43, 'another-app', 'kusama');
-  expect(handler).toHaveBeenCalledTimes(2);
+  const port = connectApp(manager, 43, 'another-app', 'kusama');
+  expect(handler).toHaveBeenCalledTimes(1);
   expect(manager.getState()).toEqual({
     apps: [
       { 
@@ -70,7 +69,7 @@ test('adding and removing apps changes state', async () => {
 
   // disconnect second app
   handler.mockClear();
-  port3.triggerDisconnect();
+  port.triggerDisconnect();
   expect(handler).toHaveBeenCalled();
   expect(manager.getState()).toEqual({
     apps: [

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -117,8 +117,7 @@ export class ConnectionManager extends (EventEmitter as { new(): StateEmitter })
       port.postMessage({ type: 'info', payload: `App ${port.name} already exists.` });
     } else {
       const newApp = new AppMediator(port, this as ConnectionManagerInterface)
-      const didAssociate = newApp.associate();
-      if (didAssociate) {
+      if (newApp.associate()) {
         this.#apps.push(newApp);
         newApp.on('stateChanged', () => this.emit('stateChanged'));
         this.emit('stateChanged');

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -117,9 +117,12 @@ export class ConnectionManager extends (EventEmitter as { new(): StateEmitter })
       port.postMessage({ type: 'info', payload: `App ${port.name} already exists.` });
     } else {
       const newApp = new AppMediator(port, this as ConnectionManagerInterface)
-      this.#apps.push(newApp);
-      newApp.on('stateChanged', () => this.emit('stateChanged'));
-      this.emit('stateChanged');
+      const didAssociate = newApp.associate();
+      if (didAssociate) {
+        this.#apps.push(newApp);
+        newApp.on('stateChanged', () => this.emit('stateChanged'));
+        this.emit('stateChanged');
+      }
     }
   }
 

--- a/projects/extension/src/background/types.ts
+++ b/projects/extension/src/background/types.ts
@@ -11,7 +11,7 @@ export interface InitAppNameSpec {
 }
 
 // TODO: this is duplicated with `NetworkStatus` in ../types
-export type AppState = 'connected' | 'ready' | 'disconnecting' | 'disconnected';
+export type AppState = 'connected' | 'disconnecting' | 'disconnected';
 
 export interface MessageIDMapping {
   readonly appID: number | undefined;

--- a/projects/extension/src/content/ExtensionMessageRouter.test.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.test.ts
@@ -29,13 +29,12 @@ const waitForMessageToBePosted = (): Promise<null> => {
   return new Promise(resolve => setTimeout(resolve, 10, null));
 }
 
-test('associate establishes a port', async () => {
+test('connect establishes a port', async () => {
   chrome.runtime.connect.mockImplementation(_ => new MockPort('test-app::westend'));
   provider.send({
     appName: 'test-app',
     chainName: 'westend',
-    action: 'forward',
-    message: { type: 'associate', payload: 'westend' },
+    action: 'connect',
     origin: 'extension-provider'
   });
 
@@ -51,8 +50,7 @@ test('port disconnecting sends disconnect message and removes port', async () =>
   provider.send({
     appName: 'test-app',
     chainName: 'westend',
-    action: 'forward',
-    message: { type: 'associate', payload: 'westend' },
+    action: 'connect',
     origin: 'extension-provider'
   });
   await waitForMessageToBePosted();
@@ -87,8 +85,7 @@ test('disconnect disconnects established connection', async () => {
   provider.send({
     appName: 'test-app',
     chainName: 'westend',
-    action: 'forward',
-    message: { type: 'associate', payload: 'westend' },
+    action: 'connect',
     origin: 'extension-provider'
   });
   await waitForMessageToBePosted();
@@ -114,8 +111,7 @@ test('forwards rpc message from app -> extension', async () => {
   provider.send({
     appName: 'test-app',
     chainName: 'westend',
-    action: 'forward',
-    message: { type: 'associate', payload: 'westend' },
+    action: 'connect',
     origin: 'extension-provider'
   });
   await waitForMessageToBePosted();
@@ -146,8 +142,7 @@ test('forwards rpc message from extension -> app', async () => {
   provider.send({
     appName: 'test-app',
     chainName: 'westend',
-    action: 'forward',
-    message: { type: 'associate', payload: 'westend' },
+    action: 'connect',
     origin: 'extension-provider'
   });
   await waitForMessageToBePosted();
@@ -172,8 +167,7 @@ test('forwards error message from extension -> app', async () => {
   window.postMessage({
     appName: 'test-app',
     chainName: 'westend',
-    action: 'forward',
-    message: { type: 'associate', payload: 'westend' },
+    action: 'connect',
     origin: 'extension-provider'
   }, '*');
   await waitForMessageToBePosted();

--- a/projects/extension/src/types/index.ts
+++ b/projects/extension/src/types/index.ts
@@ -1,6 +1,6 @@
 export type NetworkTypes = 'kusama' | 'polkadot' | 'westend' | 'kulupu'
 
-export type NetworkStatus =  'connected' | 'ready' | 'disconnecting' | 'disconnected';
+export type NetworkStatus =  'connected' | 'disconnecting' | 'disconnected';
 
 export interface TabInterface {
     tabId: number | undefined;

--- a/projects/landing-page/src/App.tsx
+++ b/projects/landing-page/src/App.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import React from 'react';
-import { CssBaseline, ThemeProvider, createMuiTheme, Typography, Box, Grid, Button } from '@material-ui/core';
+import { CssBaseline, ThemeProvider, createMuiTheme, Typography, Box, Grid } from '@material-ui/core';
 import { theme, dark, Loader, Logo, Sidebar, UIContainer, Section, SectionHeading, SectionText, SectionHeroText, SectionRef, FooterLink, SidebarLink, Code } from './components';
 import { CardNetwork, CardProject } from './components/Cards';
 

--- a/projects/multiple-network-demo/package.json
+++ b/projects/multiple-network-demo/package.json
@@ -34,7 +34,7 @@
     "typescript": "^4.1.5"
   },
   "dependencies": {
-    "@substrate/connect": "^0.3.3",
+    "@substrate/connect": "^0.3.4",
     "regenerator-runtime": "^0.13.7"
   },
   "eslintConfig": {

--- a/projects/smoldot-browser-demo/package.json
+++ b/projects/smoldot-browser-demo/package.json
@@ -36,7 +36,7 @@
     "typescript": "^4.1.5"
   },
   "dependencies": {
-    "@substrate/connect": "^0.3.3",
+    "@substrate/connect": "^0.3.4",
     "regenerator-runtime": "^0.13.7"
   },
   "eslintConfig": {


### PR DESCRIPTION
This fixes #242 - significantly simplifying the message parsing and handling on the extension side.

When a user has the extension installed and an app connects the `ExtensionProvider` now sends a message with the type `connect` instead of an `associate` message.  The `ExtensionMessageRouter` in turn connects to the background as before but no longer sends an `associate` message.  The `AppMediator` parses the network name out of the port name and becomes `connected`. 

If the background does not have a client for the network named it sends an error back to the app (as before) and disconnects the app.  If the port name is in the wrong format the background also sends an error back (this shouldn't ever happen as we control the content script).

There is no need for a separate `ready` state as the app is implicitly ready if associating the app as part of a port connecting happens successfully.