### PR TITLE
Remove AppMediator::associate

### DIFF
--- a/projects/extension/src/background/AppMediator.test.ts
+++ b/projects/extension/src/background/AppMediator.test.ts
@@ -23,7 +23,6 @@ beforeEach(() => {
   port = new MockPort('test-app::westend');
   manager = new MockConnectionManager();
   appMed = new AppMediator(port, manager);
-  appMed.associate();
 });
 
 test('Construction parses the port name and gets port information', () => {
@@ -37,9 +36,11 @@ test('Construction parses the port name and gets port information', () => {
 test('Invalid port name sends an error and disconnects', () => {
   port = new MockPort('invalid');
   manager = new MockConnectionManager();
-  appMed = new AppMediator(port, manager);
 
-  expect(appMed.associate()).toBe(false);
+  expect(() => {
+    new AppMediator(port, manager);
+  }).toThrow();
+
   const errorMsg = { 
     type: 'error', 
     payload: 'Invalid port name invalid expected <app_name>::<chain_name>'
@@ -104,7 +105,6 @@ test('Failing to add a chain sends an error and disconnects', async () => {
   port = new MockPort('test-app::westend');
   manager = new ErroringMockConnectionManager();
   appMed = new AppMediator(port, manager);
-  appMed.associate();
 
   port.triggerMessage({ type: 'spec', payload: 'westend'});
   await waitForMessageToBePosted();

--- a/projects/extension/src/background/AppMediator.ts
+++ b/projects/extension/src/background/AppMediator.ts
@@ -31,11 +31,11 @@ export class AppMediator extends (EventEmitter as { new(): StateEmitter }) {
   readonly #name: string;
   readonly #appName: string;
   readonly #port: chrome.runtime.Port;
+  readonly #chainName: string;
   // REM: what to do about the fact these might be undefined?
   readonly #tabId: number | undefined;
   readonly #url: string | undefined;
   readonly #manager: ConnectionManagerInterface;
-  #chainName: string | undefined  = undefined;
   #chain: SmoldotChain | undefined;
   #state: AppState = 'connected';
   #pendingRequests: string[] = [];
@@ -45,10 +45,23 @@ export class AppMediator extends (EventEmitter as { new(): StateEmitter }) {
    * and the extension background.
    * @param manager - the extension's connection manager that keeps track of
    * all the apps and smoldots
+   * 
+   * @throws an error if the port name is not valid, in which case an error is
+   * sent on the port and the port gets disconnected
    */
   constructor(port: chrome.runtime.Port, manager: ConnectionManagerInterface) {
     super();
-    this.#appName = port.name.substr(0, port.name.indexOf('::'));
+
+    const splitIdx = port.name.indexOf('::');
+    if (splitIdx === -1) {
+      const error: MessageFromManager = { type: 'error', payload: `Invalid port name ${port.name} expected <app_name>::<chain_name>` };
+      port.postMessage(error);
+      port.disconnect();
+      throw new Error();
+    }
+
+    this.#appName = port.name.substr(0, splitIdx);
+    this.#chainName = port.name.substr(splitIdx + 2, port.name.length);
     this.#name = port.name;
     this.#port = port;
     this.#tabId = port.sender?.tab?.id;
@@ -57,27 +70,6 @@ export class AppMediator extends (EventEmitter as { new(): StateEmitter }) {
     // Open listeners for the incoming rpc messages
     this.#port.onMessage.addListener(this.#handleMessage);
     this.#port.onDisconnect.addListener(() => { this.#handleDisconnect() });
-  }
-
-  /** 
-   * associate parses the name of the network from the port name.
-   * It sends an error and disconnects the port if the port name is not in a
-   * valid format.
-   *
-   * @remarks
-   * This MUST be called straight after constructing an AppMediator
-   *
-   * @returns true if it associated succesfully otherwise false
-   */
-  public associate(): boolean {
-    const splitIdx = this.#port.name.indexOf('::');
-    if (splitIdx === -1) {
-      this.#sendError(`Invalid port name ${this.#port.name} expected <app_name>::<chain_name>`);
-      this.#port.disconnect();
-      return false;
-    }
-    this.#chainName = this.#port.name.substr(splitIdx + 2, this.#port.name.length);
-    return true;
   }
 
   /** 

--- a/projects/extension/src/background/AppMediator.ts
+++ b/projects/extension/src/background/AppMediator.ts
@@ -54,10 +54,11 @@ export class AppMediator extends (EventEmitter as { new(): StateEmitter }) {
 
     const splitIdx = port.name.indexOf('::');
     if (splitIdx === -1) {
-      const error: MessageFromManager = { type: 'error', payload: `Invalid port name ${port.name} expected <app_name>::<chain_name>` };
+      const payload = `Invalid port name ${port.name} expected <app_name>::<chain_name>`;
+      const error: MessageFromManager = { type: 'error', payload };
       port.postMessage(error);
       port.disconnect();
-      throw new Error();
+      throw new Error(payload);
     }
 
     this.#appName = port.name.substr(0, splitIdx);

--- a/projects/extension/src/background/AppMediator.ts
+++ b/projects/extension/src/background/AppMediator.ts
@@ -156,7 +156,7 @@ export class AppMediator extends (EventEmitter as { new(): StateEmitter }) {
       return;
     }
 
-    const chainName = this.#chainName as string;
+    const chainName = this.#chainName ;
 
     if (msg.type === 'spec' && chainName) {
       return this.#handleSpecMessage(msg, chainName);

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -22,7 +22,7 @@ const l = logger('Extension Connection Manager');
 export class ConnectionManager extends (EventEmitter as { new(): StateEmitter }) implements ConnectionManagerInterface {
   #client: smoldot.SmoldotClient | undefined = undefined;
   readonly #networks: Network[] = [];
-  readonly #apps:  AppMediator[] = [];
+  readonly #apps: AppMediator[] = [];
   smoldotLogLevel = 3;
 
   /** registeredApps
@@ -117,12 +117,12 @@ export class ConnectionManager extends (EventEmitter as { new(): StateEmitter })
       port.postMessage({ type: 'error', payload: `App ${port.name} already exists.` });
       port.disconnect();
       return;
-    } 
+    }
 
-    const app = new AppMediator(port, this as ConnectionManagerInterface)
-    // if associate fails by returning false it has sent an error down the
-    // port and disconnected it, so we should just discard this `AppMediator`
-    if (app.associate()) {
+    // if create an `AppMediator` throws, it has sent an error down the
+    // port and disconnected it, so we should just ignore
+    try {
+      const app = new AppMediator(port, this as ConnectionManagerInterface);
       this.registerApp(app);
       const appInfo = port.name.split('::');
       chrome.storage.sync.get('notifications', (s) => {
@@ -133,7 +133,7 @@ export class ConnectionManager extends (EventEmitter as { new(): StateEmitter })
           type: 'basic'
         });
       });
-    }
+    } finally { }
   }
 
   /**
@@ -171,7 +171,7 @@ export class ConnectionManager extends (EventEmitter as { new(): StateEmitter })
    */
   async initSmoldot(): Promise<void> {
     try {
-      this.#client = await (smoldot as any).start({ 
+      this.#client = await (smoldot as any).start({
         forbidWs: true, /* suppress console warnings about insecure connections */
         maxLogLevel: this.smoldotLogLevel
       });
@@ -188,7 +188,7 @@ export class ConnectionManager extends (EventEmitter as { new(): StateEmitter })
    * @param jsonRpcCallback - The jsonRpcCallback function that should be triggered
    * @param relayChainName - optional string when parachain is added to depict the relay chain name
    */
-  async addChain (name: string, chainSpec: string, jsonRpcCallback: smoldot.SmoldotJsonRpcCallback, relayChainName?: string): Promise<smoldot.SmoldotChain> {
+  async addChain(name: string, chainSpec: string, jsonRpcCallback: smoldot.SmoldotJsonRpcCallback, relayChainName?: string): Promise<smoldot.SmoldotChain> {
     if (!this.#client) {
       throw new Error('Smoldot client does not exist.');
     }

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -133,7 +133,9 @@ export class ConnectionManager extends (EventEmitter as { new(): StateEmitter })
           type: 'basic'
         });
       });
-    } finally { }
+    } finally {
+      /* eslint-disable no-empty */
+    }
   }
 
   /**

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -133,8 +133,8 @@ export class ConnectionManager extends (EventEmitter as { new(): StateEmitter })
           type: 'basic'
         });
       });
-    } finally {
-      /* eslint-disable no-empty */
+    } catch (error) {
+      l.error(`Error while adding chain: ${error}`);
     }
   }
 


### PR DESCRIPTION
Instead of doing `const app = new AppMediator(...)` followed with `app.associate()`, this PR merges these two functions into one.
In other words, the constructor implicitly calls what used to be `associate()`, and throws if `associate()` fails.