### PR TITLE
Bump smoldot to match exactly v 0.2.6

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -39,7 +39,7 @@
     "eventemitter3": "^4.0.7",
     "file-entry-cache": "^6.0.1",
     "mkdirp": "^1.0.4",
-    "smoldot": "^0.2.6"
+    "smoldot": "0.2.6"
   },
   "devDependencies": {
     "@substrate/smoldot-test-utils": "file:../smoldot-test-utils",

--- a/packages/smoldot-test-utils/package.json
+++ b/packages/smoldot-test-utils/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint . --ext .js,.ts"
   },
   "dependencies": {
-    "smoldot": "^0.2.5"
+    "smoldot": "0.2.6"
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",

--- a/projects/extension/package.json
+++ b/projects/extension/package.json
@@ -72,7 +72,7 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-hot-loader": "^4.13.0",
-    "smoldot": "^0.2.5",
+    "smoldot": "0.2.6",
     "strict-event-emitter-types": "^2.0.0",
     "styled-components": "^5.2.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3166,7 +3166,7 @@
 "@substrate/smoldot-test-utils@file:packages/smoldot-test-utils":
   version "0.1.0"
   dependencies:
-    smoldot "^0.2.5"
+    smoldot "0.2.6"
 
 "@swc/helpers@^0.2.11":
   version "0.2.12"
@@ -14004,7 +14004,7 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
-smoldot@^0.2.5, smoldot@^0.2.6:
+smoldot@0.2.6:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/smoldot/-/smoldot-0.2.6.tgz#ecef568df76781bf5b8cbd2dcb302ec14562ede9"
   integrity sha512-zZRfHOg8dmO40kTX4dqqySZO3luNTRr7XpEkVmbvGsABzM1CMU5idXZhW4SWRt3J8ay/DhTw81PG2oAe+7MgEA==


### PR DESCRIPTION
It is needed to match Smoldot to exactly 0.2.6 for now - due to the issue that exists with smoldot debug build that creates the Javascript heap memory error (v 0.2.7 and 0.2.8).

This PR removes the caret (^) as if it is there then upon substrate-connect install latest minor or patch version (e.g. 0.2.8). This affects the  `apps` build and thus the progress of the integration of apps with Substrate connect light client.

Note: _A new version should be published in NPM once this PR is merged._