### PR TITLE
Update SmoldotProvider and respective tests to support smoldot v3

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -39,7 +39,7 @@
     "eventemitter3": "^4.0.7",
     "file-entry-cache": "^6.0.1",
     "mkdirp": "^1.0.4",
-    "smoldot": "0.3.1"
+    "smoldot": "0.3.2"
   },
   "devDependencies": {
     "@substrate/smoldot-test-utils": "^0.1.0",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -39,7 +39,7 @@
     "eventemitter3": "^4.0.7",
     "file-entry-cache": "^6.0.1",
     "mkdirp": "^1.0.4",
-    "smoldot": "0.2.9"
+    "smoldot": "0.3.1"
   },
   "devDependencies": {
     "@substrate/smoldot-test-utils": "^0.1.0",

--- a/packages/connect/src/SmoldotProvider/SmoldotProvider.test.ts
+++ b/packages/connect/src/SmoldotProvider/SmoldotProvider.test.ts
@@ -158,9 +158,9 @@ test('emits events when Grandpa finishes sync and then connects', async () => {
 test('send formats JSON RPC request correctly', async () => {
   // we don't really care what the reponse is
   const responses =  ['{ "id": 1, "jsonrpc": "2.0", "result": "success" }'];
-  const rpcSend = jest.fn() as jest.MockedFunction<(rpc: string) => void>;
+  const rpcSend = jest.fn() as unknown as jest.MockedFunction<(rpc: string) => void>;
   const ss = smoldotSpy(respondWith(responses), rpcSend);
-  const provider = new SmoldotProvider(JSON.stringify(EMPTY_CHAIN_SPEC), ss);
+  const provider = new SmoldotProvider(EMPTY_CHAIN_SPEC, ss);
 
   await provider.connect();
   await provider.send('hello', [ 'world' ]);
@@ -173,9 +173,9 @@ test('sending twice uses new id', async () => {
     '{ "id": 1, "jsonrpc": "2.0", "result": "success" }',
     '{ "id": 2, "jsonrpc": "2.0", "result": "success" }'
   ];
-  const rpcSend = jest.fn() as jest.MockedFunction<(rpc: string) => void>;
+  const rpcSend = jest.fn() as unknown as jest.MockedFunction<(rpc: string) => void>;
   const ss = smoldotSpy(respondWith(responses), rpcSend);
-  const provider = new SmoldotProvider(JSON.stringify(EMPTY_CHAIN_SPEC), ss);
+  const provider = new SmoldotProvider(EMPTY_CHAIN_SPEC, ss);
 
   await provider.connect();
   await provider.send('hello', [ 'world' ]);

--- a/packages/connect/src/SmoldotProvider/SmoldotProvider.test.ts
+++ b/packages/connect/src/SmoldotProvider/SmoldotProvider.test.ts
@@ -158,7 +158,7 @@ test('emits events when Grandpa finishes sync and then connects', async () => {
 test('send formats JSON RPC request correctly', async () => {
   // we don't really care what the reponse is
   const responses =  ['{ "id": 1, "jsonrpc": "2.0", "result": "success" }'];
-  const rpcSend = jest.fn() as unknown as jest.MockedFunction<(rpc: string) => void>;
+  const rpcSend = jest.fn() as jest.MockedFunction<(rpc: string) => void>;
   const ss = smoldotSpy(respondWith(responses), rpcSend);
   const provider = new SmoldotProvider(EMPTY_CHAIN_SPEC, ss);
 
@@ -173,7 +173,7 @@ test('sending twice uses new id', async () => {
     '{ "id": 1, "jsonrpc": "2.0", "result": "success" }',
     '{ "id": 2, "jsonrpc": "2.0", "result": "success" }'
   ];
-  const rpcSend = jest.fn() as unknown as jest.MockedFunction<(rpc: string) => void>;
+  const rpcSend = jest.fn() as jest.MockedFunction<(rpc: string) => void>;
   const ss = smoldotSpy(respondWith(responses), rpcSend);
   const provider = new SmoldotProvider(EMPTY_CHAIN_SPEC, ss);
 

--- a/packages/connect/src/SmoldotProvider/SmoldotProvider.test.ts
+++ b/packages/connect/src/SmoldotProvider/SmoldotProvider.test.ts
@@ -158,13 +158,13 @@ test('emits events when Grandpa finishes sync and then connects', async () => {
 test('send formats JSON RPC request correctly', async () => {
   // we don't really care what the reponse is
   const responses =  ['{ "id": 1, "jsonrpc": "2.0", "result": "success" }'];
-  const rpcSend = jest.fn() as jest.MockedFunction<(rpc: string, chainIndex: number) => void>;
+  const rpcSend = jest.fn() as jest.MockedFunction<(rpc: string) => void>;
   const ss = smoldotSpy(respondWith(responses), rpcSend);
-  const provider = new SmoldotProvider(EMPTY_CHAIN_SPEC, ss);
+  const provider = new SmoldotProvider(JSON.stringify(EMPTY_CHAIN_SPEC), ss);
 
   await provider.connect();
   await provider.send('hello', [ 'world' ]);
-  expect(rpcSend).toHaveBeenCalledWith('{"id":1,"jsonrpc":"2.0","method":"hello","params":["world"]}', 0);
+  expect(rpcSend).toHaveBeenCalledWith('{"id":1,"jsonrpc":"2.0","method":"hello","params":["world"]}');
   await provider.disconnect();
 });
 
@@ -173,9 +173,9 @@ test('sending twice uses new id', async () => {
     '{ "id": 1, "jsonrpc": "2.0", "result": "success" }',
     '{ "id": 2, "jsonrpc": "2.0", "result": "success" }'
   ];
-  const rpcSend = jest.fn() as jest.MockedFunction<(rpc: string, chainIndex: number) => void>;
+  const rpcSend = jest.fn() as jest.MockedFunction<(rpc: string) => void>;
   const ss = smoldotSpy(respondWith(responses), rpcSend);
-  const provider = new SmoldotProvider(EMPTY_CHAIN_SPEC, ss);
+  const provider = new SmoldotProvider(JSON.stringify(EMPTY_CHAIN_SPEC), ss);
 
   await provider.connect();
   await provider.send('hello', [ 'world' ]);

--- a/packages/connect/src/SmoldotProvider/SmoldotProvider.ts
+++ b/packages/connect/src/SmoldotProvider/SmoldotProvider.ts
@@ -265,7 +265,7 @@ export class SmoldotProvider implements ProviderInterface {
         chainSpec: this.#chainSpec,
         jsonRpcCallback: (response: string) => {
           this.#handleRpcReponse(response);
-        },
+        }
       });
       this.#connectionStatePingerId = setInterval(
       this.#checkClientPeercount, this.healthPingerInterval);

--- a/packages/smoldot-test-utils/package.json
+++ b/packages/smoldot-test-utils/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "asap": "^2.0.6",
-    "smoldot": "0.2.9"
+    "smoldot": "0.3.1"
   },
   "devDependencies": {
     "@types/asap": "^2.0.0",

--- a/packages/smoldot-test-utils/src/index.ts
+++ b/packages/smoldot-test-utils/src/index.ts
@@ -1,4 +1,8 @@
-import { Smoldot, SmoldotAddChainOptions, SmoldotChain, SmoldotClient, SmoldotJsonRpcCallback } from 'smoldot';
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+// REMOVE LINES ABOVE once smoldot is upgraded to v3.
+
+import { Smoldot, SmoldotAddChainOptions, SmoldotChain, SmoldotClient, SmoldotJsonRpcCallback, SmoldotLogCallback } from 'smoldot';
 import { JsonRpcObject } from '@polkadot/rpc-provider/types';
 import { jest } from '@jest/globals'
 import asap from 'asap';
@@ -253,3 +257,70 @@ export const smoldotSpy = (responder: RpcResponder, rpcSpy: jest.MockedFunction<
     }
   };
 };
+
+
+/**
+ * NOTE: All functions from this point forward are temporary 
+ * and meant only to support the running tests of smoldot version 2
+ * Should be removed once Smoldot is updated to version 3 
+ */
+ export interface SmoldotOptionsTmp {
+  maxLogLevel?: number;
+  chainSpecs: string[];
+  jsonRpcCallback?: SmoldotJsonRpcCallbackTmp;
+  logCallback?: SmoldotLogCallback;
+  forbidTcp?: boolean;
+  forbidWs?: boolean;
+  forbidWss?: boolean;
+}
+
+export interface SmoldotClientTmp {
+  sendJsonRpc(rpc: string, chainIndex: number, userData?: number): void;
+  cancelAll(userData: number): void;
+  terminate(): void;
+}
+
+export type SmoldotJsonRpcCallbackTmp = (response: string, chainIndex: number, userData?: number) => void;
+
+export interface SmoldotTmp {
+  start(options: SmoldotOptionsTmp): Promise<SmoldotClientTmp>;
+}
+
+export const smoldotSpyTemp = (responder: RpcResponder, rpcSpy: jest.MockedFunction<(rpc: string, chainIndex: number) => void>, healthResponder = healthyResponder): SmoldotTmp => {
+  return {
+    start: async (options: SmoldotOptionsTmp): Promise<SmoldotClientTmp> => {
+      const processRequest = createRequestProcessorTmp(options, responder, healthResponder);
+      return Promise.resolve({
+        terminate: doNothing,
+        sendJsonRpc: (rpc: string, chainIndex: number) => {
+          rpcSpy(rpc, chainIndex);
+          processRequest(rpc, chainIndex);
+        },
+        cancelAll: doNothing
+      });
+    }
+  };
+};
+
+const createRequestProcessorTmp = (options: SmoldotOptionsTmp, responder: RpcResponder, healthResponder: RpcResponder) => {
+  return (rpcRequest: string, chainIndex: number) => {
+      asap(() => {
+      if (options && options.jsonRpcCallback) {
+        if (/system_health/.test(rpcRequest)) {
+          options.jsonRpcCallback(healthResponder(rpcRequest), chainIndex);
+          return;
+        }
+
+        // non-health reponse
+        options.jsonRpcCallback(responder(rpcRequest), chainIndex)
+        if (/(?<!un)[sS]ubscribe/.test(rpcRequest)) {
+          // FIXME: by convention it is assumed the responder has a queue of
+          // responses setup so that a subscription response is immediately
+          // followed by a single subscription message.  Subscriptions mocking
+          // should be more flexible than this.
+          options.jsonRpcCallback(responder(rpcRequest), chainIndex)
+        }
+      }
+    });
+  };
+}

--- a/projects/extension/package.json
+++ b/projects/extension/package.json
@@ -74,7 +74,7 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-hot-loader": "^4.13.0",
-    "smoldot": "0.3.1",
+    "smoldot": "0.2.10",
     "strict-event-emitter-types": "^2.0.0",
     "styled-components": "^5.2.1"
   }

--- a/projects/extension/package.json
+++ b/projects/extension/package.json
@@ -74,7 +74,7 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-hot-loader": "^4.13.0",
-    "smoldot": "0.2.9",
+    "smoldot": "0.3.1",
     "strict-event-emitter-types": "^2.0.0",
     "styled-components": "^5.2.1"
   }

--- a/projects/extension/src/background/SmoldotMediator.test.ts
+++ b/projects/extension/src/background/SmoldotMediator.test.ts
@@ -1,7 +1,7 @@
 import { jest } from '@jest/globals';
 import { SmoldotClient} from 'smoldot';
 import {
-  smoldotSpy,
+  smoldotSpyTemp,
   respondWith
 } from '@substrate/smoldot-test-utils';
 import { SmoldotMediator } from './SmoldotMediator';
@@ -32,7 +32,7 @@ beforeEach(async () => {
     '{ "id": 3, "jsonrpc": "2.0", "result": "success" }'
   ];
   const rpcSend = jest.fn() as jest.MockedFunction<(rpc: string, chainIndex: number) => void>;
-  sc = await smoldotSpy(respondWith(responses), rpcSend).start({
+  sc = await smoldotSpyTemp(respondWith(responses), rpcSend).start({
     chainSpecs: [JSON.stringify(westend)],
     maxLogLevel: 3,
     jsonRpcCallback: (message: string) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13252,6 +13252,16 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
+smoldot@0.2.10:
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/smoldot/-/smoldot-0.2.10.tgz#1be9851415882a870ce0fb1ff0f160ad4812c366"
+  integrity sha512-sCxxISLczT6nH7GHc62k9YHF9nc7xuQNAP7f0gt5nALd0tNac73QIk4kZHE2lU8oBMUxoqwVthYj20wj/k90Fw==
+  dependencies:
+    buffer "^6.0.1"
+    performance-now "^2.1.0"
+    randombytes "^2.1.0"
+    websocket "^1.0.32"
+
 smoldot@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/smoldot/-/smoldot-0.3.1.tgz#fbf135db18e0723e8b3e7f94ef9974bd82c7a0a0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13252,10 +13252,10 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
-smoldot@0.2.9:
-  version "0.2.9"
-  resolved "https://registry.yarnpkg.com/smoldot/-/smoldot-0.2.9.tgz#65210558cca9324c76ac4394a5cf03f78953cf9b"
-  integrity sha512-+17jPzeENTQ0RyU+7SRmTyypYtrteLZ7B1byQWFLSaBfQMBkoAaFIEsA4dxPpwHfgIJWg2a4vjWnBvSXrcA9rQ==
+smoldot@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/smoldot/-/smoldot-0.3.1.tgz#fbf135db18e0723e8b3e7f94ef9974bd82c7a0a0"
+  integrity sha512-Uq5n0fS9lq3LDsbFlnvFd7ujC6TzEn0jtcInpuIijQznY0s8tfED65Z8BSHGfMJh+AC4oKAB1eIE0BJYRJBo8Q==
   dependencies:
     buffer "^6.0.1"
     performance-now "^2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13272,6 +13272,16 @@ smoldot@0.3.1:
     randombytes "^2.1.0"
     websocket "^1.0.32"
 
+smoldot@0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/smoldot/-/smoldot-0.3.2.tgz#41ec04e1fd7ee39f660a14019acfe6ca09dfeea2"
+  integrity sha512-taydQhlmlYOr9f8ezikbTrVuNxEQ8PTPJQbLpfVmQOu9h0KE0t7u7KFAunAoCP7lrNe/vclIEATauMONJID8RQ==
+  dependencies:
+    buffer "^6.0.1"
+    performance-now "^2.1.0"
+    randombytes "^2.1.0"
+    websocket "^1.0.32"
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"


### PR DESCRIPTION
- Bump version of smoldot to v3.1
- Update SmoldotProvider to new API; 
- Update smoldotTestUtilScripts;

(Tests fail on SmoldotMediator - for now opening a draft PR)