### PR TITLE
Remove sending the relay chain name to the extension

### DIFF
--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -107,8 +107,6 @@ export interface MessageToManager {
   type: 'rpc' | 'spec';
   /** Payload of the message -  a JSON encoded RPC request **/
   payload: string;
-  /** The name of the relay chain - if provided then the chain is a parachain  **/
-  relayChainName?: string;
 }
 
 /**

--- a/packages/connect/src/Detector.ts
+++ b/packages/connect/src/Detector.ts
@@ -115,14 +115,10 @@ export class Detector {
    */
   public connect = async (relay: ChainInfo | string, parachain?: ChainInfo, options?: ApiOptions): Promise<ApiPromise> => {
     const chain: ChainInfo | string = parachain || relay;
-    let relayName = "";
-    if (parachain) {
-      relayName = this.getChainName(relay);
-    }
 
     const provider: ProviderInterface = typeof chain === 'string' ?
-      this.provider(chain, undefined, parachain && relayName) :
-      this.provider(chain.name, chain.spec, parachain && relayName);
+      this.provider(chain, undefined) :
+      this.provider(chain.name, chain.spec);
 
     provider.connect().catch(console.error);
 
@@ -147,8 +143,6 @@ export class Detector {
    * 
    * @param chainName - the name of the blockchain network to connect to
    * @param chainSpec - an optional chainSpec to connect to a different network
-   * @param relayChainName - an optional param of the relay chain name that (in case of parachain)
-   * the parachain will connect to
    * @returns a provider will be used in a ApiPromise create for PolkadotJS API
    *
    * @internal
@@ -156,7 +150,7 @@ export class Detector {
    * @remarks 
    * This is used internally for advanced PolkadotJS use cases and is not supported.  Use {@link connect} instead.
    */
-  public provider = (chainName: string, chainSpec?: string, relayChainName?: string): ProviderInterface => {
+  public provider = (chainName: string, chainSpec?: string): ProviderInterface => {
     let provider: ProviderInterface = {} as ProviderInterface;
 
     if (!chainSpec && !Object.keys(this.#chainSpecs).includes(chainName)) {
@@ -164,7 +158,7 @@ export class Detector {
     }
     
     if (this.#isExtension) {
-      provider = new ExtensionProvider(this.#name, chainName, chainSpec, relayChainName) as ProviderInterface;
+      provider = new ExtensionProvider(this.#name, chainName, chainSpec) as ProviderInterface;
     } else if (!this.#isExtension) {
       const spec = JSON.stringify(this.#chainSpecs[chainName]);
       provider = new SmoldotProvider(spec);

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -49,7 +49,6 @@ test('connected and sends correct spec message', async () => {
     origin: 'extension-provider',
     message: {
       payload: "",
-      relayChainName: "",
       type: "spec"
     }  
   };
@@ -59,7 +58,7 @@ test('connected and sends correct spec message', async () => {
 });
 
 test('constructor sets properties for parachain', () => {
-  const ep = new ExtensionProvider('test', 'westmint', 'westmint-specs', 'westend');
+  const ep = new ExtensionProvider('test', 'westmint', 'westmint-specs');
   expect(ep.name).toBe('test');
   expect(ep.chainName).toBe('westmint');
   expect(ep.chainSpecs).toBe('westmint-specs');
@@ -67,7 +66,7 @@ test('constructor sets properties for parachain', () => {
 });
 
 test('connected parachain sends correct spec message', async () => {
-  const ep = new ExtensionProvider('test', 'westmint', 'westmint-specs', 'westend');
+  const ep = new ExtensionProvider('test', 'westmint', 'westmint-specs');
   const emitted = jest.fn();
   ep.on('connected', emitted);
   await ep.connect();
@@ -80,7 +79,6 @@ test('connected parachain sends correct spec message', async () => {
     origin: 'extension-provider',
     message: {
       payload: "westmint-specs",
-      relayChainName: "westend",
       type: "spec"
     }  
   };

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
@@ -77,18 +77,16 @@ export class ExtensionProvider implements ProviderInterface {
   #appName: string;
   #chainName: string;
   #chainSpecs: string;
-  #relayChainName: string;
 
   /*
    * How frequently to see if we have any peers
    */
   healthPingerInterval = CONNECTION_STATE_PINGER_INTERVAL;
 
-  public constructor(appName: string, chainName: string, chainSpecs?: string, relayChainName?: string) {
+  public constructor(appName: string, chainName: string, chainSpecs?: string) {
     this.#appName = appName;
     this.#chainName = chainName;
     this.#chainSpecs = chainSpecs || '';
-    this.#relayChainName = relayChainName || '';
     this.#connectionStatePingerId = null;
   }
 
@@ -121,15 +119,6 @@ export class ExtensionProvider implements ProviderInterface {
   */
   public get chainSpecs(): string {
     return this.#chainSpecs;
-  }
-
-  /**
-  * chainName
-  *
-  * @returns the name of the chain this `ExtensionProvider` is talking to.
-  */
-  public get relayChainName(): string {
-    return this.#relayChainName;
   }
 
   /**
@@ -317,7 +306,6 @@ export class ExtensionProvider implements ProviderInterface {
       message: {
         type: 'spec',
         payload: this.#chainSpecs || '',
-        relayChainName: this.#relayChainName,
       }
     }
 

--- a/projects/extension/src/background/AppMediator.ts
+++ b/projects/extension/src/background/AppMediator.ts
@@ -141,7 +141,7 @@ export class AppMediator extends (EventEmitter as { new(): StateEmitter }) {
       this.#port.postMessage({ type: 'rpc', payload: rpc })
     }
 
-    this.#manager.addChain(chainName, chainSpec, rpcCallback, msg.relayChainName)
+    this.#manager.addChain(chainName, chainSpec, rpcCallback)
       .then(chain => {
         this.#chain = chain;
         // process any RPC requests that came in while waiting for `addChain`

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -186,30 +186,19 @@ export class ConnectionManager extends (EventEmitter as { new(): StateEmitter })
    * @param name - Name of the chain
    * @param spec - ChainSpec of chain to be added
    * @param jsonRpcCallback - The jsonRpcCallback function that should be triggered
-   * @param relayChainName - optional string when parachain is added to depict the relay chain name
    */
-  async addChain (name: string, chainSpec: string, jsonRpcCallback: smoldot.SmoldotJsonRpcCallback, relayChainName?: string): Promise<smoldot.SmoldotChain> {
+  async addChain (name: string, chainSpec: string, jsonRpcCallback: smoldot.SmoldotJsonRpcCallback): Promise<smoldot.SmoldotChain> {
     if (!this.#client) {
       throw new Error('Smoldot client does not exist.');
     }
     let relay: Network | undefined = undefined;
     let addChainOptions = {} as SmoldotAddChainOptions;
 
-    // If this is a parachain - meaning a relayChainName is provided
-    if (relayChainName) {
-      relay = this.#networks.find(n => n.name === relayChainName)
-      addChainOptions = {
-        chainSpec,
-        jsonRpcCallback,
-        potentialRelayChains: [relay?.chain as SmoldotChain]
-      };
-    } else {
-      addChainOptions = {
-        chainSpec,
-        jsonRpcCallback
-      };
-    }
-    const addedChain = await this.#client.addChain(addChainOptions);
+    const addedChain = await this.#client.addChain({
+      chainSpec,
+      jsonRpcCallback,
+      potentialRelayChains: this.#networks.map(net => net.chain),
+    });
 
     this.#networks.push({
       name,

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as smoldot from '@substrate/smoldot-light';
-import { SmoldotJsonRpcCallback, SmoldotAddChainOptions, SmoldotChain } from '@substrate/smoldot-light';
+import { SmoldotJsonRpcCallback, SmoldotChain } from '@substrate/smoldot-light';
 import { AppMediator } from './AppMediator';
 import { ConnectionManagerInterface } from './types';
 import EventEmitter from 'eventemitter3';
@@ -197,8 +197,6 @@ export class ConnectionManager extends (EventEmitter as { new(): StateEmitter })
     if (!this.#client) {
       throw new Error('Smoldot client does not exist.');
     }
-    let relay: Network | undefined = undefined;
-    let addChainOptions = {} as SmoldotAddChainOptions;
 
     const addedChain = await this.#client.addChain({
       chainSpec,

--- a/projects/extension/src/background/types.ts
+++ b/projects/extension/src/background/types.ts
@@ -36,6 +36,6 @@ export type StateEmitter = StrictEventEmitter<EventEmitter, StateEvents>;
 export interface ConnectionManagerInterface {
   registerApp: (app: AppMediator) => void;
   unregisterApp: (app: AppMediator) => void;
-  addChain: (name: string, spec: string, jsonRpcCallback: smoldot.SmoldotJsonRpcCallback, relayChainName?: string) => Promise<smoldot.SmoldotChain>;
+  addChain: (name: string, spec: string, jsonRpcCallback: smoldot.SmoldotJsonRpcCallback) => Promise<smoldot.SmoldotChain>;
 }
 

--- a/projects/extension/src/types/index.ts
+++ b/projects/extension/src/types/index.ts
@@ -25,7 +25,7 @@ interface ChainSpec {
   chainspecPath: string;
 }
 export interface Network extends ChainSpec {
-  chain: smoldot.SmoldotChain | undefined;
+  chain: smoldot.SmoldotChain;
   parachains?: Parachain[];
 }
 export interface Parachain extends ChainSpec {


### PR DESCRIPTION
This removes passing the `relayChainName` from the foreground to the extension. Which relay chain a parachain should connect to is already found in the chain specification, so there's no need to additionally pass the same value as a separate parameter.

I've noticed that the `connect` method of the detector is broken, but it's already broken before this PR and can be fixed afterwards.
