### PR TITLE
Improve and update README

### DIFF
--- a/DEPLOY-RELEASE.md
+++ b/DEPLOY-RELEASE.md
@@ -1,0 +1,38 @@
+# Deploying docs and releasing substrate connect
+
+## Releasing
+
+TODO
+
+## Deploy Smoldot browser demo to Github Pages
+
+Before deploying make sure you have a clean working copy with no staged changes.
+The deploy script will deploy the last commit on your current branch.
+
+The deployment will build the smoldot browser demo into the dist folder and 
+construct a commit containing just that folder with a message containing a 
+reference to the SHA of the commit it came from and push that to the gh-pages
+branch. The dist folder remains ignored by git.
+
+You can deploy to Github pages like so:
+
+```bash
+yarn deploy:gh-pages:smoldot-browser-demo
+```
+
+## Deploy Smoldot browser demo to IPFS
+
+Before deploying make sure you have a Piñata API key and secret and that you
+have exported them in your shell environment:
+
+```bash
+PINATA_API_KEY=<your key>
+PINATA_API_SECRET=<your secret>
+```
+
+You can then deploy to IPFS like so:
+
+```bash
+yarn deploy:ipfs:smoldot-browser-demo
+```
+

--- a/README.md
+++ b/README.md
@@ -118,29 +118,3 @@ You can then deploy to IPFS like so:
 ```bash
 yarn deploy:ipfs:smoldot-browser-demo
 ```
-
-## Working with this repository
-
-Substrate Connect is using Yarn workspaces to manage dependencies. 
-
-Read more about it here: https://classic.yarnpkg.com/en/docs/workspaces/
-
-### Adding modules to single repositories
-
-To add new dependencies, please use the following syntax:
-
-```
-yarn workspace [module name from package.json] add your-desired-npm-package
-```
-Example to add Jest to the Burnr Wallet:
-```
-yarn workspace @substrate/burnr add jest
-```
-
-Also see https://classic.yarnpkg.com/en/docs/cli/workspace/
-
-### GH Pages Links
-This is a test for GH-Pages:
-[Burnr](https://paritytech.github.io/substrate-connect/burnr) and
-[Smoldot Browser Demo](https://paritytech.github.io/substrate-connect/smoldot-browser-demo) and
-[Multiple Network Demo](https://paritytech.github.io/substrate-connect/multiple-network-demo)

--- a/README.md
+++ b/README.md
@@ -87,34 +87,7 @@ yarn dev:smoldot-extension
 
 (Make sure to run `$ yarn install` before.)
 
-## Deploy Smoldot browser demo to Github Pages
 
-Before deploying make sure you have a clean working copy with no staged changes.
-The deploy script will deploy the last commit on your current branch.
+## [Deployments and releases](./DEPLOY-RELEASE.md)
 
-The deployment will build the smoldot browser demo into the dist folder and 
-construct a commit containing just that folder with a message containing a 
-reference to the SHA of the commit it came from and push that to the gh-pages
-branch. The dist folder remains ignored by git.
 
-You can deploy to Github pages like so:
-
-```bash
-yarn deploy:gh-pages:smoldot-browser-demo
-```
-
-## Deploy Smoldot browser demo to IPFS
-
-Before deploying make sure you have a Piñata API key and secret and that you
-have exported them in your shell environment:
-
-```bash
-PINATA_API_KEY=<your key>
-PINATA_API_SECRET=<your secret>
-```
-
-You can then deploy to IPFS like so:
-
-```bash
-yarn deploy:ipfs:smoldot-browser-demo
-```

--- a/README.md
+++ b/README.md
@@ -1,29 +1,27 @@
 # Substrate Connect
 
-Run Wasm Light Clients of any Substrate based chain directly in your browser.
+**[The most up-to-date usage instructions for app builders can be found here](https://paritytech.github.io/substrate-connect/)**
 
-**Substrate Connect** is not the name of a single product, it rather describes a vision or notion that will allow developers to quickly generate and run Wasm Light Clients of their Substrate based chains - as easy as installing a node module.
+Substrate connect provides a way to interact with [substrate](https://substrate.dev/)
+based blockchains in the browser without using an RPC server. Substrate connect
+uses a [smoldot](https://github.com/paritytech/smoldot/) WASM light client to
+securely connect to the blockchain network without relying on specific 3rd parties.
 
-Substrate Connect provides the infrastructure to run these clients directly in the browser and any other JavaScript or Node environment without deeper additional programming efforts needed. It adds Substrate light-client functionality to any Javascript environment, from in-browser applications to browser extensions and electron apps up to IOT devices and mobile phones.
+Due to browser limitations on websockets from https pages, establishing a good
+number of peers is difficult as many nodes need to be available with TLS.  Substrate
+connect provides a browser extension to overcome this limitation and to keep 
+the chains synced in the background, which makes your apps faster.
 
-It also provides an interface that enables Dapp developers to effortlessly make use of the light-client functionality in their applications.
+When building an app with substrate connect, it will detect whether the user has
+the extension and use it, or create the WASM light client in-page for them.
 
-### **Multiple building blocks on different levels are necessary to achieve this:**
-
-1. **Ready-to-use Substrate Wasm Light-Clients** to be executed in the browser. They are part of the Substrate framework and with that, available for every Substrate based project. If developers want to generate a light client of their chain, all it takes is just one command to compile a library that contains everything that's needed to run a light client in the browser.
-
-2) A **node module that bundles the light-clients** of different chains. It provides an interface that allows developers to run light nodes of different chains and to add runtimes and genesis configs of their own chain.
-
-The `@substrate/connect` node module will allow developers to include light client functionality into their application by using a predefined interface.
-
-3. For in-browser use, Substrate Connect provides a **Browser Extension** built upon the @substrate/light node module that is running the selected light clients inside the extension so that the end-user doesn't need to fire up a light node in every browser tab. This will also allow the light-node to keep syncing as long as the browser window stays open.
-
-When used in individual projects, the Substrate Connect node module will first check for the installed extension. If available, it will try to connect to the light client running inside the extension. Only if the extension is not installed it will start a light client in the browser tab.
-
+Substrate connect builds on [Polkadot JS](https://polkadot.js.org/docs/api) so
+building an app is the same experience as with using a traditional RPC server
+node.
 
 ## Installation:
 
-This repository is using [yarn workspaces](https://classic.yarnpkg.com/en/docs/workspaces/) for dependency management together with [Lerna](https://lerna.js.org/) to handle releases.
+This repository is using [yarn classic workspaces](https://classic.yarnpkg.com/en/docs/workspaces/).
 
 
 1. Clone the whole `substrate-connect` repository.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Substrate connect builds on [Polkadot JS](https://polkadot.js.org/docs/api) so
 building an app is the same experience as with using a traditional RPC server
 node.
 
+The substrate connect [API documentation is published here](https://paritytech.github.io/substrate-connect/api/).
+
 ## Development
 
 This repository is using [yarn classic workspaces](https://classic.yarnpkg.com/en/docs/workspaces/).
@@ -89,5 +91,3 @@ yarn dev:smoldot-extension
 
 
 ## [Deployments and releases](./DEPLOY-RELEASE.md)
-
-

--- a/README.md
+++ b/README.md
@@ -19,10 +19,16 @@ Substrate connect builds on [Polkadot JS](https://polkadot.js.org/docs/api) so
 building an app is the same experience as with using a traditional RPC server
 node.
 
-## Installation:
+## Development
 
 This repository is using [yarn classic workspaces](https://classic.yarnpkg.com/en/docs/workspaces/).
 
+We are tracking our work and milestones in a [github project](https://github.com/paritytech/substrate-connect/projects/1).
+
+Please see our [contributing guidelines](./CONTRIBUTING.md) for details on how
+we like to work and how to smoothly contribute to the project.
+
+## Getting Started
 
 1. Clone the whole `substrate-connect` repository.
 
@@ -42,10 +48,16 @@ yarn install
 yarn build
 ```
 
-To clean up all workspaces in the repository, run:
+To clean up all build artefacts in workspaces in the repository, run:
 
 ```bash
 yarn clean
+```
+
+To clean up all build artefacts and dependencies in workspaces in the repository, run:
+
+```bash
+yarn deep-clean
 ```
 
 ## Run local version of Burnr wallet


### PR DESCRIPTION
* Add a link to the gh-pages deployed landing page to top of README
* Update README first section so:
  * its much shorter
  * correct now we're using smoldot
  * not marketing blurb (we will have blog posts and presentations for that)
* Add a link to the deployed API documentation from the README
* Add a link to the CONTRIBUTING guidelines from the README
* Move deployment instructions out of README into its own document