### PR TITLE
Minor enhancements on Send Funds

### DIFF
--- a/projects/burnr/src/components/BalanceValue.tsx
+++ b/projects/burnr/src/components/BalanceValue.tsx
@@ -3,11 +3,9 @@ import React from 'react';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import { Box, Typography } from '@material-ui/core';
 import { SizeScale } from '../utils/types';
-import { transformCurrency } from '../utils/utils';
+import { prettyBalance } from '../utils/utils';
 import { CSSProperties } from '@material-ui/core/styles/withStyles';
 import { Balance } from '@polkadot/types/interfaces';
-import { formatBalance } from '@polkadot/util';
-import useApi from '../hooks/api/useApi';
 
 interface Props extends SizeScale {
   value: Balance;
@@ -47,9 +45,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 const BalanceValue: React.FunctionComponent<Props> = ({ value, isVisible, unit = '', size, style }: Props) => {
-  const api = useApi();
-  const fBalance = formatBalance(value, { withSi: false });
-  const fUnit = transformCurrency(formatBalance.calcSi(value.toString(), api.registry.chainDecimals[0]).value, unit);
+  const fBalance = prettyBalance(value);
   const isColored = parseInt(fBalance) >= 0;
   const classes = useStyles({ colored: isColored, visible: isVisible });
 
@@ -58,7 +54,7 @@ const BalanceValue: React.FunctionComponent<Props> = ({ value, isVisible, unit =
   return  (
     <Box component='span' className={classes.root} style={style}>
       <Typography variant={TypographyVariant} className={classes.blur} >
-        {`${fBalance} ${fUnit}`}
+        {`${fBalance} ${unit}`}
       </Typography>
     </Box>
   );

--- a/projects/burnr/src/components/SendFundsForm.tsx
+++ b/projects/burnr/src/components/SendFundsForm.tsx
@@ -154,7 +154,7 @@ const SendFundsForm: FunctionComponent = () => {
           {fee ? `Receiver will get: ${prettyBalance(parseFloat(amount))} ${unit}` : ''}
         </Typography>
         <Typography variant='subtitle1'>
-          {fee ? `Fees: ${fee?.toHuman()}` : ''}
+          {fee ? `Fees: ${prettyBalance(fee)} ${unit}` : ''}
         </Typography>
         <Typography variant='subtitle1'>
         </Typography>

--- a/projects/burnr/src/components/SendFundsForm.tsx
+++ b/projects/burnr/src/components/SendFundsForm.tsx
@@ -151,7 +151,7 @@ const SendFundsForm: FunctionComponent = () => {
       />
       <Grid item xs={12}>
         <Typography variant='subtitle1'>
-          {fee ? `Receiver will get: ${prettyBalance(parseFloat(amount))} ${unit}` : ''}
+          {fee ? `Balance after transaction: ${prettyBalance((new BN(maxAmountFull)).sub(new BN(amount)).sub(fee))} ${unit}` : ''}
         </Typography>
         <Typography variant='subtitle1'>
           {fee ? `Fees: ${prettyBalance(fee)} ${unit}` : ''}


### PR DESCRIPTION
Following enhancements took place:
- Alter formatting of values (remove unit prefixes) to use base unit.
- Alter message during transaction from "Receiver will get" to "Balance after transaction"

Fixes #374