### PR TITLE
Fix burnr wallet provider issues and deactivate Live clients

### DIFF
--- a/projects/burnr/src/components/NodeSelector.tsx
+++ b/projects/burnr/src/components/NodeSelector.tsx
@@ -74,8 +74,8 @@ export default function NodeSelector(): React.ReactElement {
   const classes = useStyles();
   const api = useApi();
   const [localEndpoint, setLocalEndpoint] = useLocalStorage('endpoint');
-  const endpointName = localEndpoint || 'Polkadot-WsProvider'
-  const [provider, setProvider] = useState<string>(ALL_PROVIDERS[endpointName].id);
+  const endpointName = localEndpoint || 'Westend-WsProvider';
+  const [provider, setProvider] = useState<string>(ALL_PROVIDERS[endpointName]?.id);
   const [open, setOpen] = useState<boolean>(false);
 
   const toggleOpen = () => {
@@ -93,7 +93,7 @@ export default function NodeSelector(): React.ReactElement {
     setLocalEndpoint(provider);
     setProvider(provider);
     
-    console.log("Burnr wallet is now connected to", ALL_PROVIDERS[provider].endpoint);
+    console.log("Burnr wallet is now connected to", ALL_PROVIDERS[provider]?.endpoint);
     // Tis is just a temporary work around. Api should be passed on as prop without reload
     location.reload();
     // setChain(REMOTE_PROVIDERS[selectedEndpoint].network);
@@ -107,8 +107,8 @@ export default function NodeSelector(): React.ReactElement {
           <Box display='flex' alignItems='center' pt={1.5} pb={1.5} pl={0.5} pr={0.5} onClick={toggleOpen}>
             <FiberManualRecordIcon style={{ fontSize: '16px', marginRight: 4 }} color={api && api.isReady ? 'primary' : 'error'} />
             <Box width='100%'>
-              <Typography variant='h4'>{ ALL_PROVIDERS[provider].network }</Typography>
-              <Typography variant='body2' color='textSecondary'>{ALL_PROVIDERS[provider].client} client</Typography>
+              <Typography variant='h4'>{ ALL_PROVIDERS[provider]?.network }</Typography>
+              <Typography variant='body2' color='textSecondary'>{ALL_PROVIDERS[provider]?.client} client</Typography>
             </Box>
             {open ? <ArrowDropUpIcon /> : <ArrowDropDownIcon /> }
           </Box>

--- a/projects/burnr/src/hooks/api/useApiCreate.ts
+++ b/projects/burnr/src/hooks/api/useApiCreate.ts
@@ -16,27 +16,30 @@ export default function useApiCreate (): ApiPromise {
   const [api, setApi] = useState<ApiPromise>({} as ApiPromise);
   const [localEndpoint] = useLocalStorage('endpoint');
 
-  const [provider] = useState<LazyProvider>(ALL_PROVIDERS[localEndpoint] || ALL_PROVIDERS['Polkadot-WsProvider']);
+  const [provider] = useState<LazyProvider>(ALL_PROVIDERS[localEndpoint] || ALL_PROVIDERS['Westend-WsProvider']);
   const  mountedRef = useIsMountedRef();
 
   useEffect((): void => {
-    const choseSmoldot = async () => {
+    const choseSmoldot = async (endpoint: string): Promise<void> => {
       try {
         const detect = new Detector('burnr wallet');
-        const api = await detect.connect('westend');
+        const api = await detect.connect(endpoint);
+        console.log(`Burnr is now connected to ${endpoint}`);
         mountedRef.current && setApi(api);
       } catch (err) {
         console.log('A wild error appeared:', err);
       }
     }
 
-    localEndpoint !== 'Westend-WsProvider' && ApiPromise
+    const endpoint = provider.network.toLowerCase();
+
+    endpoint === 'local network' && ApiPromise
       .create({
-        provider: new WsProvider(provider.endpoint),
+        provider: new WsProvider('ws://127.0.0.1:9944'),
         types: {}
       })
       .then((api): void => {
-        console.log(`Burnr is now connected to ${provider.endpoint === 'string' && provider.endpoint}`);
+        console.log(`Burnr is now connected to local network`);
         console.log("API api", api);
         mountedRef.current && setApi(api);
       })
@@ -44,8 +47,8 @@ export default function useApiCreate (): ApiPromise {
         console.error(err);
       });
 
-      localEndpoint === 'Westend-WsProvider' && choseSmoldot();
-  }, [mountedRef, provider.endpoint, localEndpoint]);
+      endpoint !== 'local network' && choseSmoldot(endpoint);
+  }, [mountedRef, provider.endpoint, provider.network, localEndpoint]);
 
   return api;
 }

--- a/projects/burnr/src/utils/constants.ts
+++ b/projects/burnr/src/utils/constants.ts
@@ -92,6 +92,31 @@ export const REMOTE_PROVIDERS: Record<string, LazyProvider> = {
       Promise.resolve(new WsProvider(endpoints.local)),
     transport: 'WsProvider',
   },
+  // DEACTIVATE LIVE NETWORKS
+  // 'Polkadot-WsProvider': {
+  //   description: 'Remote node hosted by W3F',
+  //   id: 'Polkadot-WsProvider',
+  //   network: 'Polkadot',
+  //   node: 'light',
+  //   source: 'remote',
+  //   endpoint: endpoints.polkadot,
+  //   client: 'Websocket remote',
+  //   start: (): Promise<ProviderInterface> =>
+  //     Promise.resolve(new WsProvider(endpoints.polkadot)),
+  //   transport: 'WsProvider',
+  // },
+  // 'Kusama-WsProvider': {
+  //   description: 'Remote node hosted by W3F',
+  //   id: 'Kusama-WsProvider',
+  //   network: 'Kusama',
+  //   node: 'light',
+  //   source: 'remote',
+  //   endpoint: endpoints.kusama,
+  //   client: 'Websocket remote',
+  //   start: (): Promise<ProviderInterface> =>
+  //     Promise.resolve(new WsProvider(endpoints.kusama)),
+  //   transport: 'WsProvider',
+  // },
   'Westend-WsProvider': {
     description: 'Remote node hosted by W3F',
     id: 'Westend-WsProvider',

--- a/projects/burnr/src/utils/constants.ts
+++ b/projects/burnr/src/utils/constants.ts
@@ -92,7 +92,9 @@ export const REMOTE_PROVIDERS: Record<string, LazyProvider> = {
       Promise.resolve(new WsProvider(endpoints.local)),
     transport: 'WsProvider',
   },
-  // DEACTIVATE LIVE NETWORKS
+  /* DEACTIVATE LIVE NETWORKS - This is for ensuring that there will not be any
+  ** problems and loss of funds on the burnr wallet with live networks
+  */
   // 'Polkadot-WsProvider': {
   //   description: 'Remote node hosted by W3F',
   //   id: 'Polkadot-WsProvider',

--- a/projects/burnr/src/utils/utils.ts
+++ b/projects/burnr/src/utils/utils.ts
@@ -2,6 +2,7 @@ import { Account, LocalStorageAccountCtx } from './types';
 import { uniqueNamesGenerator, Config, starWars } from 'unique-names-generator';
 import { mnemonicGenerate } from '@polkadot/util-crypto';
 import { Keyring } from '@polkadot/api';
+import { KeyringPair$Json } from '@polkadot/keyring/types';
 
 const keyring = new Keyring({ type: 'sr25519' });
 
@@ -39,7 +40,8 @@ export const downloadFile = (fileName: string, data: string, type: string): void
         userAddress: pair.address,
         userName: pair.meta.name as string || '____ _____',
         userSeed: mnemonic,
-        userJson: pair.toJson(),
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        userJson: pair.toJson as unknown as KeyringPair$Json,
         userHistory: []
     }
   }


### PR DESCRIPTION
There was an issue with burnr wallet mainly due to the upgrade of polkadotJS api to latest version.
That was not allowing the wallet to initiate. In addition through previous PRs a bug was introduced that when localStorage was empty, there was no init of the app due to the fact that localStorage was never init'ed before.

Besides the issues/bugs mentioned above - after a short discussion with @goldsteinsveta it seemed like a good idea to remove the live networks from an application like burnr wallet in order to ensure that there will not be any loss of funds.