### PR TITLE
Extension Refactor - remove request and subscription tracking

### DIFF
--- a/projects/extension/src/background/AppMediator.test.ts
+++ b/projects/extension/src/background/AppMediator.test.ts
@@ -1,224 +1,69 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import { jest } from '@jest/globals';
+/* eslint-disable @typescript-eslint/unbound-method */
 import { AppMediator } from './AppMediator';
+import { SmoldotChain } from 'smoldot';
 import { MockPort, MockConnectionManager } from '../mocks';
-import { JsonRpcResponse } from './types';
 
-function setupAppMediatorWithSubscription(
-  am: AppMediator,
-  port: MockPort,
-  appIDForRequest: number,
-  subID: number,
-  spyPortPostMessage: unknown) {
-  const prevRequestCount = am.cloneRequests().length;
-  const prevSubCount = am.cloneSubscriptions().length;
-
-  // Fake a message with an RPC request to add a subscription
-  port.triggerMessage({
-    type: 'rpc',
-    payload: `{"id":${appIDForRequest},"jsonrpc":"2.0","method":"system_health","params":[]}`,
-    subscription: true
-  });
-
-  // Should have a request mapping and a subscription mapping with no mapped subID yet
-  const pendingRequests = am.cloneRequests();
-  expect(pendingRequests.length).toBe(prevRequestCount + 1);
-  expect(am.cloneSubscriptions().length).toBe(prevSubCount + 1);
-  expect(am.cloneSubscriptions()[prevSubCount])
-    .toEqual({ appIDForRequest, subID: undefined, method: 'system_health' });
-
-  // Fake receiving an RPC response to the subscription request
-  const message: JsonRpcResponse = {
-    id: pendingRequests[pendingRequests.length - 1].chainID,
-    jsonrpc: '2.0',
-    result: subID
-  };
-  am.processSmoldotMessage(message);
-
-  // Should have removed the request mapping and updated the subscription
-  expect(am.cloneRequests().length).toBe(prevRequestCount);
-  expect(am.cloneSubscriptions()[prevSubCount])
-    .toEqual({ appIDForRequest, subID, method: 'system_health' });
-
-  // should send the acknowledgement of the subscription request back to the UApp
-  expect(spyPortPostMessage).toHaveBeenCalledWith({ type: 'rpc', payload: `{"id":${appIDForRequest},"jsonrpc":"2.0","result":${subID}}`});
+let port: MockPort;
+let manager: MockConnectionManager;
+let appMed: AppMediator;
+  
+const waitForMessageToBePosted = (): Promise<null> => {
+  // window.postMessge is async so we must do a short setTimeout to yield to
+  // the event loop
+  return new Promise(resolve => setTimeout(resolve, 10, null));
 }
 
-describe("Test AppMediator class", () => {
-  let port: MockPort;
-  let manager: MockConnectionManager;
-  let appMed: AppMediator;
-  let spyManagerRegisterApp: unknown;
-  let spyManagerUnregisterApp: unknown;
-  let spyPortPostMessage: unknown;
-  let spyPortDisconnect: unknown;
+beforeEach(() => {
+  port = new MockPort('test-app::westend');
+  manager = new MockConnectionManager();
+  appMed = new AppMediator(port, manager);
+  appMed.associate();
+});
+
+test('Initialization and getters', () => {
+  expect(appMed.name).toBe('test-app::westend');
+  expect(appMed.appName).toBe('test-app');
+  expect(appMed.url).toBe(port.sender.url);
+  expect(appMed.tabId).toBe(port.sender.tab.id);
+  expect(appMed.state).toEqual('connected');
+});
+
+// TODO: This is not right we should have a new 'connecting' state until we get
+// the spec message and check the transition 'connecting' -> 'connected'
+test('Connected state', () => {
+  port.triggerMessage({ type: 'spec', payload: 'westend'});
+  port.triggerMessage({ type: 'rpc', payload: '{ "id": 1 }'});
+  expect(appMed.state).toBe('connected');
+});
   
-  const initFunc = (portStr: string, connManagerFlag: boolean) => {
-    port = new MockPort(portStr);
-    manager = new MockConnectionManager(connManagerFlag);
-    appMed = new AppMediator(port, manager);
-    spyManagerRegisterApp = jest.spyOn(manager, 'registerApp');
-    spyManagerUnregisterApp = jest.spyOn(manager, 'unregisterApp');
-    spyPortDisconnect = jest.spyOn(port, 'disconnect');
-    spyPortPostMessage = jest.spyOn(port, 'postMessage');
-  }
+test('Disconnect cleans up properly', async () => {
+  port.triggerMessage({ type: 'spec', payload: 'westend'});
+  await waitForMessageToBePosted();
+  appMed.disconnect();
+  expect(appMed.state).toBe('disconnected');
+  expect(manager.unregisterApp).toHaveBeenCalled();
+  const chain = appMed.chain as SmoldotChain;
+  expect(chain.remove).toHaveBeenCalled();
+});
 
-  test('Initialization and getters', () => {
-    initFunc('test-app::westend', true);
-    expect(appMed.name).toBe('test-app::westend');
-    expect(appMed.appName).toBe('test-app');
-    expect(appMed.url).toBe(port.sender.url);
-    expect(appMed.tabId).toBe(port.sender.tab.id);
-    expect(appMed.subscriptions).toEqual([]);
-    expect(appMed.requests).toEqual([]);
-    expect(appMed.state).toEqual('connected');
-  });
+test('Spec message adds a chain', async () => {
+  port.triggerMessage({ type: 'spec', payload: 'westend'});
+  await waitForMessageToBePosted();
 
-  test('Connected  with client and can send messages', () => {
-    initFunc('test-app::westend', true);
-    port.triggerMessage({ type: 'rpc', payload: '{ "id": 1 }'});
-    expect(appMed.requests.length).toBe(1);
-    expect(appMed.state).toBe('connected');
-  });
-  
-  test('Test associate', () => {
-    initFunc('test-app::westend', true);
-    const result = appMed.associate();
-    expect(result).toBe(true);
-    expect(spyManagerRegisterApp).toHaveBeenCalled();
-  });
+  expect(appMed.chain).toBeDefined();
+});
 
-  test('Connect but given invalid port name', () => {
-    initFunc('test-appwestend', false);
-    const result = appMed.associate();
-    expect(result).toBe(false);
-    expect(spyPortDisconnect).toHaveBeenCalled();
-    expect(spyManagerRegisterApp).not.toHaveBeenCalled();
-    expect(spyPortPostMessage).toHaveBeenCalledWith({ type: 'error', payload: `Invalid port name test-appwestend expected <app_name>::<chain_name>`});
-  });
+test.todo('when addChain fails it sends an error and disconnects');
 
-  test('Try to connect but extension does not have client', () => {
-    initFunc('test-app::westend', false);
-    const result = appMed.associate();
-    expect(result).toBe(false);
-    expect(spyPortDisconnect).toHaveBeenCalled();
-    expect(spyManagerRegisterApp).not.toHaveBeenCalled();
-    expect(spyPortPostMessage).toHaveBeenCalledWith({ type: 'error', payload: `Extension does not have client for westend`});
-  });
+test('RPC port message sends the message to the chain', async () => {
+  port.triggerMessage({ type: 'spec', payload: 'westend'});
+  await waitForMessageToBePosted();
+  const message = JSON.stringify({ id: 1, jsonrpc: '2.0', result: {} });
+  port.triggerMessage({ type: 'rpc', payload: message});
+  await waitForMessageToBePosted();
 
-  test('Disconnect: happy path', () => {
-    initFunc('test-app::westend', true);
-    appMed.disconnect();
-    expect(appMed.state).toBe('disconnected');
-    expect(spyManagerUnregisterApp).toHaveBeenCalled();
-  });
-
-  describe('ProcessSmoldotMessage tests', () => {
-    test('ProcessSmoldotMessage: happy path', () => {
-      initFunc('test-app::westend', true);
-      port.triggerMessage({ type: 'rpc', payload: '{ "id": 1 }'});
-      const message: JsonRpcResponse = { id: 1, jsonrpc: '2.0', result: {} };
-      const result = appMed.processSmoldotMessage(message);
-      expect(result).toBe(true);
-    });
-
-    test('ProcessSmoldotMessage: request is undefined', () => {
-      initFunc('test-app::westend', true);
-      const message: JsonRpcResponse = { id: 1, jsonrpc: '2.0', result: {} };
-      const result = appMed.processSmoldotMessage(message);
-      expect(result).toBe(false);
-    });
-
-    test('ProcessSmoldotMessage: return false when app is disconnected', () => {
-      console.error = jest.fn()
-      initFunc('test-app::westend', true);
-      const message: JsonRpcResponse = { id: 1, jsonrpc: '2.0', result: {} };
-      appMed.disconnect();
-      const result = appMed.processSmoldotMessage(message);
-      expect(result).toBe(false);
-      expect(console.error).toBeCalledTimes(1);
-      expect(console.error).toBeCalledWith('Asked a disconnected UApp (test-app::westend) to process a message from undefined');
-
-    });
-
-    test('ProcessSmoldotMessage: does nothing when it has sent no requests', () => {
-      initFunc('test-app::westend', true);    
-      const message: JsonRpcResponse = { id: 1, jsonrpc: '2.0', result: {} };
-      const result = appMed.processSmoldotMessage(message);
-      expect(result).toBe(false);
-    });
-
-    test('ProcessSmoldotMessage: remaps the id to the apps id', () => {
-      initFunc('test-app::kusama', true);    
-      
-      // Fake getting a request from UApp to send an RPC message
-      port.triggerMessage({
-        type: 'rpc',
-        payload: '{"id":1,"jsonrpc":"2.0","method":"state_getStorage","params":["<hash>"]}'
-      });
-    
-      // Fake an RPC response to the request
-      const message: JsonRpcResponse = { id: manager.lastId, jsonrpc: '2.0', result: {} };
-      expect(appMed.processSmoldotMessage(message)).toBe(true);
-      // should have posted the message back to the UApp with the mapped ID
-      expect(spyPortPostMessage).toHaveBeenCalledWith({ type: 'rpc', payload: '{"id":1,"jsonrpc":"2.0","result":{}}'});
-    });
-  });
-
-  test('Tracks and forwards subscriptions', () => {
-    initFunc('test-app::westend', true);
-
-    const appIDForRequest = 1
-    const subscriptionId = 2;
-    setupAppMediatorWithSubscription(appMed, port, appIDForRequest, subscriptionId, spyPortPostMessage);
-
-    // Fake receiving an RPC message for the subscription
-    const subMessage = {
-      jsonrpc: '2.0',
-      method: 'system_health',
-      params: { subscription: subscriptionId, result: "subscription value" }
-    };
-    expect(appMed.processSmoldotMessage(subMessage)).toBe(true);
-
-    // should send subcription message back to the UApp unchanged
-    expect(spyPortPostMessage)
-      .toHaveBeenCalledWith({ type: 'rpc', payload: JSON.stringify(subMessage)});
-
-    // Fake receiving an RPC message with a subscription ID that is not one of
-    // our subscriptions
-    const subMessage2 = {
-      jsonrpc: '2.0',
-      method: 'system_health',
-      params: { subscription: 666, result: "subscription value" }
-    };
-    // shouldnt process it
-    expect(appMed.processSmoldotMessage(subMessage2)).toBe(false);
-  });
-
-  test('Unsubscribes from all subs on disconnect', () => {
-    initFunc('test-app::westend', true);
-
-    setupAppMediatorWithSubscription(appMed, port, 1, 1, spyPortPostMessage);
-    setupAppMediatorWithSubscription(appMed, port, 2, 2, spyPortPostMessage);
-
-    port.triggerDisconnect();
-    expect(appMed.state).toBe('disconnecting');
-    let pendingRequests = appMed.cloneRequests();
-    expect(pendingRequests.length).toBe(2);
-
-    // First unsub repsonse
-    const unsub1 = { jsonrpc:'2.0', id: pendingRequests[0].chainID, result: true };
-    expect(appMed.processSmoldotMessage(unsub1)).toBe(true);
-    expect(appMed.state).toBe('disconnecting');
-    pendingRequests = appMed.cloneRequests();
-    expect(pendingRequests.length).toBe(1);
-
-    // Second unsub repsonse
-    const unsub2 = { jsonrpc:'2.0', id: pendingRequests[0].chainID, result: true };
-    expect(appMed.processSmoldotMessage(unsub2)).toBe(true);
-    expect(appMed.state).toBe('disconnected');
-    pendingRequests = appMed.cloneRequests();
-    expect(pendingRequests.length).toBe(0);
-  });
+  const chain = appMed.chain as SmoldotChain;
+  expect(chain.sendJsonRpc).toHaveBeenCalledWith(message);
 });

--- a/projects/extension/src/background/AppMediator.test.ts
+++ b/projects/extension/src/background/AppMediator.test.ts
@@ -55,7 +55,21 @@ test('Spec message adds a chain', async () => {
   expect(appMed.chain).toBeDefined();
 });
 
-test.todo('when addChain fails it sends an error and disconnects');
+test('Buffers RPC messages before spec message', async () => {
+  const message1 = JSON.stringify({ id: 1, jsonrpc: '2.0', result: {} });
+  port.triggerMessage({ type: 'rpc', payload: message1 });
+  const message2 = JSON.stringify({ id: 2, jsonrpc: '2.0', result: {} });
+  port.triggerMessage({ type: 'rpc', payload: message2 });
+
+  port.triggerMessage({ type: 'spec', payload: 'westend'});
+  await waitForMessageToBePosted();
+
+  expect(appMed.chain).toBeDefined();
+  const chain = appMed.chain as SmoldotChain;
+  expect(chain.sendJsonRpc).toHaveBeenCalledTimes(2);
+  expect(chain.sendJsonRpc).toHaveBeenCalledWith(message1);
+  expect(chain.sendJsonRpc).toHaveBeenLastCalledWith(message2);
+});
 
 test('RPC port message sends the message to the chain', async () => {
   port.triggerMessage({ type: 'spec', payload: 'westend'});

--- a/projects/extension/src/background/AppMediator.ts
+++ b/projects/extension/src/background/AppMediator.ts
@@ -60,9 +60,9 @@ export class AppMediator extends (EventEmitter as { new(): StateEmitter }) {
   }
 
   /** 
-   * associate parses the name of the network from the port name and associates
-   * the app with the smoldot client or sends an error and disconnects the port
-   * if there is no smoldot client for the network.
+   * associate parses the name of the network from the port name.
+   * It sends an error and disconnects the port if the port name is not in a
+   * valid format.
    *
    * @remarks
    * This MUST be called straight after constructing an AppMediator

--- a/projects/extension/src/background/index.ts
+++ b/projects/extension/src/background/index.ts
@@ -30,7 +30,11 @@ const init = async () => {
   try {
     await manager.initSmoldot();
     for(const [key, value] of relayChains.entries()) {
-      await manager.addChain(key, value).catch(err => l.error('Error', err));
+      const rpcCallback = (rpc: string) => {
+        console.warn(`Got RPC from ${key} dummy chain: ${rpc}`);
+      };
+      await manager.addChain(key, value, rpcCallback)
+        .catch(err => l.error('Error', err));
     }
   } catch (e) {
     l.error(`Error creating smoldot: ${e}`); 

--- a/projects/extension/src/background/types.ts
+++ b/projects/extension/src/background/types.ts
@@ -11,7 +11,7 @@ export interface InitAppNameSpec {
   chainSpec?: string
 }
 
-export type AppState = 'connected' | 'disconnecting' | 'disconnected';
+export type AppState = 'connected' | 'disconnected';
 
 export interface AppInfo {
   name: string;
@@ -27,17 +27,6 @@ export interface NetworkState {
   name: string;
 }
 
-export interface MessageIDMapping {
-  readonly appID: number | undefined;
-  readonly chainID: number;
-}
-
-export interface SubscriptionMapping {
-  readonly appIDForRequest: number | undefined;
-  subID: number | string  | undefined;
-  method: string;
-}
-
 export interface StateEvents {
   stateChanged: State;
 }
@@ -45,43 +34,8 @@ export interface StateEvents {
 export type StateEmitter = StrictEventEmitter<EventEmitter, StateEvents>;
 
 export interface ConnectionManagerInterface {
-  hasClientFor: (name: string) => boolean;
-  sendRpcMessageTo: (name: string, message: JsonRpcRequest) => number;
-  registerApp: (app: AppMediator, name: string) => void;
-  unregisterApp: (app: AppMediator, name: string) => void;
-  addChain: (name: string, spec: string) => Promise<smoldot.SmoldotChain | undefined>;
+  registerApp: (app: AppMediator) => void;
+  unregisterApp: (app: AppMediator) => void;
+  addChain: (name: string, spec: string, jsonRpcCallback: smoldot.SmoldotJsonRpcCallback) => Promise<smoldot.SmoldotChain | undefined>;
 }
 
-export interface JsonRpcObject {
-  id?: number;
-  jsonrpc: string;
-}
-
-export interface JsonRpcRequest extends JsonRpcObject {
-  method: string;
-  params: unknown[];
-}
-
-export interface JsonRpcResponseBaseError {
-  code: number;
-  data?: number | string;
-  message: string;
-}
-
-export interface JsonRpcResponseSingle {
-  error?: JsonRpcResponseBaseError;
-  result?: unknown;
-}
-
-export interface JsonRpcResponseSubscription {
-  method?: string;
-  params?: {
-    error?: JsonRpcResponseBaseError;
-    result: unknown;
-    subscription: number | string;
-  };
-}
-
-export type JsonRpcResponseBase = JsonRpcResponseSingle & JsonRpcResponseSubscription;
-
-export type JsonRpcResponse = JsonRpcObject & JsonRpcResponseBase

--- a/projects/extension/src/mocks.ts
+++ b/projects/extension/src/mocks.ts
@@ -53,33 +53,14 @@ export class MockPort implements chrome.runtime.Port {
 }
 
 export class MockConnectionManager implements ConnectionManagerInterface {
-  readonly #willFindClient: boolean;
-  lastId = 0;
-
-
-  constructor(willFindClient: boolean) {
-    this.#willFindClient = willFindClient;
-  }
 
   addChain (): Promise<SmoldotChain | undefined> {
-    return Promise.resolve({} as SmoldotChain);
+    return Promise.resolve({
+      sendJsonRpc: jest.fn(),
+      remove: jest.fn()
+    } as SmoldotChain);
   }
 
-  registerApp(): void {
-    return;
-  }
-
-  unregisterApp(): void {
-    return;
-  }
-
-  hasClientFor = (): boolean => {
-    return this.#willFindClient;
-  };
-
-  sendRpcMessageTo = (): number => {
-    return ++this.lastId;
-  };
+  registerApp: () => void = jest.fn();
+  unregisterApp: () => void = jest.fn();
 }
-
-


### PR DESCRIPTION
This fixes #438.  It also fixes 2 bugs in the implementation.

* The `AppMediator` was asking the `ConnectionManager` to send messages on its behalf but the `ConnectionManager` would just pick the first chain with the matching name instead of using the chain that was created for that `AppMediator`.  I removed the message sending from the `ConnectionManager` and the `AppMediator` just asks the chain it has to send the message.
* If an RPC message was received before a spec message or before `addChain` had completed then it would crash because the chain was not yet defined.  I now buffer any early RPC messages that come in and when the `addChain` completes check for those messages and send them all.

I spotted a couple more small issues with the implementation but they aren't causing complete crashes / erroneous behaviour so I added TODO comments to clean them up.

