### PR TITLE
Make mocking system_health more flexible

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -44,12 +44,10 @@
     "@types/jest": "^26.0.20",
     "@types/jsdom": "^16.2.7",
     "@types/mkdirp": "^1.0.1",
-    "@types/sinon": "^9.0.10",
     "@typescript-eslint/parser": "^4.17.0",
     "eslint": "^7.21.0",
     "jest": "^27.0.0-next.9",
     "jsdom": "^16.5.1",
-    "sinon": "^9.2.3",
     "ts-node": "^9.1.1",
     "typescript": "^4.2.3"
   },

--- a/packages/connect/src/SmoldotProvider/SmoldotProvider.test.ts
+++ b/packages/connect/src/SmoldotProvider/SmoldotProvider.test.ts
@@ -15,6 +15,7 @@ import {
   smoldotSpy,
   respondWith
 } from '@substrate/smoldot-test-utils';
+import { jest } from '@jest/globals';
 
 const EMPTY_CHAIN_SPEC = '{}';
 
@@ -134,13 +135,13 @@ test('emits connect and never emits disconnect for development chain', async () 
 test('send formats JSON RPC request correctly', async () => {
   // we don't really care what the reponse is
   const responses =  ['{ "id": 1, "jsonrpc": "2.0", "result": "success" }'];
-  const rpcSend = jest.fn();
+  const rpcSend = jest.fn() as jest.MockedFunction<(rpc: string, chainIndex: number) => void>;
   const ss = smoldotSpy(respondWith(responses), rpcSend);
   const provider = new SmoldotProvider(EMPTY_CHAIN_SPEC, ss);
 
   await provider.connect();
   const reply = await provider.send('hello', [ 'world' ]);
-  expect(rpcSend).toHaveBeenCalledWith('{"id":1,"jsonrpc":"2.0","method":"hello","params":["world"]}');
+  expect(rpcSend).toHaveBeenCalledWith('{"id":1,"jsonrpc":"2.0","method":"hello","params":["world"]}', 0);
   await provider.disconnect();
 });
 
@@ -149,7 +150,7 @@ test('sending twice uses new id', async () => {
     '{ "id": 1, "jsonrpc": "2.0", "result": "success" }',
     '{ "id": 2, "jsonrpc": "2.0", "result": "success" }'
   ];
-  const rpcSend = jest.fn();
+  const rpcSend = jest.fn() as jest.MockedFunction<(rpc: string, chainIndex: number) => void>;
   const ss = smoldotSpy(respondWith(responses), rpcSend);
   const provider = new SmoldotProvider(EMPTY_CHAIN_SPEC, ss);
 

--- a/packages/connect/src/SmoldotProvider/SmoldotProvider.test.ts
+++ b/packages/connect/src/SmoldotProvider/SmoldotProvider.test.ts
@@ -14,6 +14,7 @@ import {
   devChainHealthResponder,
   mockSmoldot,
   smoldotSpy,
+  SystemHealth,
   respondWith
 } from '@substrate/smoldot-test-utils';
 
@@ -65,7 +66,11 @@ test('emits error when system_health responds with error', async () => {
 });
 
 test('emits events when it connects then disconnects', async () => {
-  const ms = mockSmoldot(respondWith([]), customHealthResponder([true, false]));
+  const healthResponses = [
+    { isSyncing: true, peerCount: 1, shouldHavePeers: true },
+    { isSyncing: true, peerCount: 0, shouldHavePeers: true }
+  ];
+  const ms = mockSmoldot(respondWith([]), customHealthResponder(healthResponses));
   const provider = new SmoldotProvider(EMPTY_CHAIN_SPEC, ms);
 
   // we don't want the test to be slow
@@ -82,7 +87,12 @@ test('emits events when it connects then disconnects', async () => {
 });
 
 test('emits events when it connects / disconnects / reconnects', async () => {
-  const ms = mockSmoldot(respondWith([]), customHealthResponder([true, false, true]));
+  const healthResponses = [
+    { isSyncing: true, peerCount: 1, shouldHavePeers: true },
+    { isSyncing: true, peerCount: 0, shouldHavePeers: true },
+    { isSyncing: true, peerCount: 1, shouldHavePeers: true }
+  ];
+  const ms = mockSmoldot(respondWith([]), customHealthResponder(healthResponses));
   const provider = new SmoldotProvider(EMPTY_CHAIN_SPEC, ms);
 
   // we don't want the test to be slow

--- a/packages/smoldot-test-utils/package.json
+++ b/packages/smoldot-test-utils/package.json
@@ -50,6 +50,8 @@
       "plugin:@typescript-eslint/recommended-requiring-type-checking"
     ],
     "rules": {
+      "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+      "@typescript-eslint/restrict-template-expressions": "off",
       "tsdoc/syntax": "error"
     },
     "env": {

--- a/packages/smoldot-test-utils/package.json
+++ b/packages/smoldot-test-utils/package.json
@@ -13,7 +13,7 @@
     "clean": "rm -rf dist/",
     "build": "tsc",
     "test": "echo \"No tests for smoldot-test-utils\"",
-    "lint": "echo \"No lint yet for smoldot-test-utils: actual command -> yarn eslint . --ext .js,.ts\"",
+    "lint": "eslint . --ext .js,.ts",
     "postinstall": "yarn build"
   },
   "dependencies": {

--- a/packages/smoldot-test-utils/package.json
+++ b/packages/smoldot-test-utils/package.json
@@ -20,6 +20,8 @@
     "smoldot": "^0.2.0"
   },
   "devDependencies": {
+    "@types/jest": "^26.0.20",
+    "jest": "^27.0.0-next.9",
     "@typescript-eslint/eslint-plugin": "^4.15.1",
     "@typescript-eslint/parser": "^4.15.1",
     "eslint": "^7.20.0",

--- a/packages/smoldot-test-utils/package.json
+++ b/packages/smoldot-test-utils/package.json
@@ -21,10 +21,11 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",
-    "jest": "^27.0.0-next.9",
     "@typescript-eslint/eslint-plugin": "^4.15.1",
     "@typescript-eslint/parser": "^4.15.1",
     "eslint": "^7.20.0",
+    "eslint-plugin-tsdoc": "^0.2.14",
+    "jest": "^27.0.0-next.9",
     "typescript": "^4.1.5"
   },
   "eslintConfig": {
@@ -36,7 +37,8 @@
       }
     },
     "plugins": [
-      "@typescript-eslint"
+      "@typescript-eslint",
+      "eslint-plugin-tsdoc"
     ],
     "parserOptions": {
       "project": "./tsconfig.json",
@@ -47,6 +49,9 @@
       "plugin:@typescript-eslint/recommended",
       "plugin:@typescript-eslint/recommended-requiring-type-checking"
     ],
+    "rules": {
+      "tsdoc/syntax": "error"
+    },
     "env": {
       "node": true
     }

--- a/packages/smoldot-test-utils/src/index.ts
+++ b/packages/smoldot-test-utils/src/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 import { Smoldot, SmoldotClient, SmoldotOptions } from 'smoldot';
 import { JsonRpcObject } from '@polkadot/rpc-provider/types';
 import { jest } from '@jest/globals'

--- a/packages/smoldot-test-utils/src/index.ts
+++ b/packages/smoldot-test-utils/src/index.ts
@@ -10,7 +10,7 @@ import { jest } from '@jest/globals'
  * @remarks
  *
  * We define SystemHealth instead of using the Health type in
- * interfaces/system/types in @polkadot/api because its more ergonomic to use:
+ * interfaces/system/types in \@polkadot/api because its more ergonomic to use:
  * primitive booleans and numbers instead of the polkadotjs wrapped
  * Codec implementations of those.
  */
@@ -60,7 +60,7 @@ type RpcResponder = (request: string) => string;
  * "system_health" RPC request and returns a valid matching healthy response. It
  * takes the ID from the request and ensures the response has the same ID.
  *
- * @param requestJSON
+ * @param requestJSON - the RPC request JSON
  * @returns a JSON string
  */
 const healthyResponder = (requestJSON: string) => {
@@ -74,7 +74,7 @@ const healthyResponder = (requestJSON: string) => {
  * response for a "dev chain". It takes the ID from the request and ensures the
  * response has the same ID.
  *
- * @param requestJSON
+ * @param requestJSON - the RPC request JSON
  * @returns a JSON string
  */
 export const devChainHealthResponder = (requestJSON: string): string => {
@@ -86,7 +86,7 @@ export const devChainHealthResponder = (requestJSON: string): string => {
  * unhealthyResponder - takes a JSON request that is expected to look like any
  * valid RPC request and and always generates an RPC error response.
  *
- * @param requestJSON
+ * @param requestJSON - the RPC request JSON
  * @returns a JSON string
  */
 export const erroringResponder = (requestJSON: string): string => {

--- a/packages/smoldot-test-utils/src/index.ts
+++ b/packages/smoldot-test-utils/src/index.ts
@@ -96,7 +96,13 @@ export const erroringResponder = (requestJSON: string) => {
   return `{ "id": ${id}, "jsonrpc": "2.0", "error": {"code": 666, "message": "boom!" } }`;
 }
 
-// ---
+
+/**
+ * Orchestrators - these are higher order factory functions take the
+ * definitions of a sequence of reponses to respond with and returns
+ * `RpcResponder` function that when called will return a reponse matching what
+ * was supplied one-by-one
+ */
 
 // Orchestrates a sequence of has peers / has no peers responses
 export const customHealthResponder = (hasPeers: boolean[]) => {
@@ -108,6 +114,23 @@ export const customHealthResponder = (hasPeers: boolean[]) => {
     }
   };
 }
+
+// Orchestrates an `RpcResponder` with a queue of mock reponses to respond with.
+export const respondWith = (jsonResponses: string[]) => {
+  return (_: string) => {
+    const mockResponse = jsonResponses.shift();
+    if (!mockResponse) { 
+      throw new Error("json_rpc_callback was called but there are no mock responses left to respond with"); 
+    }
+    return mockResponse;
+  };
+}
+
+
+/**
+ * Fakes - these are the actual mock / spy implementations you will 
+ * create to use in place of a real instance of smoldot
+ */
 
 
 // Mimics the behaviour of the WASM light client by deferring a call to 
@@ -173,13 +196,3 @@ export const smoldotSpy = (responder: RpcResponder, rpcSpy: any, healthResponder
   };
 };
 
-// Creates an `RpcResponder` with a queue of mock reponses to respond with.
-export const respondWith = (jsonResponses: string[]) => {
-  return (_: string) => {
-    const mockResponse = jsonResponses.shift();
-    if (!mockResponse) { 
-      throw new Error("json_rpc_callback was called but there are no mock responses left to respond with"); 
-    }
-    return mockResponse;
-  };
-}

--- a/packages/smoldot-test-utils/src/index.ts
+++ b/packages/smoldot-test-utils/src/index.ts
@@ -18,8 +18,8 @@ import { SmoldotClient, SmoldotOptions } from 'smoldot';
  *
  * @returns a JSON string
  */
-const systemHealthReponse = (id: number, peerCount: number) => {
-  return `{"jsonrpc":"2.0","id":${id} ,"result":{"isSyncing":true,"peers":${peerCount},"shouldHavePeers":true}}`;
+const systemHealthReponse = (id: number, isSyncing: boolean, peerCount: number, shouldHavePeers: boolean) => {
+  return `{"jsonrpc":"2.0","id":${id} ,"result":{"isSyncing":${isSyncing},"peers":${peerCount},"shouldHavePeers":${shouldHavePeers}}`;
 }
 
 /**
@@ -33,7 +33,7 @@ const systemHealthReponse = (id: number, peerCount: number) => {
  * Dev chains never have peers
  */
 const devChainHealthResponse = (id: number) => {
-  return `{"jsonrpc":"2.0","id":${id} ,"result":{"isSyncing":true,"peers":0,"shouldHavePeers":false}}`;
+  return systemHealthReponse(id, true, 0, false);
 }
 
 /**
@@ -53,7 +53,7 @@ type RpcResponder = (request: string) => string;
  */
 const healthyResponder = (requestJSON: string) => {
   const id = JSON.parse(requestJSON).id;
-  return systemHealthReponse(id, 1);
+  return systemHealthReponse(id, false, 1, true);
 }
 
 /**
@@ -67,7 +67,7 @@ const healthyResponder = (requestJSON: string) => {
  */
 const unhealthyResponder = (requestJSON: string) => {
   const id = JSON.parse(requestJSON).id;
-  return systemHealthReponse(id, 0);
+  return systemHealthReponse(id, true, 0, true);
 }
 
 /**

--- a/packages/smoldot-test-utils/src/index.ts
+++ b/packages/smoldot-test-utils/src/index.ts
@@ -8,29 +8,95 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { SmoldotClient, SmoldotOptions } from 'smoldot';
 
-type RpcResponder = (request: string) => string;
+/**
+ * Response builders - functions that simplify making RPC responses
+ */
 
+/**
+ * systemHealthReponse - creates a valid RPC response that looks like a response
+ * to a "system_health" RPC request using the supplied arguments
+ *
+ * @returns a JSON string
+ */
 const systemHealthReponse = (id: number, peerCount: number) => {
   return `{"jsonrpc":"2.0","id":${id} ,"result":{"isSyncing":true,"peers":${peerCount},"shouldHavePeers":true}}`;
 }
 
-// Always responds to a health request with a response that has peers
+/**
+ * devChainHealthResponse - creates a valid RPC response that looks like a response
+ * to a "system_health" RPC request that came from a "dev chain"
+ *
+ * @returns a JSON string
+ *
+ * @remarks
+ *
+ * Dev chains never have peers
+ */
+const devChainHealthResponse = (id: number) => {
+  return `{"jsonrpc":"2.0","id":${id} ,"result":{"isSyncing":true,"peers":0,"shouldHavePeers":false}}`;
+}
+
+/**
+ * RpcResponder - an RpcResponder is a type representing a function that takes
+ * a JSON string representing an RPC request and uses it to create a JSON RPC
+ * response.
+ */
+type RpcResponder = (request: string) => string;
+
+/**
+ * healthyResponder - takes a JSON request that is expected to look like a valid
+ * "system_health" RPC request and returns a valid matching healthy response. It
+ * takes the ID from the request and ensures the response has the same ID.
+ *
+ * @param requestJSON
+ * @returns a JSON string
+ */
 const healthyResponder = (requestJSON: string) => {
   const id = JSON.parse(requestJSON).id;
   return systemHealthReponse(id, 1);
 }
 
-// Always responds to a health request with a response that has no peers
+/**
+ * unhealthyResponder - takes a JSON request that is expected to look like a valid
+ * "system_health" RPC request and returns a valid matching unhealthy response. It
+ * takes the ID from the request and ensures the response has the same ID. The
+ * response will say there are no peers.
+ *
+ * @param requestJSON
+ * @returns a JSON string
+ */
 const unhealthyResponder = (requestJSON: string) => {
   const id = JSON.parse(requestJSON).id;
   return systemHealthReponse(id, 0);
 }
 
-// Always responds with an error reponse
+/**
+ * devChainHealthResponder - takes a JSON request that is expected to look like
+ * a valid "system_health" RPC request and returns a valid matching healthy
+ * response for a "dev chain". It takes the ID from the request and ensures the
+ * response has the same ID.
+ *
+ * @param requestJSON
+ * @returns a JSON string
+ */
+export const devChainHealthResponder = (requestJSON: string) => {
+  const id = JSON.parse(requestJSON).id;
+  return devChainHealthResponse(id);
+}
+
+/**
+ * unhealthyResponder - takes a JSON request that is expected to look like any
+ * valid RPC request and and always generates an RPC error response.
+ *
+ * @param requestJSON
+ * @returns a JSON string
+ */
 export const erroringResponder = (requestJSON: string) => {
   const id = JSON.parse(requestJSON).id;
   return `{ "id": ${id}, "jsonrpc": "2.0", "error": {"code": 666, "message": "boom!" } }`;
 }
+
+// ---
 
 // Orchestrates a sequence of has peers / has no peers responses
 export const customHealthResponder = (hasPeers: boolean[]) => {
@@ -43,16 +109,6 @@ export const customHealthResponder = (hasPeers: boolean[]) => {
   };
 }
 
-// dev chains never have peers
-const devChainHealthResponse = (id: number) => {
-  return `{"jsonrpc":"2.0","id":${id} ,"result":{"isSyncing":true,"peers":0,"shouldHavePeers":false}}`;
-}
-
-export const devChainHealthResponder = (requestJSON: string) => {
-  const id = JSON.parse(requestJSON).id;
-  return devChainHealthResponse(id);
-
-}
 
 // Mimics the behaviour of the WASM light client by deferring a call to 
 // `jsonRpcCallback` after it is called which returns the response

--- a/packages/smoldot-test-utils/src/index.ts
+++ b/packages/smoldot-test-utils/src/index.ts
@@ -173,8 +173,15 @@ const doNothing = () => {
   // Do nothing
 }
 
-// Creates a fake smoldot. Calls to send use `fakeRpcSend` to mimic the light
-// client behaviour
+/**
+ * mockSmoldot - creates a fake smoldot using the reponder and optional 
+ * healthResponder to orchestrate the responses it should reply with.
+ *
+ * @param responder - controls what responses to reply with for regular messages
+ * and subscription messages.
+ * @param healthResponder - controls what reponses to reply with for
+ * "system_health" RPC requests
+ */
 export const mockSmoldot = (responder: RpcResponder, healthResponder = healthyResponder): Smoldot => {
   return {
     start: async (options: SmoldotOptions): Promise<SmoldotClient> => {
@@ -187,12 +194,22 @@ export const mockSmoldot = (responder: RpcResponder, healthResponder = healthyRe
   };
 };
 
-// Creates a spying `smoldot` that records calls to `json_rpc_send` in `rpcSpy`
-// and then uses `fakeRpcSend` to mimic the light client behaviour.
+/**
+ * spySmoldot - creates a fake smoldot using the reponder and optional 
+ * healthResponder to orchestrate the responses it should reply with that also
+ * takes a spy so that you can inspect the calls that are made internally
+ * to `sendJsonRpc`
+ *
+ * @param responder - controls what responses to reply with for regular messages
+ * and subscription messages.
+ * @param rpcSpy - a jest mock function to record the calls to `sendJsonRpc`
+ * @param healthResponder - controls what reponses to reply with for
+ * "system_health" RPC requests
+ */
 export const smoldotSpy = (responder: RpcResponder, rpcSpy: jest.MockedFunction<(rpc: string, chainIndex: number) => void>, healthResponder = healthyResponder): Smoldot => {
   return {
     start: async (options: SmoldotOptions): Promise<SmoldotClient> => {
-      const processRequest = createRequestProcessor(options, responder, healthyResponder);
+      const processRequest = createRequestProcessor(options, responder, healthResponder);
       return Promise.resolve({
         terminate: doNothing,
         sendJsonRpc: (rpc: string, chainIndex: number) => {

--- a/packages/smoldot-test-utils/src/index.ts
+++ b/packages/smoldot-test-utils/src/index.ts
@@ -7,6 +7,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { SmoldotClient, SmoldotOptions } from 'smoldot';
+import { jest } from '@jest/globals'
 
 export interface SystemHealth {
   isSyncing: boolean;
@@ -174,14 +175,14 @@ export const mockSmoldot = (responder: RpcResponder, healthResponder = healthyRe
 
 // Creates a spying `smoldot` that records calls to `json_rpc_send` in `rpcSpy`
 // and then uses `fakeRpcSend` to mimic the light client behaviour.
-export const smoldotSpy = (responder: RpcResponder, rpcSpy: any, healthResponder = healthyResponder) => {
+export const smoldotSpy = (responder: RpcResponder, rpcSpy: jest.MockedFunction<(rpc: string, chainIndex: number) => void>, healthResponder = healthyResponder) => {
   return {
     start: async (options: SmoldotOptions): Promise<SmoldotClient> => {
       return Promise.resolve({
         terminate: () => {},
         sendJsonRpc: (rpc: string, chainIndex: number) => {
           // record the message call
-          rpcSpy(rpc);
+          rpcSpy(rpc, chainIndex);
           // fake the async reply using the responder
           fakeRpcSend(options, responder, healthResponder)(rpc, chainIndex)
         },

--- a/packages/smoldot-test-utils/src/index.ts
+++ b/packages/smoldot-test-utils/src/index.ts
@@ -1,18 +1,19 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { SmoldotClient, SmoldotOptions } from 'smoldot';
+import { Smoldot, SmoldotClient, SmoldotOptions } from 'smoldot';
+import { JsonRpcObject } from '@polkadot/rpc-provider/types';
 import { jest } from '@jest/globals'
 
-// Temporary until we fix the exports in the typescript definitions for smoldot
-interface Smoldot {
-  start: (options: SmoldotOptions) => Promise<SmoldotClient>;
-}
-
-interface JsonRpcObject {
-  id?: number;
-  jsonrpc: string;
-}
-
+/** 
+ * SystemHealth is the type of the object in the `result` field of the JSON
+ * RPC responses from smoldot for the system_health RPC request.
+ *
+ * @remarks
+ *
+ * We define SystemHealth instead of using the Health type in
+ * interfaces/system/types in @polkadot/api because its more ergonomic to use:
+ * primitive booleans and numbers instead of the polkadotjs wrapped
+ * Codec implementations of those.
+ */
 export interface SystemHealth {
   isSyncing: boolean;
   peerCount: number;
@@ -64,7 +65,7 @@ type RpcResponder = (request: string) => string;
  */
 const healthyResponder = (requestJSON: string) => {
   const { id } = JSON.parse(requestJSON) as JsonRpcObject;
-  return systemHealthReponse(id!, { isSyncing: false, peerCount: 1, shouldHavePeers: true });
+  return systemHealthReponse(id, { isSyncing: false, peerCount: 1, shouldHavePeers: true });
 }
 
 /**
@@ -78,7 +79,7 @@ const healthyResponder = (requestJSON: string) => {
  */
 export const devChainHealthResponder = (requestJSON: string): string => {
   const { id } = JSON.parse(requestJSON) as JsonRpcObject;
-  return devChainHealthResponse(id!);
+  return devChainHealthResponse(id);
 }
 
 /**
@@ -112,7 +113,7 @@ export const customHealthResponder = (healthResponses: SystemHealth[]) => {
       throw new Error(NO_MORE_RESPONSES); 
     }
 
-    return systemHealthReponse(id!, health);
+    return systemHealthReponse(id, health);
   };
 }
 


### PR DESCRIPTION
For this pull request I've only achieved some of what I'd hoped but the key change here is that you are now able to specify a sequence of health responses when testing your new 'connected' behaviour (previously you could only control the 'hasPeers' property of the health responses).

In the process I also reorganised and documented all of smoldot-test-utils and refactored some things to make them more readable.  I also enabled linting and fixed all the problems.  

You might find it easier to review this pull request by reviewing each commit one-by-one instead of viewing the "Files Changed" for the whole PR. I was careful to do each refactoring in a small step and to commit after (although I did retrospectively fix a couple of errors I'd missed as I went).  

### Future work

My vision with smoldot-test-utils is to eventually make it also provide a fake polkadotJS API instance that is pre-configured to respond with whatever responses you want so that you can integration test how an app behaves when the API gives known responses without having to mock the network.  I'm actually quite close to being able to do that, but I need to do some further refactoring to:

* unify the healthResponder and responders.  I.E. make it so that you can tell it what responses it should reply with for what request types (have different sequences of responses for different request methods) 
* fix the subscription mock responses so that they are more configurable (allow more control than sending a single subscription message)

In doing those 2 things I will also be able to make the code drastically more understandable than it currently is.  Unfortunately those changes require more invasive public API changes and I think it's better to wait until your test refactorings are merged before attempting that so as not to cause merge hell.
