### PR TITLE
Replace smoldot with @substrate/smoldot-light

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -35,7 +35,7 @@
     "@polkadot/api": "^5.4.1",
     "@polkadot/rpc-provider": "^5.4.1",
     "@substrate/connect-extension-protocol": "^0.3.0",
-    "@substrate/smoldot-light": "^0.3.10",
+    "@substrate/smoldot-light": "^0.4.0",
     "browserify-fs": "^1.0.0",
     "eventemitter3": "^4.0.7",
     "file-entry-cache": "^6.0.1",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -35,11 +35,11 @@
     "@polkadot/api": "^5.4.1",
     "@polkadot/rpc-provider": "^5.4.1",
     "@substrate/connect-extension-protocol": "^0.3.0",
+    "@substrate/smoldot-light": "^0.3.10",
     "browserify-fs": "^1.0.0",
     "eventemitter3": "^4.0.7",
     "file-entry-cache": "^6.0.1",
-    "mkdirp": "^1.0.4",
-    "smoldot": "0.3.4"
+    "mkdirp": "^1.0.4"
   },
   "devDependencies": {
     "@substrate/smoldot-test-utils": "^0.1.0",

--- a/packages/connect/src/SmoldotProvider/SmoldotProvider.test.ts
+++ b/packages/connect/src/SmoldotProvider/SmoldotProvider.test.ts
@@ -4,7 +4,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { SmoldotProvider } from './SmoldotProvider';
-import { SmoldotClient } from 'smoldot';
+import { SmoldotClient } from '@substrate/smoldot-light';
 import {
   erroringResponder,
   customHealthResponder,

--- a/packages/connect/src/SmoldotProvider/SmoldotProvider.ts
+++ b/packages/connect/src/SmoldotProvider/SmoldotProvider.ts
@@ -8,7 +8,7 @@ import {
 } from '@polkadot/rpc-provider/types';
 import { assert, logger } from '@polkadot/util';
 import EventEmitter from 'eventemitter3';
-import * as smoldot from 'smoldot';
+import * as smoldot from '@substrate/smoldot-light';
 import { HealthCheckError } from '../errors.js';
 import { isUndefined } from '../utils/index.js';
 

--- a/packages/smoldot-test-utils/package.json
+++ b/packages/smoldot-test-utils/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint . --ext .js,.ts"
   },
   "dependencies": {
-    "@substrate/smoldot-light": "^0.3.10",
+    "@substrate/smoldot-light": "^0.4.0",
     "asap": "^2.0.6"
   },
   "devDependencies": {

--- a/packages/smoldot-test-utils/package.json
+++ b/packages/smoldot-test-utils/package.json
@@ -16,8 +16,8 @@
     "lint": "eslint . --ext .js,.ts"
   },
   "dependencies": {
-    "asap": "^2.0.6",
-    "smoldot": "0.3.4"
+    "@substrate/smoldot-light": "^0.3.10",
+    "asap": "^2.0.6"
   },
   "devDependencies": {
     "@types/asap": "^2.0.0",

--- a/packages/smoldot-test-utils/src/index.ts
+++ b/packages/smoldot-test-utils/src/index.ts
@@ -214,6 +214,8 @@ export const mockSmoldot = (responder: RpcResponder, healthResponder = healthyRe
     },
     healthChecker: (): HealthChecker => {
       return ({
+        setSendJsonRpc: doNothing,
+        sendJsonRpc: doNothing,
         start: doNothing,
         stop: doNothing,
         responsePassThrough: (_resp: string) => ''
@@ -260,6 +262,8 @@ export const smoldotSpy = (responder: RpcResponder, rpcSpy: jest.MockedFunction<
     },
     healthChecker: (): HealthChecker => {
       return ({
+        setSendJsonRpc: doNothing,
+        sendJsonRpc: doNothing,
         start: doNothing,
         stop: doNothing,
         responsePassThrough: (_resp: string) => ''

--- a/packages/smoldot-test-utils/src/index.ts
+++ b/packages/smoldot-test-utils/src/index.ts
@@ -1,4 +1,4 @@
-import { Smoldot, SmoldotAddChainOptions, SmoldotChain, SmoldotClient, SmoldotJsonRpcCallback } from 'smoldot';
+import { HealthChecker, Smoldot, SmoldotAddChainOptions, SmoldotChain, SmoldotClient, SmoldotJsonRpcCallback } from '@substrate/smoldot-light';
 import { JsonRpcObject } from '@polkadot/rpc-provider/types';
 import { jest } from '@jest/globals'
 import asap from 'asap';
@@ -211,6 +211,13 @@ export const mockSmoldot = (responder: RpcResponder, healthResponder = healthyRe
           jsonRpcCallback: createRequestProcessor(options, responder, healthResponder)
         })
       });
+    },
+    healthChecker: (): HealthChecker => {
+      return ({
+        start: doNothing,
+        stop: doNothing,
+        responsePassThrough: (_resp: string) => ''
+      })
     }
   };
 };
@@ -250,6 +257,13 @@ export const smoldotSpy = (responder: RpcResponder, rpcSpy: jest.MockedFunction<
           })
         }
       });
+    },
+    healthChecker: (): HealthChecker => {
+      return ({
+        start: doNothing,
+        stop: doNothing,
+        responsePassThrough: (_resp: string) => ''
+      })
     }
   };
 };

--- a/projects/extension/package.json
+++ b/projects/extension/package.json
@@ -72,7 +72,7 @@
     "@material-ui/styles": "^4.11.3",
     "@polkadot/rpc-provider": "^4.10.1",
     "@substrate/connect-extension-protocol": "^0.3.0",
-    "@substrate/smoldot-light": "^0.3.10",
+    "@substrate/smoldot-light": "^0.4.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-hot-loader": "^4.13.0",

--- a/projects/extension/package.json
+++ b/projects/extension/package.json
@@ -72,10 +72,10 @@
     "@material-ui/styles": "^4.11.3",
     "@polkadot/rpc-provider": "^4.10.1",
     "@substrate/connect-extension-protocol": "^0.3.0",
+    "@substrate/smoldot-light": "^0.3.10",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-hot-loader": "^4.13.0",
-    "smoldot": "0.3.4",
     "strict-event-emitter-types": "^2.0.0",
     "styled-components": "^5.2.1"
   }

--- a/projects/extension/src/background/AppMediator.test.ts
+++ b/projects/extension/src/background/AppMediator.test.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/unbound-method */
 import { AppMediator } from './AppMediator';
-import { SmoldotChain } from 'smoldot';
+import { SmoldotChain } from '@substrate/smoldot-light';
 import { 
   MockPort, 
   MockConnectionManager,

--- a/projects/extension/src/background/AppMediator.ts
+++ b/projects/extension/src/background/AppMediator.ts
@@ -8,7 +8,7 @@ import {
   ConnectionManagerInterface,
   StateEmitter,
 } from './types';
-import { SmoldotChain } from 'smoldot';
+import { SmoldotChain } from '@substrate/smoldot-light';
 import westend from '../../public/assets/westend.json';
 import kusama from '../../public/assets/kusama.json';
 import polkadot from '../../public/assets/polkadot.json';

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -2,14 +2,14 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import * as smoldot from 'smoldot';
+import * as smoldot from '@substrate/smoldot-light';
+import { SmoldotAddChainOptions, SmoldotChain } from '@substrate/smoldot-light';
 import { AppMediator } from './AppMediator';
 import { ConnectionManagerInterface } from './types';
 import EventEmitter from 'eventemitter3';
 import { StateEmitter, State } from './types';
 import { Network } from '../types';
 import { logger } from '@polkadot/util';
-import { SmoldotAddChainOptions, SmoldotChain } from 'smoldot';
 
 const l = logger('Extension Connection Manager');
 

--- a/projects/extension/src/background/types.ts
+++ b/projects/extension/src/background/types.ts
@@ -1,4 +1,4 @@
-import * as smoldot from 'smoldot';
+import * as smoldot from '@substrate/smoldot-light';
 import { AppMediator } from './AppMediator';
 import EventEmitter from 'eventemitter3';
 import StrictEventEmitter from 'strict-event-emitter-types';

--- a/projects/extension/src/mocks.ts
+++ b/projects/extension/src/mocks.ts
@@ -8,7 +8,7 @@ import {
   MessageToManager, 
   MessageFromManager 
 } from '@substrate/connect-extension-protocol';
-import { SmoldotChain } from 'smoldot';
+import { SmoldotChain } from '@substrate/smoldot-light';
 
 export class MockPort implements chrome.runtime.Port {
   sender: any;

--- a/projects/extension/src/types/index.ts
+++ b/projects/extension/src/types/index.ts
@@ -1,4 +1,4 @@
-import * as smoldot from 'smoldot';
+import * as smoldot from '@substrate/smoldot-light';
 
 export type NetworkTypes = 'kusama' | 'polkadot' | 'westend' | 'kulupu'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2739,10 +2739,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@substrate/smoldot-light@^0.3.10":
-  version "0.3.10"
-  resolved "https://registry.yarnpkg.com/@substrate/smoldot-light/-/smoldot-light-0.3.10.tgz#e046c0fb9807b9a6e15d75e6005a20a78560374b"
-  integrity sha512-nzeT8UhazQSXZN+JL0IuMlVi1HoR38k7z9i9FFsnHGewo52k/CuYLe5+18S93bmRNW5+1sfXiJwR7u3puB2XmQ==
+"@substrate/smoldot-light@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@substrate/smoldot-light/-/smoldot-light-0.4.0.tgz#875d9dbfb0d63be1205b8666c8a07c7c9ed1e800"
+  integrity sha512-i2UZPqkDTaXBO0Org3+gMO2uOsoaato89HwbShmXDvVxsTwCzCOpL1EPCsx8tVZ+X4m73oJEfsMbCY+K3wceDA==
   dependencies:
     buffer "^6.0.1"
     performance-now "^2.1.0"
@@ -13155,16 +13155,6 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
-smoldot@0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/smoldot/-/smoldot-0.3.6.tgz#08031fa2523e99c767e967e43de6193f7a06b1c0"
-  integrity sha512-+bjlWPfZBGFpR9FSjtNS61FUeWSBvpJoZDotjEa9c2+QfRzTFmjPvxaZ9/3P1QvVp8uT4QshKoPd7Slhlq6G3g==
-  dependencies:
-    buffer "^6.0.1"
-    performance-now "^2.1.0"
-    randombytes "^2.1.0"
-    websocket "^1.0.32"
-
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -13654,7 +13644,7 @@ style-loader@^2.0.0:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-styled-components@^5, styled-components@^5.2.1:
+styled-components@^5.2.1:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.3.0.tgz#e47c3d3e9ddfff539f118a3dd0fd4f8f4fb25727"
   integrity sha512-bPJKwZCHjJPf/hwTJl6TbkSZg/3evha+XPEizrZUGb535jLImwDUdjTNxXqjjaASt2M4qO4AVfoHJNe3XB/tpQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2739,6 +2739,16 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@substrate/smoldot-light@^0.3.10":
+  version "0.3.10"
+  resolved "https://registry.yarnpkg.com/@substrate/smoldot-light/-/smoldot-light-0.3.10.tgz#e046c0fb9807b9a6e15d75e6005a20a78560374b"
+  integrity sha512-nzeT8UhazQSXZN+JL0IuMlVi1HoR38k7z9i9FFsnHGewo52k/CuYLe5+18S93bmRNW5+1sfXiJwR7u3puB2XmQ==
+  dependencies:
+    buffer "^6.0.1"
+    performance-now "^2.1.0"
+    randombytes "^2.1.0"
+    websocket "^1.0.32"
+
 "@swc/helpers@^0.2.11":
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.2.13.tgz#95d69aaed0998040d455832efbe1342ed79d0809"
@@ -13145,10 +13155,10 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
-smoldot@0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/smoldot/-/smoldot-0.3.4.tgz#2bb20bf85cd1261a18fe6f2171ffa3fa339e55e2"
-  integrity sha512-VoWb3E8mCtMPglAB6IguzimPj60s1l53CFEIDfO2J3bmClDozRINaeuwrFTUZv4YFqgCO/37GCHfZezZdb0bbw==
+smoldot@0.3.6:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/smoldot/-/smoldot-0.3.6.tgz#08031fa2523e99c767e967e43de6193f7a06b1c0"
+  integrity sha512-+bjlWPfZBGFpR9FSjtNS61FUeWSBvpJoZDotjEa9c2+QfRzTFmjPvxaZ9/3P1QvVp8uT4QshKoPd7Slhlq6G3g==
   dependencies:
     buffer "^6.0.1"
     performance-now "^2.1.0"
@@ -13644,7 +13654,7 @@ style-loader@^2.0.0:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-styled-components@^5.2.1:
+styled-components@^5, styled-components@^5.2.1:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.3.0.tgz#e47c3d3e9ddfff539f118a3dd0fd4f8f4fb25727"
   integrity sha512-bPJKwZCHjJPf/hwTJl6TbkSZg/3evha+XPEizrZUGb535jLImwDUdjTNxXqjjaASt2M4qO4AVfoHJNe3XB/tpQ==


### PR DESCRIPTION
- replacing deprecated smoldot package with @substrate/smoldot-light
- adds in `packages/smoldot-test-utils/src/index.ts` the mock for healthChecker