### PR TITLE
Send the right error message when addChain fails and add missing tests for all error cases

### DIFF
--- a/projects/extension/jest.config.ts
+++ b/projects/extension/jest.config.ts
@@ -1,5 +1,5 @@
 export default {
-  coverageReporters: ["text-summary"],
+  coverageReporters: ["text-summary","lcov"],
   roots: ['<rootDir>/src'],
   reporters: ["jest-silent-reporter"],
   testEnvironment: 'jsdom',

--- a/projects/extension/src/background/AppMediator.ts
+++ b/projects/extension/src/background/AppMediator.ts
@@ -143,27 +143,18 @@ export class AppMediator extends (EventEmitter as { new(): StateEmitter }) {
 
     this.#manager.addChain(chainName, chainSpec, rpcCallback)
       .then(chain => {
-        if (chain) {
-          this.#chain = chain;
-          // process any RPC requests that came in while waiting for `addChain`
-          // to complete
-          if (this.#pendingRequests.length > 0) {
-            this.#pendingRequests.forEach(req => chain.sendJsonRpc(req));
-            this.#pendingRequests = [];
-          }
-        } else {
-          // TODO: remove this duplicate error block when `addChain` on the 
-          // ConnectionManager has been cleaned up to not catch errors adding
-          // chains
-          this.#sendError('Error adding chainspec');
-          this.#manager.unregisterApp(this);
-          this.#port.disconnect();
+        this.#chain = chain;
+        // process any RPC requests that came in while waiting for `addChain`
+        // to complete
+        if (this.#pendingRequests.length > 0) {
+          this.#pendingRequests.forEach(req => chain.sendJsonRpc(req));
+          this.#pendingRequests = [];
         }
       })
       .catch(e => {
         this.#sendError((e as Error).message);
-        this.#manager.unregisterApp(this);
         this.#port.disconnect();
+        this.#manager.unregisterApp(this);
       });
   }
 

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -183,30 +183,24 @@ export class ConnectionManager extends (EventEmitter as { new(): StateEmitter })
    * @param name - Name of the chain
    * @param spec - ChainSpec of chain to be added
    */
-  async addChain (name: string, chainSpec: string, jsonRpcCallback: smoldot.SmoldotJsonRpcCallback): Promise<smoldot.SmoldotChain | undefined> {
-    try {
-      if (!this.#client) {
-        throw new Error('Smoldot client does not exist.');
-      }
-      const addedChain = await this.#client.addChain({
-        chainSpec,
-        jsonRpcCallback
-      });
-
-      this.#networks.push({
-        name,
-        chain: addedChain,
-        status: 'connected',
-        isKnown: true,
-        chainspecPath: `${name}.json`
-      });
-
-      return addedChain;
-    } catch (err) {
-      // TODO: we shouldnt catch the error here - we need to report it back to
-      // the app and disconnect the port if e.g. they have sent an invalid chain
-      // spec
-      l.error(`Error while trying to connect to chain ${name}: ${err}`);
+  async addChain (name: string, chainSpec: string, jsonRpcCallback: smoldot.SmoldotJsonRpcCallback): Promise<smoldot.SmoldotChain> {
+    if (!this.#client) {
+      throw new Error('Smoldot client does not exist.');
     }
+
+    const addedChain = await this.#client.addChain({
+      chainSpec,
+      jsonRpcCallback
+    });
+
+    this.#networks.push({
+      name,
+      chain: addedChain,
+      status: 'connected',
+      isKnown: true,
+      chainspecPath: `${name}.json`
+    });
+
+    return addedChain;
   }
 }

--- a/projects/extension/src/background/types.ts
+++ b/projects/extension/src/background/types.ts
@@ -36,6 +36,6 @@ export type StateEmitter = StrictEventEmitter<EventEmitter, StateEvents>;
 export interface ConnectionManagerInterface {
   registerApp: (app: AppMediator) => void;
   unregisterApp: (app: AppMediator) => void;
-  addChain: (name: string, spec: string, jsonRpcCallback: smoldot.SmoldotJsonRpcCallback) => Promise<smoldot.SmoldotChain | undefined>;
+  addChain: (name: string, spec: string, jsonRpcCallback: smoldot.SmoldotJsonRpcCallback) => Promise<smoldot.SmoldotChain>;
 }
 

--- a/projects/extension/src/mocks.ts
+++ b/projects/extension/src/mocks.ts
@@ -54,11 +54,21 @@ export class MockPort implements chrome.runtime.Port {
 
 export class MockConnectionManager implements ConnectionManagerInterface {
 
-  addChain (): Promise<SmoldotChain | undefined> {
+  addChain (): Promise<SmoldotChain> {
     return Promise.resolve({
       sendJsonRpc: jest.fn(),
       remove: jest.fn()
     } as SmoldotChain);
+  }
+
+  registerApp: () => void = jest.fn();
+  unregisterApp: () => void = jest.fn();
+}
+
+export class ErroringMockConnectionManager implements ConnectionManagerInterface {
+
+  addChain (): Promise<SmoldotChain> {
+    return Promise.reject(new Error('Invalid chain spec'));
   }
 
   registerApp: () => void = jest.fn();


### PR DESCRIPTION
- Don't catch the error when adding the chain - use the message to send
  it back to the app.
- Add missing tests for sending an error when the port name is not valid

This closes #442 