### PR TITLE
Exclude node modules and parcel cache from tsconfig

### DIFF
--- a/packages/connect/tsconfig.json
+++ b/packages/connect/tsconfig.json
@@ -14,7 +14,7 @@
     "module": "ES2020"
   },
   "exclude": ["jest.config*", "tsconfig*"],
-  "include": [ "src/**/*", "src/**/*.json" ],
+  "include": [ "src/**/*", "src/**/*.json", ".parcel*", "*node_modules*"],
   "references": [
     { "path": "../smoldot-test-utils" },
     { "path": "../connect-extension-protocol" }


### PR DESCRIPTION
In this PR I am adding the .parcel-cache and node_modules in exclusion of base tsconfig (connect package).
With the latest changes that took place, now all packages/projects, correctly includes the base tsconfig from connect package in order to have the reference of projects across.
The huge load of files (especially in .parcel and node_modules) though in each project, now makes the VSCode linter to break.
More specifically:
```
$. du -a | cut -d/ -f2 | sort | uniq -c | sort -nr
  93997 node_modules <---
  16582 .parcel-cache   <---
   4660 .git
   2010 projects
    251 packages
     13 coverage
```
As soon as these dirs are not App specifics they should be excluded in tsconfig.