### PR TITLE
Fix issue with extensions .js that was breaking ts-jest

### DIFF
--- a/packages/connect/extension-resolver.cjs
+++ b/packages/connect/extension-resolver.cjs
@@ -1,0 +1,28 @@
+let defaultResolver;
+
+function requireDefaultResolver() {
+  if (!defaultResolver) {
+    try {
+      defaultResolver = import (`jest-resolve/build/defaultResolver`);
+    } catch (error) {
+      defaultResolver = import (`jest-resolve/build/default_resolver`);
+    }
+  }
+
+  return defaultResolver;
+}
+
+
+module.exports = (request, options) => {
+  const {basedir, defaultResolver, extensions} = options;
+
+  if (!defaultResolver) {
+    defaultResolver = requireDefaultResolver();
+  }
+
+  try {
+    return defaultResolver(request, options);
+  } catch (e) {
+    return defaultResolver(request.replace(/\.js$/, '.ts'), options);
+  }
+}

--- a/packages/connect/extension-resolver.cjs
+++ b/packages/connect/extension-resolver.cjs
@@ -1,3 +1,7 @@
+// This code was adapted from https://github.com/AyogoHealth/jest-ts-webcompat-resolver
+// Original code was MIT Licensed: https://opensource.org/licenses/MIT
+// Original author: Darryl Pogue <darryl@dpogue.ca>
+// Original copyright 2019 Ayogo Health Inc.
 let defaultResolver;
 
 function requireDefaultResolver() {

--- a/packages/connect/extension-resolver.cjs
+++ b/packages/connect/extension-resolver.cjs
@@ -1,17 +1,8 @@
 let defaultResolver;
 
 function requireDefaultResolver() {
-  if (!defaultResolver) {
-    try {
-      defaultResolver = import (`jest-resolve/build/defaultResolver`);
-    } catch (error) {
-      defaultResolver = import (`jest-resolve/build/default_resolver`);
-    }
-  }
-
-  return defaultResolver;
+  return import (`jest-resolve/build/defaultResolver`);
 }
-
 
 module.exports = (request, options) => {
   const {basedir, defaultResolver, extensions} = options;
@@ -22,8 +13,21 @@ module.exports = (request, options) => {
 
   try {
     return defaultResolver(request, options);
-  } catch (e) {
-    console.log(`${e} - Temporary replace extension '.js' to '.ts' for tests to run.\n`)
-    return defaultResolver(request.replace(/\.js$/, '.ts'), options);
+  } catch (err) {
+    if (
+      // We should not try to fix issues of other packages
+      !err.message.includes('node_modules') &&
+      request.endsWith('.js') && // make sure that the file ends with .js
+      err.code === 'MODULE_NOT_FOUND' // make sure error code is specific
+    ) {
+      try {
+        console.log(`Temporary replace extension '.js' to '.ts' for tests to run.\n`)
+        return defaultResolver(request.replace(/\.js$/, '.ts'), options);  
+      } catch (e) {
+        console.error(`Errored resolving a module after replacing js extension with ts.${err.message}\n`);
+        console.error(`${e}`);
+      }
+    }
+    throw e;
   }
 }

--- a/packages/connect/extension-resolver.cjs
+++ b/packages/connect/extension-resolver.cjs
@@ -23,6 +23,8 @@ module.exports = (request, options) => {
   try {
     return defaultResolver(request, options);
   } catch (e) {
+    console.error(e);
+    console.info(`Try to resolve extension '.js' to '.ts' for tests to run.`)
     return defaultResolver(request.replace(/\.js$/, '.ts'), options);
   }
 }

--- a/packages/connect/extension-resolver.cjs
+++ b/packages/connect/extension-resolver.cjs
@@ -23,8 +23,7 @@ module.exports = (request, options) => {
   try {
     return defaultResolver(request, options);
   } catch (e) {
-    console.error(e);
-    console.info(`Try to resolve extension '.js' to '.ts' for tests to run.`)
+    console.log(`${e} - Temporary replace extension '.js' to '.ts' for tests to run.\n`)
     return defaultResolver(request.replace(/\.js$/, '.ts'), options);
   }
 }

--- a/packages/connect/jest.config.ts
+++ b/packages/connect/jest.config.ts
@@ -3,7 +3,7 @@ import type {Config} from '@jest/types';
 const config: Config.InitialOptions = {
   coverageReporters: ["text-summary"],
   reporters: ["jest-silent-reporter"],
-  resolver: "jest-ts-webcompat-resolver",
+  resolver: "./extension-resolver.cjs",
   roots: ['<rootDir>/src'],
   verbose: true,
   transformIgnorePatterns:["./src/__mocks__/client.js"],

--- a/packages/connect/jest.config.ts
+++ b/packages/connect/jest.config.ts
@@ -3,6 +3,7 @@ import type {Config} from '@jest/types';
 const config: Config.InitialOptions = {
   coverageReporters: ["text-summary"],
   reporters: ["jest-silent-reporter"],
+  resolver: "jest-ts-webcompat-resolver",
   roots: ['<rootDir>/src'],
   verbose: true,
   transformIgnorePatterns:["./src/__mocks__/client.js"],

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -51,7 +51,6 @@
     "eslint-plugin-tsdoc": "^0.2.14",
     "jest": "^27.0.5",
     "jest-silent-reporter": "^0.5.0",
-    "jest-ts-webcompat-resolver": "^1.0.0",
     "jsdom": "^16.5.1",
     "ts-jest": "^27.0.3",
     "ts-node": "^9.1.1",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@substrate/connect",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Substrate-connect to Smoldot clients. Using either substrate extension with predefined clients or an internal smoldot client based on chainSpecs provided.",
   "author": "Parity Team <admin@parity.io>",
   "license": "GPL-3.0-only",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -51,6 +51,7 @@
     "eslint-plugin-tsdoc": "^0.2.14",
     "jest": "^27.0.5",
     "jest-silent-reporter": "^0.5.0",
+    "jest-ts-webcompat-resolver": "^1.0.0",
     "jsdom": "^16.5.1",
     "ts-jest": "^27.0.3",
     "ts-node": "^9.1.1",

--- a/packages/connect/src/Detector.ts
+++ b/packages/connect/src/Detector.ts
@@ -1,8 +1,8 @@
 import { ApiPromise } from '@polkadot/api';
 import { ApiOptions } from '@polkadot/api/types';
 import { ProviderInterface } from '@polkadot/rpc-provider/types';
-import { SmoldotProvider }  from './SmoldotProvider/SmoldotProvider';
-import { ExtensionProvider } from './ExtensionProvider/ExtensionProvider';
+import { SmoldotProvider }  from './SmoldotProvider/SmoldotProvider.js';
+import { ExtensionProvider } from './ExtensionProvider/ExtensionProvider.js';
 import westend from './specs/westend.json';
 import kusama from './specs/kusama.json';
 import polkadot from './specs/polkadot.json';

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
@@ -8,7 +8,7 @@ import {
 } from '@polkadot/rpc-provider/types';
 import { logger } from '@polkadot/util';
 import EventEmitter from 'eventemitter3';
-import { isUndefined } from '../utils/index';
+import { isUndefined } from '../utils/index.js';
 import {
   MessageFromManager,
   ProviderMessageData,

--- a/packages/connect/src/ExtensionProvider/index.ts
+++ b/packages/connect/src/ExtensionProvider/index.ts
@@ -2,6 +2,6 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import {ExtensionProvider} from './ExtensionProvider';
+import {ExtensionProvider} from './ExtensionProvider.js';
 
 export { ExtensionProvider };

--- a/packages/connect/src/SmoldotProvider/SmoldotProvider.ts
+++ b/packages/connect/src/SmoldotProvider/SmoldotProvider.ts
@@ -9,8 +9,8 @@ import {
 import { assert, logger } from '@polkadot/util';
 import EventEmitter from 'eventemitter3';
 import * as smoldot from 'smoldot';
-import { HealthCheckError } from './errors';
-import { isUndefined } from '../utils/index';
+import { HealthCheckError } from './errors.js';
+import { isUndefined } from '../utils/index.js';
 
 const l = logger('smoldot-provider');
 

--- a/packages/connect/src/SmoldotProvider/index.ts
+++ b/packages/connect/src/SmoldotProvider/index.ts
@@ -2,6 +2,6 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { SmoldotProvider } from './SmoldotProvider';
+import { SmoldotProvider } from './SmoldotProvider.js';
 
 export { SmoldotProvider };

--- a/projects/burnr/package.json
+++ b/projects/burnr/package.json
@@ -34,7 +34,7 @@
     "@polkadot/react-identicon": "^0.68.1",
     "@polkadot/util": "^5.5.2",
     "@polkadot/util-crypto": "^5.5.2",
-    "@substrate/connect": "^0.3.12",
+    "@substrate/connect": "^0.3.13",
     "qrcode.react": "^1.0.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/projects/multiple-network-demo/package.json
+++ b/projects/multiple-network-demo/package.json
@@ -32,7 +32,7 @@
     "typescript": "^4.3.2"
   },
   "dependencies": {
-    "@substrate/connect": "^0.3.12",
+    "@substrate/connect": "^0.3.13",
     "regenerator-runtime": "^0.13.7"
   }
 }

--- a/projects/smoldot-browser-demo/package.json
+++ b/projects/smoldot-browser-demo/package.json
@@ -35,7 +35,7 @@
     "typescript": "^4.3.2"
   },
   "dependencies": {
-    "@substrate/connect": "^0.3.12",
+    "@substrate/connect": "^0.3.13",
     "regenerator-runtime": "^0.13.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9390,6 +9390,11 @@ jest-styled-components@^7.0.3:
   dependencies:
     css "^2.2.4"
 
+jest-ts-webcompat-resolver@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/jest-ts-webcompat-resolver/-/jest-ts-webcompat-resolver-1.0.0.tgz#a554eb77446e1a8d2aabb810d6302bffaa00095c"
+  integrity sha512-BFoaU7LeYqZNnTYEr6iMRf87xdCQntNc/Wk8YpzDBcuz+CIZ0JsTtzuMAMnKiEgTRTC1wRWLUo2RlVjVijBcHQ==
+
 jest-util@^26.0.0, jest-util@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.6.2.tgz#907535dbe4d5a6cb4c47ac9b926f6af29576cbc1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9390,11 +9390,6 @@ jest-styled-components@^7.0.3:
   dependencies:
     css "^2.2.4"
 
-jest-ts-webcompat-resolver@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/jest-ts-webcompat-resolver/-/jest-ts-webcompat-resolver-1.0.0.tgz#a554eb77446e1a8d2aabb810d6302bffaa00095c"
-  integrity sha512-BFoaU7LeYqZNnTYEr6iMRf87xdCQntNc/Wk8YpzDBcuz+CIZ0JsTtzuMAMnKiEgTRTC1wRWLUo2RlVjVijBcHQ==
-
 jest-util@^26.0.0, jest-util@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.6.2.tgz#907535dbe4d5a6cb4c47ac9b926f6af29576cbc1"


### PR DESCRIPTION
Added an extension-resolver for jest that does exactly what we are searching for: finding .js extensions and replacing them temporary with .ts for ts-jest to run.