### PR TITLE
Share eslint config across projects

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,29 @@
+module.exports = {
+    root: true,
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { "argsIgnorePattern": "^_" }
+      ],
+      "@typescript-eslint/restrict-template-expressions": "off",
+      "tsdoc/syntax": "error"
+    },
+    parser: "@typescript-eslint/parser",
+    settings: { react: { version: "detect" } },
+    plugins: [
+      "@typescript-eslint",
+      "eslint-plugin-tsdoc"
+    ],
+    parserOptions: {
+      project: "./tsconfig.json",
+      createDefaultProgram: true
+    },
+    extends: [
+      "eslint:recommended",
+      "plugin:@typescript-eslint/recommended",
+      "plugin:@typescript-eslint/recommended-requiring-type-checking"
+    ],
+    env: {
+      browser: true
+    }
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,29 +1,33 @@
 module.exports = {
-    root: true,
-    rules: {
-      "@typescript-eslint/no-unused-vars": [
-        "error",
-        { "argsIgnorePattern": "^_" }
-      ],
-      "@typescript-eslint/restrict-template-expressions": "off",
-      "tsdoc/syntax": "error"
-    },
-    parser: "@typescript-eslint/parser",
-    settings: { react: { version: "detect" } },
-    plugins: [
-      "@typescript-eslint",
-      "eslint-plugin-tsdoc"
+  root: true,
+  rules: {
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      { "argsIgnorePattern": "^_" }
     ],
-    parserOptions: {
-      project: "./tsconfig.json",
-      createDefaultProgram: true
-    },
-    extends: [
-      "eslint:recommended",
-      "plugin:@typescript-eslint/recommended",
-      "plugin:@typescript-eslint/recommended-requiring-type-checking"
+    "@typescript-eslint/restrict-plus-operands": [
+      "error",
+      { "checkCompoundAssignments": false }
     ],
-    env: {
-      browser: true
-    }
+    "@typescript-eslint/restrict-template-expressions": "off",
+    "tsdoc/syntax": "error"
+  },
+  parser: "@typescript-eslint/parser",
+  settings: { react: { version: "detect" } },
+  plugins: [
+    "@typescript-eslint",
+    "eslint-plugin-tsdoc"
+  ],
+  parserOptions: {
+    project: "./tsconfig.json",
+    createDefaultProgram: true
+  },
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking"
+  ],
+  env: {
+    browser: true
+  }
 };

--- a/packages/connect-extension-protocol/package.json
+++ b/packages/connect-extension-protocol/package.json
@@ -18,30 +18,5 @@
     "eslint": "^7.21.0",
     "eslint-plugin-tsdoc": "^0.2.14",
     "typescript": "^4.3.2"
-  },
-  "eslintConfig": {
-    "root": true,
-    "rules": {
-      "@typescript-eslint/restrict-template-expressions": "off",
-      "tsdoc/syntax": "warn"
-    },
-    "parser": "@typescript-eslint/parser",
-    "settings": {},
-    "plugins": [
-      "@typescript-eslint",
-      "eslint-plugin-tsdoc"
-    ],
-    "parserOptions": {
-      "project": "./tsconfig.json",
-      "createDefaultProgram": true
-    },
-    "extends": [
-      "eslint:recommended",
-      "plugin:@typescript-eslint/recommended",
-      "plugin:@typescript-eslint/recommended-requiring-type-checking"
-    ],
-    "env": {
-      "browser": true
-    }
   }
 }

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -53,34 +53,5 @@
   },
   "peerDependencies": {
     "@polkadot/wasm-crypto": "^3.2.2"
-  },
-  "eslintConfig": {
-    "root": true,
-    "rules": {
-      "@typescript-eslint/restrict-template-expressions": "off",
-      "tsdoc/syntax": "warn"
-    },
-    "parser": "@typescript-eslint/parser",
-    "settings": {
-      "react": {
-        "version": "detect"
-      }
-    },
-    "plugins": [
-      "@typescript-eslint",
-      "eslint-plugin-tsdoc"
-    ],
-    "parserOptions": {
-      "project": "./tsconfig.json",
-      "createDefaultProgram": true
-    },
-    "extends": [
-      "eslint:recommended",
-      "plugin:@typescript-eslint/recommended",
-      "plugin:@typescript-eslint/recommended-requiring-type-checking"
-    ],
-    "env": {
-      "node": true
-    }
   }
 }

--- a/packages/connect/src/__mocks__/client.js
+++ b/packages/connect/src/__mocks__/client.js
@@ -2,12 +2,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { JSDOM } from 'jsdom';
-const dom = new JSDOM();
-
-window.document = dom.window.document;
-window.window = dom.window;
-
 const localStorageMock = (() => {
     let store = {};
     return {

--- a/packages/connect/src/__mocks__/client.js
+++ b/packages/connect/src/__mocks__/client.js
@@ -5,8 +5,8 @@
 import { JSDOM } from 'jsdom';
 const dom = new JSDOM();
 
-global.document = dom.window.document;
-global.window = dom.window;
+window.document = dom.window.document;
+window.window = dom.window;
 
 const localStorageMock = (() => {
     let store = {};
@@ -26,4 +26,4 @@ const localStorageMock = (() => {
     };
 })();
 
-Object.defineProperty(global.window, 'localStorage', { value: localStorageMock });
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });

--- a/packages/smoldot-test-utils/package.json
+++ b/packages/smoldot-test-utils/package.json
@@ -26,35 +26,5 @@
     "eslint-plugin-tsdoc": "^0.2.14",
     "jest": "^27.0.0-next.9",
     "typescript": "^4.3.2"
-  },
-  "eslintConfig": {
-    "root": true,
-    "parser": "@typescript-eslint/parser",
-    "settings": {
-      "react": {
-        "version": "detect"
-      }
-    },
-    "plugins": [
-      "@typescript-eslint",
-      "eslint-plugin-tsdoc"
-    ],
-    "parserOptions": {
-      "project": "./tsconfig.json",
-      "createDefaultProgram": true
-    },
-    "extends": [
-      "eslint:recommended",
-      "plugin:@typescript-eslint/recommended",
-      "plugin:@typescript-eslint/recommended-requiring-type-checking"
-    ],
-    "rules": {
-      "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
-      "@typescript-eslint/restrict-template-expressions": "off",
-      "tsdoc/syntax": "error"
-    },
-    "env": {
-      "node": true
-    }
   }
 }

--- a/projects/burnr/.eslintignore
+++ b/projects/burnr/.eslintignore
@@ -4,3 +4,5 @@ node_modules
 dist
 # don't lint .cache
 .cache
+# dont lint the config
+.eslintrc.js

--- a/projects/burnr/.eslintrc.js
+++ b/projects/burnr/.eslintrc.js
@@ -1,0 +1,25 @@
+module.exports = {
+  rules: {
+    "react/prop-types": 0,
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn",
+    "@typescript-eslint/no-misused-promises": [
+      "error",
+      {
+        "checksConditionals": false
+      }
+    ],
+    "@typescript-eslint/restrict-plus-operands": [
+      "error",
+      {
+        "checkCompoundAssignments": false
+      }
+    ]
+  },
+  plugins: [
+    "react-hooks"
+  ],
+  extends: [
+    "plugin:react/recommended"
+  ]
+};

--- a/projects/burnr/.eslintrc.js
+++ b/projects/burnr/.eslintrc.js
@@ -2,19 +2,7 @@ module.exports = {
   rules: {
     "react/prop-types": 0,
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn",
-    "@typescript-eslint/no-misused-promises": [
-      "error",
-      {
-        "checksConditionals": false
-      }
-    ],
-    "@typescript-eslint/restrict-plus-operands": [
-      "error",
-      {
-        "checkCompoundAssignments": false
-      }
-    ]
+    "react-hooks/exhaustive-deps": "warn"
   },
   plugins: [
     "react-hooks"

--- a/projects/burnr/package.json
+++ b/projects/burnr/package.json
@@ -77,23 +77,6 @@
     "typescript": "^4.3.2"
   },
   "eslintConfig": {
-    "root": true,
-    "parser": "@typescript-eslint/parser",
-    "settings": {
-      "react": {
-        "version": "detect"
-      }
-    },
-    "plugins": [
-      "@typescript-eslint",
-      "react-hooks"
-    ],
-    "parserOptions": {
-      "project": [
-        "./tsconfig.json"
-      ],
-      "createDefaultProgram": true
-    },
     "rules": {
       "react/prop-types": 0,
       "react-hooks/rules-of-hooks": "error",
@@ -109,25 +92,13 @@
         {
           "checkCompoundAssignments": false
         }
-      ],
-      "@typescript-eslint/restrict-template-expressions": [
-        "warn",
-        {
-          "allowNumber": true,
-          "allowBoolean": true,
-          "allowNullable": true,
-          "allowAny": true
-        }
       ]
     },
-    "extends": [
-      "eslint:recommended",
-      "plugin:@typescript-eslint/recommended",
-      "plugin:react/recommended",
-      "plugin:@typescript-eslint/recommended-requiring-type-checking"
+    "plugins": [
+      "react-hooks"
     ],
-    "env": {
-      "node": true
-    }
+    "extends": [
+      "plugin:react/recommended"
+    ]
   }
 }

--- a/projects/burnr/package.json
+++ b/projects/burnr/package.json
@@ -75,30 +75,5 @@
     "ts-jest": "^26.5.1",
     "tsc-watch": "^4.2.9",
     "typescript": "^4.3.2"
-  },
-  "eslintConfig": {
-    "rules": {
-      "react/prop-types": 0,
-      "react-hooks/rules-of-hooks": "error",
-      "react-hooks/exhaustive-deps": "warn",
-      "@typescript-eslint/no-misused-promises": [
-        "error",
-        {
-          "checksConditionals": false
-        }
-      ],
-      "@typescript-eslint/restrict-plus-operands": [
-        "error",
-        {
-          "checkCompoundAssignments": false
-        }
-      ]
-    },
-    "plugins": [
-      "react-hooks"
-    ],
-    "extends": [
-      "plugin:react/recommended"
-    ]
   }
 }

--- a/projects/burnr/src/utils/constants.ts
+++ b/projects/burnr/src/utils/constants.ts
@@ -5,7 +5,7 @@ import { LazyProvider } from './types';
 
 /**
  * Temporary hard-coded work around to test Wasm Light client 
- * until @substrate/connect is properly implemented
+ * until \@substrate/connect is properly implemented
  */
 
 

--- a/projects/extension/.eslintrc.cjs
+++ b/projects/extension/.eslintrc.cjs
@@ -1,0 +1,13 @@
+module.exports = {
+  rules: {
+    "react/prop-types": 0,
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn"
+  },
+  plugins: [
+    "react-hooks"
+  ],
+  extends: [
+    "plugin:react/recommended"
+  ]
+};

--- a/projects/extension/package.json
+++ b/projects/extension/package.json
@@ -75,18 +75,5 @@
     "smoldot": "^0.2.5",
     "strict-event-emitter-types": "^2.0.0",
     "styled-components": "^5.2.1"
-  },
-  "eslintConfig": {
-    "rules": {
-      "react/prop-types": 0,
-      "react-hooks/rules-of-hooks": "error",
-      "react-hooks/exhaustive-deps": "warn"
-    },
-    "plugins": [
-      "react-hooks"
-    ],
-    "extends": [
-      "plugin:react/recommended"
-    ]
   }
 }

--- a/projects/extension/package.json
+++ b/projects/extension/package.json
@@ -77,40 +77,16 @@
     "styled-components": "^5.2.1"
   },
   "eslintConfig": {
-    "root": true,
     "rules": {
-      "@typescript-eslint/restrict-template-expressions": 0,
-      "tsdoc/syntax": "warn",
       "react/prop-types": 0,
       "react-hooks/rules-of-hooks": "error",
-      "react-hooks/exhaustive-deps": "warn",
-      "@typescript-eslint/no-var-requires": 0
-    },
-    "parser": "@typescript-eslint/parser",
-    "settings": {
-      "react": {
-        "version": "detect"
-      }
+      "react-hooks/exhaustive-deps": "warn"
     },
     "plugins": [
-      "@typescript-eslint",
-      "react-hooks",
-      "eslint-plugin-tsdoc"
+      "react-hooks"
     ],
-    "parserOptions": {
-      "project": [
-        "./tsconfig.json"
-      ],
-      "createDefaultProgram": true
-    },
     "extends": [
-      "eslint:recommended",
-      "plugin:@typescript-eslint/recommended",
-      "plugin:react/recommended",
-      "plugin:@typescript-eslint/recommended-requiring-type-checking"
-    ],
-    "env": {
-      "node": true
-    }
+      "plugin:react/recommended"
+    ]
   }
 }

--- a/projects/landing-page/.eslintignore
+++ b/projects/landing-page/.eslintignore
@@ -4,3 +4,5 @@ node_modules
 dist
 # don't lint .cache
 .cache
+# don't lint the config file
+.eslintrc.js

--- a/projects/landing-page/.eslintrc.js
+++ b/projects/landing-page/.eslintrc.js
@@ -1,0 +1,25 @@
+module.exports = {
+  plugins: [
+    "react-hooks"
+  ],
+  rules: {
+    "react/prop-types": 0,
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn",
+    "@typescript-eslint/no-misused-promises": [
+      "error",
+      {
+        "checksConditionals": false
+      }
+    ],
+    "@typescript-eslint/restrict-plus-operands": [
+      "error",
+      {
+        "checkCompoundAssignments": false
+      }
+    ]
+  },
+  extends: [
+    "plugin:react/recommended"
+  ]
+};

--- a/projects/landing-page/.eslintrc.js
+++ b/projects/landing-page/.eslintrc.js
@@ -5,19 +5,7 @@ module.exports = {
   rules: {
     "react/prop-types": 0,
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn",
-    "@typescript-eslint/no-misused-promises": [
-      "error",
-      {
-        "checksConditionals": false
-      }
-    ],
-    "@typescript-eslint/restrict-plus-operands": [
-      "error",
-      {
-        "checkCompoundAssignments": false
-      }
-    ]
+    "react-hooks/exhaustive-deps": "warn"
   },
   extends: [
     "plugin:react/recommended"

--- a/projects/landing-page/package.json
+++ b/projects/landing-page/package.json
@@ -58,30 +58,5 @@
     "ts-jest": "^26.5.1",
     "tsc-watch": "^4.2.9",
     "typescript": "^4.3.2"
-  },
-  "eslintConfig": {
-    "plugins": [
-      "react-hooks"
-    ],
-    "rules": {
-      "react/prop-types": 0,
-      "react-hooks/rules-of-hooks": "error",
-      "react-hooks/exhaustive-deps": "warn",
-      "@typescript-eslint/no-misused-promises": [
-        "error",
-        {
-          "checksConditionals": false
-        }
-      ],
-      "@typescript-eslint/restrict-plus-operands": [
-        "error",
-        {
-          "checkCompoundAssignments": false
-        }
-      ]
-    },
-    "extends": [
-      "plugin:react/recommended"
-    ]
   }
 }

--- a/projects/landing-page/package.json
+++ b/projects/landing-page/package.json
@@ -60,23 +60,9 @@
     "typescript": "^4.3.2"
   },
   "eslintConfig": {
-    "root": true,
-    "parser": "@typescript-eslint/parser",
-    "settings": {
-      "react": {
-        "version": "detect"
-      }
-    },
     "plugins": [
-      "@typescript-eslint",
       "react-hooks"
     ],
-    "parserOptions": {
-      "project": [
-        "./tsconfig.json"
-      ],
-      "createDefaultProgram": true
-    },
     "rules": {
       "react/prop-types": 0,
       "react-hooks/rules-of-hooks": "error",
@@ -92,25 +78,10 @@
         {
           "checkCompoundAssignments": false
         }
-      ],
-      "@typescript-eslint/restrict-template-expressions": [
-        "warn",
-        {
-          "allowNumber": true,
-          "allowBoolean": true,
-          "allowNullable": true,
-          "allowAny": true
-        }
       ]
     },
     "extends": [
-      "eslint:recommended",
-      "plugin:@typescript-eslint/recommended",
-      "plugin:react/recommended",
-      "plugin:@typescript-eslint/recommended-requiring-type-checking"
-    ],
-    "env": {
-      "node": true
-    }
+      "plugin:react/recommended"
+    ]
   }
 }

--- a/projects/multiple-network-demo/package.json
+++ b/projects/multiple-network-demo/package.json
@@ -35,31 +35,5 @@
   "dependencies": {
     "@substrate/connect": "^0.3.9",
     "regenerator-runtime": "^0.13.7"
-  },
-  "eslintConfig": {
-    "root": true,
-    "parser": "@typescript-eslint/parser",
-    "settings": {
-      "react": {
-        "version": "detect"
-      }
-    },
-    "plugins": [
-      "@typescript-eslint"
-    ],
-    "parserOptions": {
-      "project": [
-        "./tsconfig.json"
-      ],
-      "createDefaultProgram": true
-    },
-    "extends": [
-      "eslint:recommended",
-      "plugin:@typescript-eslint/recommended",
-      "plugin:@typescript-eslint/recommended-requiring-type-checking"
-    ],
-    "env": {
-      "node": true
-    }
   }
 }

--- a/projects/smoldot-browser-demo/package.json
+++ b/projects/smoldot-browser-demo/package.json
@@ -38,31 +38,5 @@
   "dependencies": {
     "@substrate/connect": "^0.3.9",
     "regenerator-runtime": "^0.13.7"
-  },
-  "eslintConfig": {
-    "root": true,
-    "parser": "@typescript-eslint/parser",
-    "settings": {
-      "react": {
-        "version": "detect"
-      }
-    },
-    "plugins": [
-      "@typescript-eslint"
-    ],
-    "parserOptions": {
-      "project": [
-        "./tsconfig.json"
-      ],
-      "createDefaultProgram": true
-    },
-    "extends": [
-      "eslint:recommended",
-      "plugin:@typescript-eslint/recommended",
-      "plugin:@typescript-eslint/recommended-requiring-type-checking"
-    ],
-    "env": {
-      "node": true
-    }
   }
 }


### PR DESCRIPTION
This PR fixes #293.  I have moved all the common eslint configuration into a root `.eslintrc.js`.  I favoured using a separate js file since it is easier to read when its not embedded in a `package.json` and we can use comments to explain why we configured / disabled rules if we want to.  Many of the projects no longer have any eslint config but those that do now have a minimal `.eslintrc.js` file specifying only the project-specific overrides.  I also removed the `no-misused-promises` rule as there were no errors and I moved the `restrict-plus-operands` rule config to the root.