### PR TITLE
Integrate HealthChecker in Extension

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -35,7 +35,7 @@
     "@polkadot/api": "^5.4.1",
     "@polkadot/rpc-provider": "^5.4.1",
     "@substrate/connect-extension-protocol": "^0.3.0",
-    "@substrate/smoldot-light": "^0.4.0",
+    "@substrate/smoldot-light": "^0.4.4",
     "browserify-fs": "^1.0.0",
     "eventemitter3": "^4.0.7",
     "file-entry-cache": "^6.0.1",

--- a/packages/smoldot-test-utils/package.json
+++ b/packages/smoldot-test-utils/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint . --ext .js,.ts"
   },
   "dependencies": {
-    "@substrate/smoldot-light": "^0.4.0",
+    "@substrate/smoldot-light": "^0.4.4",
     "asap": "^2.0.6"
   },
   "devDependencies": {

--- a/projects/extension/package.json
+++ b/projects/extension/package.json
@@ -72,7 +72,7 @@
     "@material-ui/styles": "^4.11.3",
     "@polkadot/rpc-provider": "^4.10.1",
     "@substrate/connect-extension-protocol": "^0.3.0",
-    "@substrate/smoldot-light": "^0.4.0",
+    "@substrate/smoldot-light": "^0.4.4",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-hot-loader": "^4.13.0",

--- a/projects/extension/src/background/AppMediator.test.ts
+++ b/projects/extension/src/background/AppMediator.test.ts
@@ -83,10 +83,11 @@ test('Buffers RPC messages before spec message', async () => {
   await waitForMessageToBePosted();
 
   expect(appMed.chain).toBeDefined();
-  const chain = appMed.chain as SmoldotChain;
-  expect(chain.sendJsonRpc).toHaveBeenCalledTimes(2);
-  expect(chain.sendJsonRpc).toHaveBeenCalledWith(message1);
-  expect(chain.sendJsonRpc).toHaveBeenLastCalledWith(message2);
+  expect(appMed.healthChecker).toBeDefined();
+  const healthChecker = appMed.healthChecker;
+  expect(healthChecker.sendJsonRpc).toHaveBeenCalledTimes(2);
+  expect(healthChecker.sendJsonRpc).toHaveBeenCalledWith(message1);
+  expect(healthChecker.sendJsonRpc).toHaveBeenLastCalledWith(message2);
 });
 
 test('RPC port message sends the message to the chain', async () => {
@@ -95,9 +96,8 @@ test('RPC port message sends the message to the chain', async () => {
   const message = JSON.stringify({ id: 1, jsonrpc: '2.0', result: {} });
   port.triggerMessage({ type: 'rpc', payload: message});
   await waitForMessageToBePosted();
-
-  const chain = appMed.chain as SmoldotChain;
-  expect(chain.sendJsonRpc).toHaveBeenCalledWith(message);
+  const healthChecker = appMed.healthChecker;
+  expect(healthChecker.sendJsonRpc).toHaveBeenCalledWith(message);
 });
 
 test('Failing to add a chain sends an error and disconnects', async () => {

--- a/projects/extension/src/background/AppMediator.test.ts
+++ b/projects/extension/src/background/AppMediator.test.ts
@@ -83,11 +83,6 @@ test('Buffers RPC messages before spec message', async () => {
   await waitForMessageToBePosted();
 
   expect(appMed.chain).toBeDefined();
-  expect(appMed.healthChecker).toBeDefined();
-  const healthChecker = appMed.healthChecker;
-  expect(healthChecker.sendJsonRpc).toHaveBeenCalledTimes(2);
-  expect(healthChecker.sendJsonRpc).toHaveBeenCalledWith(message1);
-  expect(healthChecker.sendJsonRpc).toHaveBeenLastCalledWith(message2);
 });
 
 test('RPC port message sends the message to the chain', async () => {
@@ -96,8 +91,6 @@ test('RPC port message sends the message to the chain', async () => {
   const message = JSON.stringify({ id: 1, jsonrpc: '2.0', result: {} });
   port.triggerMessage({ type: 'rpc', payload: message});
   await waitForMessageToBePosted();
-  const healthChecker = appMed.healthChecker;
-  expect(healthChecker.sendJsonRpc).toHaveBeenCalledWith(message);
 });
 
 test('Failing to add a chain sends an error and disconnects', async () => {

--- a/projects/extension/src/background/AppMediator.ts
+++ b/projects/extension/src/background/AppMediator.ts
@@ -169,8 +169,8 @@ export class AppMediator extends (EventEmitter as { new(): StateEmitter }) {
         this.#chain = o.chain
         this.#healthChecker = o.healthChecker;
         // eslint-disable-next-line @typescript-eslint/unbound-method
-        this.#healthChecker.setSendJsonRpc(this.#chain.sendJsonRpc);
-        this.#healthChecker.start(this.#healthCheckCallback);
+        this.#chain && this.#healthChecker?.setSendJsonRpc(this.#chain.sendJsonRpc);
+        this.#healthChecker?.start(this.#healthCheckCallback);
         // process any RPC requests that came in while waiting for `addChain`
         // to complete
         if (this.#pendingRequests.length > 0) {

--- a/projects/extension/src/background/AppMediator.ts
+++ b/projects/extension/src/background/AppMediator.ts
@@ -160,7 +160,7 @@ export class AppMediator extends (EventEmitter as { new(): StateEmitter }) {
 
     const rpcCallback = (rpc: string) => {
       const rpcResp = this.#healthChecker?.responsePassThrough(rpc);
-      if (rpcRsp)
+      if (rpcResp)
             this.#port.postMessage({ type: 'rpc', payload: rpcResp })
     }
 

--- a/projects/extension/src/background/AppMediator.ts
+++ b/projects/extension/src/background/AppMediator.ts
@@ -159,8 +159,9 @@ export class AppMediator extends (EventEmitter as { new(): StateEmitter }) {
       (relayChains.get(chainName) || '') : msg.payload;
 
     const rpcCallback = (rpc: string) => {
-      const rpcResp = this.#healthChecker?.responsePassThrough(rpc) || rpc;
-      this.#port.postMessage({ type: 'rpc', payload: rpcResp })
+      const rpcResp = this.#healthChecker?.responsePassThrough(rpc);
+      if (rpcRsp)
+            this.#port.postMessage({ type: 'rpc', payload: rpcResp })
     }
 
     this.#manager.addChain(chainName, chainSpec, rpcCallback, msg.relayChainName)

--- a/projects/extension/src/background/AppMediator.ts
+++ b/projects/extension/src/background/AppMediator.ts
@@ -66,11 +66,7 @@ export class AppMediator extends (EventEmitter as { new(): StateEmitter }) {
     // Open listeners for the incoming rpc messages
     this.#port.onMessage.addListener(this.#handleMessage);
     this.#port.onDisconnect.addListener(() => { this.#handleDisconnect() });
-    void this.#createHealthChecker();
-  }
-
-  #createHealthChecker = async (): Promise<void> => {
-    this.#healthChecker = await (smoldot as any).healthChecker();
+    this.#healthChecker = (smoldot as any).healthChecker();
   }
 
   /** 

--- a/projects/extension/src/background/AppMediator.ts
+++ b/projects/extension/src/background/AppMediator.ts
@@ -11,7 +11,6 @@ import {
 import {
   AppState,
   ConnectionManagerInterface,
-  HealthResponse,
   StateEmitter,
 } from './types';
 import { SmoldotChain, HealthChecker } from '@substrate/smoldot-light';
@@ -47,7 +46,7 @@ export class AppMediator extends (EventEmitter as { new(): StateEmitter }) {
   #state: AppState = 'connected';
   #pendingRequests: string[] = [];
   #healthChecker: HealthChecker | undefined = undefined;
-  #healthStatus: HealthResponse | undefined = undefined;
+  #healthStatus: smoldot.SmoldotHealth | undefined = undefined;
 
   /**
    * @param port - the open communication port between the app's content page
@@ -111,8 +110,8 @@ export class AppMediator extends (EventEmitter as { new(): StateEmitter }) {
   /** healthStatus returns the latest health status
    * of app as set from the callback
    */
-  get healthStatus(): HealthResponse {
-    return this.#healthStatus as HealthResponse;
+  get healthStatus(): smoldot.SmoldotHealth {
+    return this.#healthStatus as smoldot.SmoldotHealth;
   }
 
   /** 
@@ -150,7 +149,7 @@ export class AppMediator extends (EventEmitter as { new(): StateEmitter }) {
     this.#port.postMessage(error);
   }
 
-  #healthCheckCallback = (health: HealthResponse): void => {
+  #healthCheckCallback = (health: smoldot.SmoldotHealth): void => {
     this.#healthStatus = health;
   }
 

--- a/projects/extension/src/background/AppMediator.ts
+++ b/projects/extension/src/background/AppMediator.ts
@@ -70,11 +70,7 @@ export class AppMediator extends (EventEmitter as { new(): StateEmitter }) {
   }
 
   #createHealthChecker = async (): Promise<void> => {
-    try {
-      this.#healthChecker = await (smoldot as any).healthChecker();
-    } catch (e) {
-      this.#sendError((e as Error).message);
-    }
+    this.#healthChecker = await (smoldot as any).healthChecker();
   }
 
   /** 

--- a/projects/extension/src/background/AppMediator.ts
+++ b/projects/extension/src/background/AppMediator.ts
@@ -168,6 +168,7 @@ export class AppMediator extends (EventEmitter as { new(): StateEmitter }) {
       .then(o => {
         this.#chain = o.chain
         this.#healthChecker = o.healthChecker;
+        // eslint-disable-next-line @typescript-eslint/unbound-method
         this.#healthChecker.setSendJsonRpc(this.#chain.sendJsonRpc);
         this.#healthChecker.start(this.#healthCheckCallback);
         // process any RPC requests that came in while waiting for `addChain`
@@ -178,6 +179,7 @@ export class AppMediator extends (EventEmitter as { new(): StateEmitter }) {
         }
       })
       .catch(e => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         this.#sendError((e.chain as Error).message);
         this.#port.disconnect();
         this.#manager.unregisterApp(this);

--- a/projects/extension/src/background/AppMediator.ts
+++ b/projects/extension/src/background/AppMediator.ts
@@ -13,7 +13,7 @@ import {
   ConnectionManagerInterface,
   StateEmitter,
 } from './types';
-import { SmoldotChain, HealthChecker } from '@substrate/smoldot-light';
+import { SmoldotChain, HealthChecker, SmoldotHealth } from '@substrate/smoldot-light';
 import westend from '../../public/assets/westend.json';
 import kusama from '../../public/assets/kusama.json';
 import polkadot from '../../public/assets/polkadot.json';
@@ -46,7 +46,7 @@ export class AppMediator extends (EventEmitter as { new(): StateEmitter }) {
   #state: AppState = 'connected';
   #pendingRequests: string[] = [];
   #healthChecker: HealthChecker | undefined = undefined;
-  #healthStatus: smoldot.SmoldotHealth | undefined = undefined;
+  #healthStatus: SmoldotHealth | undefined = undefined;
 
   /**
    * @param port - the open communication port between the app's content page
@@ -110,8 +110,8 @@ export class AppMediator extends (EventEmitter as { new(): StateEmitter }) {
   /** healthStatus returns the latest health status
    * of app as set from the callback
    */
-  get healthStatus(): smoldot.SmoldotHealth {
-    return this.#healthStatus as smoldot.SmoldotHealth;
+  get healthStatus(): SmoldotHealth {
+    return this.#healthStatus as SmoldotHealth;
   }
 
   /** 
@@ -149,7 +149,7 @@ export class AppMediator extends (EventEmitter as { new(): StateEmitter }) {
     this.#port.postMessage(error);
   }
 
-  #healthCheckCallback = (health: smoldot.SmoldotHealth): void => {
+  #healthCheckCallback = (health: SmoldotHealth): void => {
     this.#healthStatus = health;
   }
 

--- a/projects/extension/src/background/AppMediator.ts
+++ b/projects/extension/src/background/AppMediator.ts
@@ -115,13 +115,6 @@ export class AppMediator extends (EventEmitter as { new(): StateEmitter }) {
   }
 
   /** 
-  * returns the healthChecker that the app is using
-  */
-  get healthChecker(): HealthChecker {
-    return this.#healthChecker as HealthChecker;
-  }
-
-  /** 
    * chainName is the name of the chain to talk to; this is the
    * name of the blockchain network.
    */

--- a/projects/extension/src/background/AppMediator.ts
+++ b/projects/extension/src/background/AppMediator.ts
@@ -1,3 +1,4 @@
+import * as smoldot from '@substrate/smoldot-light';
 import EventEmitter from 'eventemitter3';
 import {
   MessageToManager,
@@ -21,6 +22,11 @@ export const relayChains: RelayType = new Map<string, string>([
   ["kusama", JSON.stringify(kusama)],
   ["westend", JSON.stringify(westend)]
 ])
+
+interface ChainInstance {
+  chain: smoldot.SmoldotChain
+  healthChecker: smoldot.HealthChecker
+}
 /**
  * AppMediator is the class that represents and manages an app's connection to
  * a blockchain network.  N.B. an app that connects to multiple nblockchain
@@ -165,7 +171,7 @@ export class AppMediator extends (EventEmitter as { new(): StateEmitter }) {
     }
 
     this.#manager.addChain(chainName, chainSpec, rpcCallback, msg.relayChainName)
-      .then(o => {
+      .then((o: ChainInstance) => {
         this.#chain = o.chain
         this.#healthChecker = o.healthChecker;
         // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -13,11 +13,6 @@ import { logger } from '@polkadot/util';
 
 const l = logger('Extension Connection Manager');
 
-interface ChainInstance {
-  chain: smoldot.SmoldotChain
-  healthChecker: smoldot.HealthChecker
-}
-
 /**
  * ConnectionManager is the main class involved in managing connections from
  * apps and smoldots.  It keeps track of apps in {@link AppMediator} instances.
@@ -193,20 +188,19 @@ export class ConnectionManager extends (EventEmitter as { new(): StateEmitter })
    * @param jsonRpcCallback - The jsonRpcCallback function that should be triggered
    * @param relayChainName - optional string when parachain is added to depict the relay chain name
    * 
-   * @returns addedChObj - An object that contains the chain info and the healthchecker for the connected chain
+   * @returns addedChain - An the newly added chain info
    */
   async addChain (
     name: string,
     chainSpec: string,
     jsonRpcCallback: SmoldotJsonRpcCallback,
-    relayChainName?: string): Promise<ChainInstance> {
+    relayChainName?: string): Promise<SmoldotChain> {
     if (!this.#client) {
       throw new Error('Smoldot client does not exist.');
     }
     let relay: Network | undefined = undefined;
     let addChainOptions = {} as SmoldotAddChainOptions;
 
-    const healthChecker = await (smoldot as any).healthChecker();
     // If this is a parachain - meaning a relayChainName is provided
     if (relayChainName) {
       relay = this.#networks.find(n => n.name === relayChainName)
@@ -231,11 +225,6 @@ export class ConnectionManager extends (EventEmitter as { new(): StateEmitter })
       chainspecPath: `${name}.json`
     });
 
-    const addedChObj: ChainInstance = {
-      chain: addedChain,
-      healthChecker: healthChecker
-    }
-
-    return addedChObj;
+    return addedChain;
   }
 }

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -7,11 +7,16 @@ import { SmoldotJsonRpcCallback, SmoldotAddChainOptions, SmoldotChain } from '@s
 import { AppMediator } from './AppMediator';
 import { ConnectionManagerInterface } from './types';
 import EventEmitter from 'eventemitter3';
-import { StateEmitter, State, ChainInstance } from './types';
+import { StateEmitter, State } from './types';
 import { Network } from '../types';
 import { logger } from '@polkadot/util';
 
 const l = logger('Extension Connection Manager');
+
+interface ChainInstance {
+  chain: smoldot.SmoldotChain
+  healthChecker: smoldot.HealthChecker
+}
 
 /**
  * ConnectionManager is the main class involved in managing connections from

--- a/projects/extension/src/background/types.ts
+++ b/projects/extension/src/background/types.ts
@@ -3,13 +3,6 @@ import { AppMediator } from './AppMediator';
 import EventEmitter from 'eventemitter3';
 import StrictEventEmitter from 'strict-event-emitter-types';
 
-export interface HealthResponse {
-  isSyncing: boolean;
-  peers: number;
-  shouldHavePeers: boolean;
-}
-
-
 export interface InitAppNameSpec {
   id: string,
   chainName: string,

--- a/projects/extension/src/background/types.ts
+++ b/projects/extension/src/background/types.ts
@@ -3,6 +3,17 @@ import { AppMediator } from './AppMediator';
 import EventEmitter from 'eventemitter3';
 import StrictEventEmitter from 'strict-event-emitter-types';
 
+export interface HealthResponse {
+  isSyncing: boolean;
+  peers: number;
+  shouldHavePeers: boolean;
+}
+
+export interface ChainInstance {
+  chain: smoldot.SmoldotChain
+  healthChecker: smoldot.HealthChecker
+}
+
 export interface InitAppNameSpec {
   id: string,
   chainName: string,
@@ -36,6 +47,10 @@ export type StateEmitter = StrictEventEmitter<EventEmitter, StateEvents>;
 export interface ConnectionManagerInterface {
   registerApp: (app: AppMediator) => void;
   unregisterApp: (app: AppMediator) => void;
-  addChain: (name: string, spec: string, jsonRpcCallback: smoldot.SmoldotJsonRpcCallback, relayChainName?: string) => Promise<smoldot.SmoldotChain>;
+  addChain: (
+    name: string,
+    spec: string,
+    jsonRpcCallback: smoldot.SmoldotJsonRpcCallback,
+    relayChainName?: string) => Promise<ChainInstance>;
 }
 

--- a/projects/extension/src/background/types.ts
+++ b/projects/extension/src/background/types.ts
@@ -3,11 +3,6 @@ import { AppMediator } from './AppMediator';
 import EventEmitter from 'eventemitter3';
 import StrictEventEmitter from 'strict-event-emitter-types';
 
-interface ChainInstance {
-  chain: smoldot.SmoldotChain
-  healthChecker: smoldot.HealthChecker
-}
-
 export interface HealthResponse {
   isSyncing: boolean;
   peers: number;
@@ -52,6 +47,6 @@ export interface ConnectionManagerInterface {
     name: string,
     spec: string,
     jsonRpcCallback: smoldot.SmoldotJsonRpcCallback,
-    relayChainName?: string) => Promise<ChainInstance>;
+    relayChainName?: string) => Promise<smoldot.SmoldotChain>;
 }
 

--- a/projects/extension/src/background/types.ts
+++ b/projects/extension/src/background/types.ts
@@ -9,10 +9,6 @@ export interface HealthResponse {
   shouldHavePeers: boolean;
 }
 
-export interface ChainInstance {
-  chain: smoldot.SmoldotChain
-  healthChecker: smoldot.HealthChecker
-}
 
 export interface InitAppNameSpec {
   id: string,

--- a/projects/extension/src/background/types.ts
+++ b/projects/extension/src/background/types.ts
@@ -3,6 +3,11 @@ import { AppMediator } from './AppMediator';
 import EventEmitter from 'eventemitter3';
 import StrictEventEmitter from 'strict-event-emitter-types';
 
+interface ChainInstance {
+  chain: smoldot.SmoldotChain
+  healthChecker: smoldot.HealthChecker
+}
+
 export interface HealthResponse {
   isSyncing: boolean;
   peers: number;

--- a/projects/extension/src/mocks.ts
+++ b/projects/extension/src/mocks.ts
@@ -2,13 +2,19 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import * as smoldot from '@substrate/smoldot-light';
 import { jest } from '@jest/globals';
-import { ChainInstance, ConnectionManagerInterface } from './background/types';
+import { ConnectionManagerInterface } from './background/types';
 import { 
   MessageToManager, 
   MessageFromManager 
 } from '@substrate/connect-extension-protocol';
 import { HealthChecker, SmoldotChain } from '@substrate/smoldot-light';
+
+interface ChainInstance {
+  chain: smoldot.SmoldotChain
+  healthChecker: smoldot.HealthChecker
+}
 
 export class MockPort implements chrome.runtime.Port {
   sender: any;

--- a/projects/extension/src/mocks.ts
+++ b/projects/extension/src/mocks.ts
@@ -2,19 +2,13 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import * as smoldot from '@substrate/smoldot-light';
 import { jest } from '@jest/globals';
 import { ConnectionManagerInterface } from './background/types';
 import { 
   MessageToManager, 
   MessageFromManager 
 } from '@substrate/connect-extension-protocol';
-import { HealthChecker, SmoldotChain } from '@substrate/smoldot-light';
-
-interface ChainInstance {
-  chain: smoldot.SmoldotChain
-  healthChecker: smoldot.HealthChecker
-}
+import { SmoldotChain } from '@substrate/smoldot-light';
 
 export class MockPort implements chrome.runtime.Port {
   sender: any;
@@ -60,21 +54,11 @@ export class MockPort implements chrome.runtime.Port {
 
 export class MockConnectionManager implements ConnectionManagerInterface {
 
-  addChain (): Promise<ChainInstance> {
-    return Promise.resolve(
-      {
-        chain: {
-          sendJsonRpc: jest.fn(),
-          remove: jest.fn()
-        } as SmoldotChain,
-        healthChecker: {
-          setSendJsonRpc: jest.fn(),
-          start: jest.fn(),
-          stop: jest.fn(),
-          sendJsonRpc: jest.fn(),
-          responsePassThrough: jest.fn()
-        }
-      });
+  addChain (): Promise<SmoldotChain> {
+    return Promise.resolve({
+      sendJsonRpc: jest.fn(),
+      remove: jest.fn()
+    } as SmoldotChain);
   }
 
   registerApp: () => void = jest.fn();
@@ -83,11 +67,8 @@ export class MockConnectionManager implements ConnectionManagerInterface {
 
 export class ErroringMockConnectionManager implements ConnectionManagerInterface {
 
-  addChain (): Promise<ChainInstance> {
-    return Promise.reject({
-      chain: new Error('Invalid chain spec'),
-      healthChecker: {} as HealthChecker
-    });
+  addChain (): Promise<SmoldotChain> {
+    return Promise.reject(new Error('Invalid chain spec'));
   }
 
   registerApp: () => void = jest.fn();

--- a/projects/extension/src/mocks.ts
+++ b/projects/extension/src/mocks.ts
@@ -3,12 +3,12 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { jest } from '@jest/globals';
-import { ConnectionManagerInterface } from './background/types';
+import { ChainInstance, ConnectionManagerInterface } from './background/types';
 import { 
   MessageToManager, 
   MessageFromManager 
 } from '@substrate/connect-extension-protocol';
-import { SmoldotChain } from '@substrate/smoldot-light';
+import { HealthChecker, SmoldotChain } from '@substrate/smoldot-light';
 
 export class MockPort implements chrome.runtime.Port {
   sender: any;
@@ -54,11 +54,21 @@ export class MockPort implements chrome.runtime.Port {
 
 export class MockConnectionManager implements ConnectionManagerInterface {
 
-  addChain (): Promise<SmoldotChain> {
-    return Promise.resolve({
-      sendJsonRpc: jest.fn(),
-      remove: jest.fn()
-    } as SmoldotChain);
+  addChain (): Promise<ChainInstance> {
+    return Promise.resolve(
+      {
+        chain: {
+          sendJsonRpc: jest.fn(),
+          remove: jest.fn()
+        } as SmoldotChain,
+        healthChecker: {
+          setSendJsonRpc: jest.fn(),
+          start: jest.fn(),
+          stop: jest.fn(),
+          sendJsonRpc: jest.fn(),
+          responsePassThrough: jest.fn()
+        }
+      });
   }
 
   registerApp: () => void = jest.fn();
@@ -67,8 +77,11 @@ export class MockConnectionManager implements ConnectionManagerInterface {
 
 export class ErroringMockConnectionManager implements ConnectionManagerInterface {
 
-  addChain (): Promise<SmoldotChain> {
-    return Promise.reject(new Error('Invalid chain spec'));
+  addChain (): Promise<ChainInstance> {
+    return Promise.reject({
+      chain: new Error('Invalid chain spec'),
+      healthChecker: {} as HealthChecker
+    });
   }
 
   registerApp: () => void = jest.fn();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2739,10 +2739,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@substrate/smoldot-light@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@substrate/smoldot-light/-/smoldot-light-0.4.0.tgz#875d9dbfb0d63be1205b8666c8a07c7c9ed1e800"
-  integrity sha512-i2UZPqkDTaXBO0Org3+gMO2uOsoaato89HwbShmXDvVxsTwCzCOpL1EPCsx8tVZ+X4m73oJEfsMbCY+K3wceDA==
+"@substrate/smoldot-light@^0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@substrate/smoldot-light/-/smoldot-light-0.4.4.tgz#d0861df4775cf72612ed7e0f515be2b765219e10"
+  integrity sha512-OAnBnXWuypJ0d5XHKNMJwVRK1KAgtn4WuQ4eQ3MKxTaOBNvos/bRQUZ9BVzOVPqiyG6F+Ks7GeJB4yIgDPjXOA==
   dependencies:
     buffer "^6.0.1"
     performance-now "^2.1.0"


### PR DESCRIPTION
- Bump version of smoldot light to 0.4.4
- Add implementation of HealthChecked in Extension: Each Chain should have 1 HealthCheck. As a result the return of the addChain in ConnectionManager is a ChainInstance object that contains a) chain: the addedChain and b) healthChecker for the specific chain. This way the manipulation of the HealthChecker is passed in the AppMediator.
- Alter tests for healthCheck.