### PR TITLE
Landing page fixes

### DIFF
--- a/projects/landing-page/src/App.tsx
+++ b/projects/landing-page/src/App.tsx
@@ -152,10 +152,6 @@ const App: React.FunctionComponent = () => {
           </Section>
           <ThemeProvider theme={createMuiTheme(dark)}>
             <Section pt={5} pb={5}>
-              <SectionHeading id='playground' prefix='6'>Playground</SectionHeading>
-              <SectionText>Save logged API as global variable. Call methods</SectionText>
-              <SectionHeroText>cmd + alt + i</SectionHeroText>
-              <SectionHeroText>ctrl + shift + i</SectionHeroText>
               {/* TODO: Playground */}
               <Box pt={25}>
                 <FooterLink>© 2021 Parity Technologies</FooterLink>

--- a/projects/landing-page/src/App.tsx
+++ b/projects/landing-page/src/App.tsx
@@ -57,21 +57,21 @@ const App: React.FunctionComponent = () => {
               </CardNetwork>
               <CardNetwork
                 title='Rococo'
-                statusProps={{status:'very soon'}}
+                statusProps={{status:'soon'}}
                 linkProps={{href:'https://polkadot.network/rococo-v1-a-holiday-gift-to-the-polkadot-community/'}}
               >
                 Testnet designed for parachains and related technologies: Cumulus and HRMP
               </CardNetwork>
               <CardNetwork
                 title='Kusama'
-                statusProps={{status:'soon'}}
+                statusProps={{status:'supported'}}
                 linkProps={{href:'https://kusama.network/'}}
               >
                 A network built as a risk-taking, fast-moving ‘canary in the coal mine’ for its cousin Polkadot
               </CardNetwork>
               <CardNetwork
                 title='Polkadot'
-                statusProps={{status:'soon'}}
+                statusProps={{status:'supported'}}
                 linkProps={{href:'https://polkadot.network/'}}
               >
                 Scalable sharded chain and the first protocol that provides a secure environment for cross-chain composability

--- a/projects/landing-page/src/App.tsx
+++ b/projects/landing-page/src/App.tsx
@@ -93,21 +93,21 @@ const App: React.FunctionComponent = () => {
 
                 <Box mt={2}>{`// Create a new UApp with a unique name`}</Box>
                 <Box>{`const app = new Detector('burnr-wallet');`}</Box>
-                <Box>{`const westend = app.detect('westend');`}</Box>
-                <Box>{`const kusama = app.detect('kusama');`}</Box>
+                <Box>{`const westend = await app.detect('westend');`}</Box>
+                <Box>{`const kusama = await app.detect('kusama');`}</Box>
 
-                <Box mt={2}>{`westend.rpc.chain.subscribeNewHeads((lastHeader) => {`}</Box>
+                <Box mt={2}>{`await westend.rpc.chain.subscribeNewHeads((lastHeader) => {`}</Box>
                 <Box pl={3}>{`console.log(lastHeader.hash);`}</Box>
                 <Box>{`);`}</Box>
 
-                <Box mt={2}>{`kusama.rpc.chain.subscribeNewHeads((lastHeader) => {`}</Box>
+                <Box mt={2}>{`await kusama.rpc.chain.subscribeNewHeads((lastHeader) => {`}</Box>
                 <Box pl={3}>{`console.log(lastHeader.hash);`}</Box>
                 <Box>{`});`}</Box>
 
                 <Box mt={2}>{`// etc ...`}</Box>
 
-                <Box mt={2}>{`westend.disconnect();`}</Box>
-                <Box>{`kusama.disconnect();`}</Box>
+                <Box mt={2}>{`await westend.disconnect();`}</Box>
+                <Box>{`await kusama.disconnect();`}</Box>
               </Code>
             </ThemeProvider>
           </Section>

--- a/projects/landing-page/src/App.tsx
+++ b/projects/landing-page/src/App.tsx
@@ -89,10 +89,10 @@ const App: React.FunctionComponent = () => {
                 yarn add @substrate/substrate-connect
               </Code>
               <Code heading='index.ts'>
-                <Box>{`import { UApp } from '@substrate/connect';`}</Box>
+                <Box>{`import { Detector } from '@substrate/connect';`}</Box>
 
                 <Box mt={2}>{`// Create a new UApp with a unique name`}</Box>
-                <Box>{`const app = new UApp('burnr-wallet');`}</Box>
+                <Box>{`const app = new Detector('burnr-wallet');`}</Box>
                 <Box>{`const westend = app.detect('westend');`}</Box>
                 <Box>{`const kusama = app.detect('kusama');`}</Box>
 

--- a/projects/landing-page/src/App.tsx
+++ b/projects/landing-page/src/App.tsx
@@ -145,7 +145,7 @@ const App: React.FunctionComponent = () => {
               title='Next Project'
               imageProps={{path:YourProject}}
             >
-              <SectionRef href='https://github.com/paritytech/substrate/blob/master/docs/CONTRIBUTING.adoc#rules'>
+              <SectionRef href='https://github.com/paritytech/substrate-connect/blob/master/CONTRIBUTING.md'>
                 Contributor’s guide
               </SectionRef>
             </CardProject>

--- a/projects/landing-page/src/App.tsx
+++ b/projects/landing-page/src/App.tsx
@@ -56,13 +56,6 @@ const App: React.FunctionComponent = () => {
                 Testing environment for Polkadot and Kusama deployments and processes
               </CardNetwork>
               <CardNetwork
-                title='Rococo'
-                statusProps={{status:'soon'}}
-                linkProps={{href:'https://polkadot.network/rococo-v1-a-holiday-gift-to-the-polkadot-community/'}}
-              >
-                Testnet designed for parachains and related technologies: Cumulus and HRMP
-              </CardNetwork>
-              <CardNetwork
                 title='Kusama'
                 statusProps={{status:'supported'}}
                 linkProps={{href:'https://kusama.network/'}}
@@ -75,6 +68,13 @@ const App: React.FunctionComponent = () => {
                 linkProps={{href:'https://polkadot.network/'}}
               >
                 Scalable sharded chain and the first protocol that provides a secure environment for cross-chain composability
+              </CardNetwork>
+              <CardNetwork
+                title='Rococo'
+                statusProps={{status:'soon'}}
+                linkProps={{href:'https://polkadot.network/rococo-v1-a-holiday-gift-to-the-polkadot-community/'}}
+              >
+                Testnet designed for parachains and related technologies: Cumulus and HRMP
               </CardNetwork>
             </Grid>
             <SectionRef href='https://github.com/paritytech/substrate-connect/tree/13bd26a1ca2904f8e0b5d04dfa35e82364d37d99/packages/connect/assets'>

--- a/projects/landing-page/src/App.tsx
+++ b/projects/landing-page/src/App.tsx
@@ -153,7 +153,7 @@ const App: React.FunctionComponent = () => {
           <ThemeProvider theme={createMuiTheme(dark)}>
             <Section pt={5} pb={5}>
               {/* TODO: Playground */}
-              <Box pt={25}>
+              <Box>
                 <FooterLink>© 2021 Parity Technologies</FooterLink>
                 <FooterLink>Terms & conditions</FooterLink>
                 <FooterLink>Privacy policy</FooterLink>

--- a/projects/landing-page/src/App.tsx
+++ b/projects/landing-page/src/App.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import React from 'react';
 import { CssBaseline, ThemeProvider, createMuiTheme, Typography, Box, Grid } from '@material-ui/core';
-import { theme, dark, Loader, Logo, Sidebar, UIContainer, Section, SectionHeading, SectionText, SectionHeroText, SectionRef, FooterLink, SidebarLink, Code } from './components';
+import { theme, dark, Loader, Logo, Sidebar, UIContainer, Section, SectionHeading, SectionText, SectionRef, FooterLink, SidebarLink, Code } from './components';
 import { CardNetwork, CardProject } from './components/Cards';
 
 import BrowserDemo from 'url:../public/assets/images/BrowserDemo.png';


### PR DESCRIPTION
This fixes the examples and links in the landing page.  It also updates the status of the networks to indicate support of kusama and polkadot and changing rococco to "soon". I also removed the playground text from the footer as it doesn't currently make any sense.  I looked at it in both Firefox and Chrome but you probably want to have a look yourself @goldsteinsveta as there is now quite a large black space where that text was before.