### PR TITLE
Split detector to Connect and Provider functions

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@substrate/connect",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "Substrate-connect to Smoldot clients. Using either substrate extension with predefined clients or an internal smoldot client based on chainSpecs provided.",
   "author": "Parity Team <admin@parity.io>",
   "license": "GPL-3.0-only",

--- a/packages/connect/src/Detector.ts
+++ b/packages/connect/src/Detector.ts
@@ -22,8 +22,8 @@ import polkadot from './specs/polkadot.json';
  *
  * // Create a new UApp with a unique name
  * const app = new Detector('burnr-wallet');
- * const westend = await app.detect('westend');
- * const kusama = await app.detect('kusama');
+ * const westend = await app.connect('westend');
+ * const kusama = await app.connect('kusama');
  *
  * await westend.rpc.chain.subscribeNewHeads((lastHeader) => {
  *   console.log(lastHeader.hash);
@@ -107,15 +107,17 @@ export class Detector {
     return await ApiPromise.create(Object.assign(options ?? {}, {provider}));
   }
 
-  /**
-   * creates and returns a provider (either Smoldot or Extension one) to be used
-   * in PolkadotJS API instance
+  /** 
+   * Detects and returns an appropriate PolkadotJS provider depending on whether the user has the substrate connect extension installed
    * 
    * @param chainName - the name of the blockchain network to connect to
    * @param chainSpec - an optional chainSpec to connect to a different network
    * @returns a provider will be used in a ApiPromise create for PolkadotJS API
    *
    * @internal
+   * 
+   * @remarks 
+   * This is used internally for advanced PolkadotJS use cases and is not supported.  Use {@link connect} instead.
    */
   public provider = (chainName: string, chainSpec?: string): ExtensionProvider | SmoldotProvider => {
     let provider: ExtensionProvider | SmoldotProvider = {} as ExtensionProvider | SmoldotProvider;

--- a/packages/connect/src/Detector.ts
+++ b/packages/connect/src/Detector.ts
@@ -100,6 +100,24 @@ export class Detector {
    * {@link https://polkadot.js.org/docs/}
    */
   public connect = async (chainName: string, chainSpec?: string, options?: ApiOptions): Promise<ApiPromise> => {
+    const provider: ExtensionProvider | SmoldotProvider = this.provider(chainName, chainSpec);
+    provider.connect().catch(console.error);
+
+    this.#providers[chainName] = provider as ProviderInterface;
+    return await ApiPromise.create(Object.assign(options ?? {}, {provider}));
+  }
+
+  /**
+   * creates and returns a provider (either Smoldot or Extension one) to be used
+   * in PolkadotJS API instance
+   * 
+   * @param chainName - the name of the blockchain network to connect to
+   * @param chainSpec - an optional chainSpec to connect to a different network
+   * @returns a provider will be used in a ApiPromise create for PolkadotJS API
+   *
+   * @internal
+   */
+  public provider = (chainName: string, chainSpec?: string): ExtensionProvider | SmoldotProvider => {
     let provider: ExtensionProvider | SmoldotProvider = {} as ExtensionProvider | SmoldotProvider;
 
     if (Object.keys(this.#chainSpecs).includes(chainName)) {
@@ -114,10 +132,7 @@ export class Detector {
     } else if (!chainSpec) {
       throw new Error(`No known Chain was detected and no chainSpec was provided. Either give a known chain name ('${Object.keys(this.#chainSpecs).join('\', \'')}') or provide valid chainSpecs.`)
     }
-    await provider.connect();
-
-    this.#providers[chainName] = provider as ProviderInterface;
-    return await ApiPromise.create(Object.assign(options ?? {}, {provider}));
+    return provider;
   }
 
   /**

--- a/projects/burnr/package.json
+++ b/projects/burnr/package.json
@@ -34,7 +34,7 @@
     "@polkadot/react-identicon": "^0.68.1",
     "@polkadot/util": "^5.5.2",
     "@polkadot/util-crypto": "^5.5.2",
-    "@substrate/connect": "^0.3.11",
+    "@substrate/connect": "^0.3.12",
     "qrcode.react": "^1.0.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/projects/landing-page/src/App.tsx
+++ b/projects/landing-page/src/App.tsx
@@ -101,8 +101,8 @@ const App: React.FunctionComponent = () => {
 
                 <Box mt={2}>{`// Create a new UApp with a unique name`}</Box>
                 <Box>{`const app = new Detector('burnr-wallet');`}</Box>
-                <Box>{`const westend = await app.detect('westend');`}</Box>
-                <Box>{`const kusama = await app.detect('kusama');`}</Box>
+                <Box>{`const westend = await app.connect('westend');`}</Box>
+                <Box>{`const kusama = await app.connect('kusama');`}</Box>
 
                 <Box mt={2}>{`await westend.rpc.chain.subscribeNewHeads((lastHeader) => {`}</Box>
                 <Box pl={3}>{`console.log(lastHeader.hash);`}</Box>

--- a/projects/multiple-network-demo/package.json
+++ b/projects/multiple-network-demo/package.json
@@ -32,7 +32,7 @@
     "typescript": "^4.3.2"
   },
   "dependencies": {
-    "@substrate/connect": "^0.3.11",
+    "@substrate/connect": "^0.3.12",
     "regenerator-runtime": "^0.13.7"
   }
 }

--- a/projects/smoldot-browser-demo/package.json
+++ b/projects/smoldot-browser-demo/package.json
@@ -35,7 +35,7 @@
     "typescript": "^4.3.2"
   },
   "dependencies": {
-    "@substrate/connect": "^0.3.11",
+    "@substrate/connect": "^0.3.12",
     "regenerator-runtime": "^0.13.7"
   }
 }


### PR DESCRIPTION
This PR splits the .connect() function to 2. One provider() function that detects and returns the detected Provider (SmoldotProvider or ExtensionProvider) and a simplified connect() that is using the latter for the functionality that was already implementing.

Reason of this split is having the provider() function for advanced usage (e.g. PolkadotJS) and for internal use.