### PR TITLE
Make eslint aware of dependent typescript projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "scripts": {
     "deep-clean": "yarn workspaces run deep-clean && rm -rf .parcel-cache && rm -rf node_modules",
     "clean": " yarn workspaces run clean",
-    "prelint": "yarn workspace @substrate/connect-extension-protocol run build",
     "lint": "yarn workspaces run lint",
     "build": "yarn workspaces run build",
     "test": "yarn workspaces run test",

--- a/packages/connect/.eslintignore
+++ b/packages/connect/.eslintignore
@@ -5,9 +5,6 @@ dist
 coverage
 # don't lint .cache
 .chains
-# don't lint examples and tests
-src/examples/**/*.ts
-src/**/*.test.ts
 
 downloadSpecs.js
 jest.*.ts

--- a/packages/connect/.eslintignore
+++ b/packages/connect/.eslintignore
@@ -8,3 +8,5 @@ coverage
 # don't lint examples and tests
 src/examples/**/*.ts
 src/**/*.test.ts
+
+downloadSpecs.js

--- a/packages/connect/.eslintignore
+++ b/packages/connect/.eslintignore
@@ -10,3 +10,4 @@ src/examples/**/*.ts
 src/**/*.test.ts
 
 downloadSpecs.js
+jest.*.ts

--- a/packages/connect/.eslintrc.cjs
+++ b/packages/connect/.eslintrc.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  parserOptions: {
+    project: [
+      "./tsconfig.json",
+      "../connect-extension-protocol/tsconfig.json"
+    ]
+  }
+};

--- a/packages/connect/.eslintrc.cjs
+++ b/packages/connect/.eslintrc.cjs
@@ -1,8 +1,26 @@
+// These options are here to force typescript-eslint to understand our project
+// references and solve the problem of the types for connect-extension-protocol
+// not being available when you try to lint this project before you have built
+// connect-extension-protocol.
+//
+// Project references are not officially supported yet:
+// https://github.com/typescript-eslint/typescript-eslint/issues/2094 
+//
+// Adding the tsconfigs for dependent projects into parserOptions.project is 
+// *supposed* to work but doesn't.
+//
+// Someone from the community found a way to make it work (with a performance
+// hit) with moderately sized mono repos and added the EXPERIMENTAL_ flag which
+// I use below:
+//
+// https://github.com/typescript-eslint/typescript-eslint/issues/2094#issuecomment-707270558
+// https://github.com/typescript-eslint/typescript-eslint/pull/2669/
 module.exports = {
   parserOptions: {
+    EXPERIMENTAL_useSourceOfProjectReferenceRedirect: true,
     project: [
-      "./tsconfig.json",
-      "../connect-extension-protocol/tsconfig.json"
+      "../connect-extension-protocol/tsconfig.json",
+      "./tsconfig.json"
     ]
   }
 };

--- a/packages/connect/src/Detector.test.ts
+++ b/packages/connect/src/Detector.test.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * @jest-environment jsdom
  */
 import { Detector } from './Detector';

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * @jest-environment jsdom
  */
 import {jest} from '@jest/globals'

--- a/packages/connect/tsconfig.eslint.json
+++ b/packages/connect/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./"
+  }
+}
+

--- a/projects/extension/.eslintignore
+++ b/projects/extension/.eslintignore
@@ -4,8 +4,7 @@ node_modules
 dist
 # don't lint .cache
 .cache
-src/**/*.test.ts
-src/mocks.ts
+
 jest-setup.js
 jest.config.ts
 webpack.*

--- a/projects/extension/.eslintignore
+++ b/projects/extension/.eslintignore
@@ -8,3 +8,5 @@ src/**/*.test.ts
 src/mocks.ts
 jest-setup.js
 jest.config.ts
+webpack.*
+downloadSpecs.js

--- a/projects/extension/.eslintrc.cjs
+++ b/projects/extension/.eslintrc.cjs
@@ -1,4 +1,12 @@
 module.exports = {
+  parserOptions: {
+    // See the connect .eslintrc.cjs for an explanation of this config
+    EXPERIMENTAL_useSourceOfProjectReferenceRedirect: true,
+    project: [
+      "../../packages/connect-extension-protocol/tsconfig.json",
+      "./tsconfig.json"
+    ]
+  },
   rules: {
     "react/prop-types": 0,
     "react-hooks/rules-of-hooks": "error",

--- a/projects/extension/tsconfig.json
+++ b/projects/extension/tsconfig.json
@@ -18,6 +18,7 @@
   },
   "include": [ "src/**/*", "public/assets/*.json" ],
   "references": [
-    { "path": "../../packages/connect-extension-protocol" }
+    { "path": "../../packages/connect-extension-protocol" },
+    { "path": "../../packages/smoldot-test-utils" }
   ]
 }

--- a/projects/extension/tsconfig.json
+++ b/projects/extension/tsconfig.json
@@ -16,5 +16,8 @@
     "allowSyntheticDefaultImports" : true,
     "esModuleInterop": true
   },
-  "include": [ "src/**/*", "public/assets/*.json" ]
+  "include": [ "src/**/*", "public/assets/*.json" ],
+  "references": [
+    { "path": "../../packages/connect-extension-protocol" }
+  ]
 }

--- a/projects/extension/webpack.config.js
+++ b/projects/extension/webpack.config.js
@@ -34,6 +34,7 @@ const config = {
         loader: "ts-loader",
         exclude: /node_modules/,
         options: {
+          projectReferences: true,
           transpileOnly: true
         }
       },


### PR DESCRIPTION
This PR configures eslint with new options to force typescript-eslint to understand our project references and solve the problem of the types for `connect-extension-protocol` not being available when you try to lint the `connect` or `extension` projects before you have built.

Project references are [not officially supported yet](https://github.com/typescript-eslint/typescript-eslint/issues/2094) by typescript-eslint. Adding the paths to the tsconfigs for dependent projects into `parserOptions.project` is [*supposed* to be a workaround](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/parser#parseroptionsproject). Unfortunately it doesn't.

Someone from the community found [a way to make it work](https://github.com/typescript-eslint/typescript-eslint/issues/2094#issuecomment-707270558) (with a performance hit) with moderately sized mono repos. They [added an EXPERIMENTAL_ option](https://github.com/typescript-eslint/typescript-eslint/pull/2669/) 

This PR adds the `parserOptions.project` config and the `EXPERIMENTAL_` config option to the `connect` and `extension` `.eslintrc.cjs` configs and linting works as expected even before anything has been built.

We also no longer need the `prelint` hack to build `connect-extension-protocol` before linting :smile:.

This PR fixes #249 by removing the last pain point outlined in the description.  See [my comment here](https://github.com/paritytech/substrate-connect/issues/249#issuecomment-863120132) for more detail. This PR also closes #264 - we can keep yarn now as all the problems should be resolved.

Doing this PR I realised I hadn't configured the extension properly with project references to `connect-extension-protocol` and `smoldot-test-utils`.  I fixed that.

Finally I enabled linting of the connect and extension tests.  Now the only ignored files are javascript helpers in the roots of packages and config files for tools.  This fixes #343 