### PR TITLE
Improve ConnectionManager tests and fix notification behaviour

### DIFF
--- a/projects/extension/src/background/ConnectionManager.test.ts
+++ b/projects/extension/src/background/ConnectionManager.test.ts
@@ -198,14 +198,15 @@ describe('Unit tests', () => {
     expect(manager.networks).toHaveLength(2);
   });
 
-  test('Add an app that already exists', () => {
+  test('Adding an app that already exists sends an error and disconnects', () => {
     const port = connectApp(manager, 13, 'test-app-3', 'westend');
     expect(port.postMessage).toHaveBeenCalledTimes(1);
     expect(port.postMessage).toHaveBeenLastCalledWith({ type: 'error', payload: 'App test-app-3::westend already exists.' })
+    expect(port.disconnect).toHaveBeenCalled();
   });
 });
 
-describe('Test functions when smoldot client is terminated', () => {
+describe('When the manager is shutdown', () => {
   const manager = new ConnectionManager();
 
   beforeEach(async () => {
@@ -213,7 +214,7 @@ describe('Test functions when smoldot client is terminated', () => {
     await manager.initSmoldot();
   });
 
-  test('Test manager.addApp error', () => {
+  test('adding an app after the manager is shutdown throws an error', () => {
     const port = new MockPort('test-app-5::westend');
     port.setTabId(15);
     expect(() => {

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -116,19 +116,16 @@ export class ConnectionManager extends (EventEmitter as { new(): StateEmitter })
       return;
     } 
 
-    let notifMsg: string;
     const app = new AppMediator(port, this as ConnectionManagerInterface)
     // if associate fails by returning false it has sent an error down the
     // port and disconnected it, so we should just discard this `AppMediator`
     if (app.associate()) {
       this.registerApp(app);
       const appInfo = port.name.split('::');
-      notifMsg = `App ${appInfo[0]} connected to ${appInfo[1]}.`
-
       chrome.storage.sync.get('notifications', (s) => {
         s.notifications && chrome.notifications.create(port.name, {
           title: 'Substrate Connect',
-          message: notifMsg,
+          message: `App ${appInfo[0]} connected to ${appInfo[1]}.`,
           iconUrl: './icons/icon-32.png',
           type: 'basic'
         });


### PR DESCRIPTION
- Test that disconnect is called after sending an error when an app
  already exists
- Improve some of the test names
- Only show a notification to the user if an app successfully connects.  The app will get an error if it fails so it is the app's responsibility to update it's UI to tell the user.

This is the first part of #442. I'm splitting the PRs to make it easier to review instead of having several small unrelated changes mixed together.