### PR TITLE
[WIP] Integrate health checker in SmoldotProvider

### DIFF
--- a/packages/connect/src/SmoldotProvider/SmoldotProvider.test.ts
+++ b/packages/connect/src/SmoldotProvider/SmoldotProvider.test.ts
@@ -33,8 +33,6 @@ describe('Test Development chain', () => {
     const ms = mockSmoldot(respondWith([]), customHealthResponder(healthResponses));
     provider = new SmoldotProvider(EMPTY_CHAIN_SPEC, ms);
   
-    // we don't want the test to be slow
-    provider.healthPingerInterval = 1;
     await provider.connect();
   
     return new Promise<void>((resolve) => {
@@ -53,8 +51,6 @@ describe('Test Development chain', () => {
     const ms = mockSmoldot(respondWith([]), devChainHealthResponder);
     provider = new SmoldotProvider(EMPTY_CHAIN_SPEC, ms);
   
-    // we don't want the test to be slow
-    provider.healthPingerInterval = 1;
     await provider.connect();
     
     return new Promise<void>((resolve, reject) => {
@@ -101,21 +97,6 @@ test('awaiting send returns message result', async () => {
   await provider.disconnect();
 });
 
-test('emits error when system_health responds with error', async () => {
-  const ms = mockSmoldot(respondWith([]), erroringResponder);
-  const provider = new SmoldotProvider(EMPTY_CHAIN_SPEC, ms);
-
-  // we don't want the test to be slow
-  provider.healthPingerInterval = 1;
-  await provider.connect();
-  return new Promise<void>((resolve) => {
-    provider.on('error', error => {
-      expect(error.message).toBe('Got error response asking for system health');
-      return provider.disconnect().then(() => resolve());
-    });
-  });
-});
-
 test('emits events when it connects then disconnects', async () => {
   const healthResponses = [
     { isSyncing: false, peerCount: 1, shouldHavePeers: true },
@@ -124,8 +105,6 @@ test('emits events when it connects then disconnects', async () => {
   const ms = mockSmoldot(respondWith([]), customHealthResponder(healthResponses));
   const provider = new SmoldotProvider(EMPTY_CHAIN_SPEC, ms);
 
-  // we don't want the test to be slow
-  provider.healthPingerInterval = 1;
   await provider.connect();
   return new Promise<void>((resolve) => {
     provider.on('connected', () => {
@@ -145,8 +124,6 @@ test('emits events when Grandpa finishes sync and then connects', async () => {
   const ms = mockSmoldot(respondWith([]), customHealthResponder(healthResponses));
   const provider = new SmoldotProvider(EMPTY_CHAIN_SPEC, ms);
 
-  // we don't want the test to be slow
-  provider.healthPingerInterval = 1;
   await provider.connect();
   return new Promise<void>((resolve) => {
     provider.on('connected', () => {
@@ -227,7 +204,7 @@ test('subscribe', async () => {
 
   await provider.connect();
 
-  expect.assertions(2);
+  expect.assertions(3);
   return new Promise<void>((resolve, reject) => {
     return provider.subscribe('state_test', 'test_subscribe', [],  (error: Error | null, result: any) => {
       if (error !== null) {
@@ -252,7 +229,7 @@ test('subscribe copes with out of order responses', async () => {
 
   await provider.connect();
 
-  expect.assertions(2);
+  expect.assertions(3);
   return new Promise<void>((resolve, reject) => {
     return provider.subscribe('state_test', 'test_subscribe', [],  (error: Error | null, result: any) => {
       if (error !== null) {
@@ -279,7 +256,7 @@ test('converts british english method spelling to US', async () => {
 
   await provider.connect();
 
-  expect.assertions(2);
+  expect.assertions(3);
   return new Promise<void>((resolve, reject) => {
     return provider.subscribe('chain_finalizedHead', 'chain_subscribeFinalizedHeads', [],  (error: Error | null, result: any) => {
       if (error !== null) {

--- a/packages/smoldot-test-utils/src/index.ts
+++ b/packages/smoldot-test-utils/src/index.ts
@@ -1,3 +1,4 @@
+import * as smoldot from '@substrate/smoldot-light';
 import { HealthChecker, Smoldot, SmoldotAddChainOptions, SmoldotChain, SmoldotClient, SmoldotJsonRpcCallback } from '@substrate/smoldot-light';
 import { JsonRpcObject } from '@polkadot/rpc-provider/types';
 import { jest } from '@jest/globals'
@@ -32,7 +33,7 @@ export interface SystemHealth {
  */
 const systemHealthReponse = (id: number, health: SystemHealth) => {
   return `{"jsonrpc":"2.0","id":${id} ,"result":{"isSyncing":${health.isSyncing},"peers":${health.peerCount},"shouldHavePeers":${health.shouldHavePeers}}}`;
-  }
+}
 
 /**
  * devChainHealthResponse - creates a valid RPC response that looks like a response
@@ -48,7 +49,7 @@ const systemHealthReponse = (id: number, health: SystemHealth) => {
  * equal to 0.
  */
 const devChainHealthResponse = (id: number) => {
-  return systemHealthReponse(id, { isSyncing: true, peerCount: 0, shouldHavePeers: false});
+  return systemHealthReponse(id, { isSyncing: true, peerCount: 0, shouldHavePeers: false });
 }
 
 /**
@@ -174,6 +175,11 @@ const createRequestProcessor = (options: SmoldotAddChainOptions, responder: RpcR
           return;
         }
 
+        if (/chain_subscribeNewHeads/.test(rpcRequest)) {
+          options.jsonRpcCallback(healthResponder(rpcRequest));
+          return;
+        }
+
         // non-health reponse
         options.jsonRpcCallback(responder(rpcRequest))
         if (/(?<!un)[sS]ubscribe/.test(rpcRequest)) {
@@ -212,15 +218,7 @@ export const mockSmoldot = (responder: RpcResponder, healthResponder = healthyRe
         })
       });
     },
-    healthChecker: (): HealthChecker => {
-      return ({
-        setSendJsonRpc: doNothing,
-        sendJsonRpc: doNothing,
-        start: doNothing,
-        stop: doNothing,
-        responsePassThrough: (_resp: string) => ''
-      })
-    }
+    healthChecker: (): HealthChecker => smoldot.smoldot.healthChecker(),
   };
 };
 
@@ -260,14 +258,6 @@ export const smoldotSpy = (responder: RpcResponder, rpcSpy: jest.MockedFunction<
         }
       });
     },
-    healthChecker: (): HealthChecker => {
-      return ({
-        setSendJsonRpc: doNothing,
-        sendJsonRpc: doNothing,
-        start: doNothing,
-        stop: doNothing,
-        responsePassThrough: (_resp: string) => ''
-      })
-    }
+    healthChecker: (): HealthChecker => smoldot.smoldot.healthChecker(),
   };
 };


### PR DESCRIPTION
This PR replaces the dummy health pinger with the health checker that is implemented in the `smoldot` package.

This more elaborate health checker not only uses `system_health`, but also `chain_subscribeNewHeads` in order to detect new blocks and immediately detect when the syncing is complete.

As a consequence, the "mock" smoldot used in the tests of the `SmoldotProvider` doesn't work. The test utils are too rigid and assume that only `system_health` is used to determine the health of the node.
I'm opening this PR knowing that the tests fail, and asking for advice on what to do with these tests.

Considering that the health checker is in the `smoldot` package and assumes that the entirety of the JSON-RPC functions are available, the only way to properly implement a mock smoldot is to implement every single JSON-RPC function in the mock. Any other solution would be a violation of the separation between substrate-connect and smoldot. Doing so is obviously too much work.

To me there are three solutions:

- Also properly implement a mock health checker. The tests would become even more tautological than they already are.
- Use the actual smoldot rather than a mock, and make it actually connect to a local chain.
- Get rid of the tests related to the health checking.
