### PR TITLE
Disable jekyll in gh-pages and build before deploying

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -13,9 +13,6 @@ readonly -f die
 
 directory=_site
 branch=gh-pages
-build_command() {
-  jekyll build
-}
 
 initDirs() {
   rm -rf ./$directory/*
@@ -23,6 +20,7 @@ initDirs() {
   mkdir -p ./$directory/smoldot-browser-demo
   mkdir -p ./$directory/multiple-network-demo
   mkdir -p ./$directory/extension
+  touch ./$directory/.nojekyll
 }
 
 deployGhPages() {
@@ -49,7 +47,7 @@ echo -e "\033[0;32mChecking out $branch....\033[0m"
 git worktree add $directory -f $branch
 
 echo -e "\033[0;32mGenerating site...\033[0m"
-deployGhPages #build_command
+deployGhPages
 
 echo -e "\033[0;32mDeploying $branch branch...\033[0m"
 cd $directory &&

--- a/deploy.sh
+++ b/deploy.sh
@@ -46,6 +46,9 @@ rm -rf $directory
 echo -e "\033[0;32mChecking out $branch....\033[0m"
 git worktree add $directory -f $branch
 
+echo -e "\033[0;32mRebuilding everything...\033[0m"
+yarn build
+
 echo -e "\033[0;32mGenerating site...\033[0m"
 deployGhPages
 


### PR DESCRIPTION
If you don't disable jekyll it breaks the pages that with start with an underscore (which we have in the API docs).  We aren't using jekyll anyway.  I also removed the unused jekyll build function in the deploy script.

This PR also forces the deployment to do a fresh production build before deploying.  Commonly we are testing the demos and landing page using `yarn dev` before deploying to check everything is ok.  Without this, it is easy to accidentally deploy a debug build of the apps / landing page to gh-pages.  The landing page will not work with a debug build on gh-pages.