### PR TITLE
Reject pending requests on disconnect

### DIFF
--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
@@ -9,7 +9,7 @@ import {
 } from '@polkadot/rpc-provider/types';
 import { logger } from '@polkadot/util';
 import EventEmitter from 'eventemitter3';
-import { isUndefined } from '../utils/index.js';
+import { isUndefined, eraseRecord } from '../utils/index.js';
 import { HealthCheckError } from '../errors.js';
 import {
   MessageFromManager,
@@ -45,16 +45,6 @@ interface HealthResponse {
   isSyncing: boolean;
   peers: number;
   shouldHavePeers: boolean;
-}
-
-function eraseRecord<T> (record: Record<string, T>, cb?: (item: T) => void): void {
-  Object.keys(record).forEach((key): void => {
-    if (cb) {
-      cb(record[key]);
-    }
-
-    delete record[key];
-  });
 }
 
 

--- a/packages/connect/src/utils/index.ts
+++ b/packages/connect/src/utils/index.ts
@@ -2,6 +2,17 @@ const isUndefined = (value?: unknown): value is undefined => {
     return typeof value === 'undefined';
 }
 
+function eraseRecord<T> (record: Record<string, T>, cb?: (item: T) => void): void {
+  Object.keys(record).forEach((key): void => {
+    if (cb) {
+      cb(record[key]);
+    }
+
+    delete record[key];
+  });
+}
+
 export {
-    isUndefined
+    isUndefined,
+    eraseRecord
 };

--- a/packages/connect/src/utils/utils.test.ts
+++ b/packages/connect/src/utils/utils.test.ts
@@ -1,6 +1,7 @@
-import { isUndefined } from './';
+import { jest } from '@jest/globals';
+import { isUndefined, eraseRecord } from './';
 
-test('Test util: isUndefined', () => {
+test('isUndefined returns true for undefined otherwise false', () => {
   let check: boolean;
   let value: unknown = undefined;
   check = isUndefined(value);
@@ -8,4 +9,17 @@ test('Test util: isUndefined', () => {
   value = 'Not undefined';
   check = isUndefined(value);
   expect(check).toBe(false);
+});
+
+test('eraseRecord removes all entries', () => {
+  const record = { 'foo': 'bar', 'baz': 'quux' };
+  eraseRecord(record);
+  expect(Object.keys(record).length).toBe(0);
+});
+
+test('eraseRecord calls back with each entry', () => {
+  const record = { 'foo': 'bar', 'baz': 'quux' };
+  const spy = jest.fn();
+  eraseRecord(record, spy);
+  expect(spy).toHaveBeenCalledTimes(2);
 });


### PR DESCRIPTION
When the extension disconnects an app for an error the `ExtensionProvider` now rejects any pending req	uest promises.  This is a direct copy of the logic from the WsProvider