### PR TITLE
Improving loading times on substrate-connect

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -28,7 +28,7 @@
     "test:integration": "../../bin/node-esm $(yarn bin)/jest --colors --silent --coverage --config=jest.config.integration.ts",
     "deep-clean": "yarn clean && rm -rf node_modules",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
-    "build": "tsc -b",
+    "build": "tsc -b && node ./src/specs/generate-specs.js",
     "lint": "yarn eslint . --ext .js,.ts"
   },
   "dependencies": {

--- a/packages/connect/src/specs/generate-specs.js
+++ b/packages/connect/src/specs/generate-specs.js
@@ -1,0 +1,33 @@
+import { promisify } from "util"
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFile as _readFile,
+  writeFile as _writeFile,
+} from "fs"
+import path from "path"
+
+const readFile = promisify(_readFile)
+const writeFile = promisify(_writeFile)
+
+const BASE_PATH = "./src/specs"
+
+const files = readdirSync(BASE_PATH)
+
+/* eslint-disable */
+const processFile = async (fileName) => {
+  const rawStr = await readFile(path.join(BASE_PATH, fileName), "utf8")
+  const fileStr = `export default \`${JSON.stringify(JSON.parse(rawStr))}\``
+  await writeFile(
+    `${path.join("./dist/specs/generated/", fileName.slice(0, -5))}.js`,
+    fileStr,
+    "utf8",
+  )
+}
+
+if (!existsSync("./dist/specs/generated")) {
+  mkdirSync("./dist/specs/generated", { resursive: true })
+}
+
+Promise.all(files.filter((file) => file.endsWith(".json")).map(processFile))

--- a/packages/connect/src/specs/index.ts
+++ b/packages/connect/src/specs/index.ts
@@ -1,0 +1,15 @@
+export enum SupportedChains {
+  polkadot = "polkadot",
+  kusama = "kusama",
+  rococo = "rococo",
+  westend = "westend",
+}
+
+export async function getSpec(chain: SupportedChains): Promise<string> {
+  const specRaw = (await import("./generated/" + chain + ".js")) as Promise<
+    string | { default: string }
+  >
+  return typeof specRaw === "string"
+    ? specRaw
+    : (specRaw as unknown as { default: string }).default
+}


### PR DESCRIPTION
I recently tested the performance of the loading times on a project that was using `substrate-connect` and the performance metrics were not looking good.

After some analysis, I was able to confirm that the main reasons were:

- Loading and parsing on the main JS chunk the JSON files for all the known chain-specs.
- Loading on the main JS chunk both providers (SmoldotProvider and ExtensionProvider)
- Loading on the main JS chunk `@polkadot/api`

Luckily for us, we can dynamically load the provider that the user needs when they call `connect`, while in a parallel request we load the `@polkadot/api`. That's what the first commit of this PR does.

However, what was penalizing the performance the most was the issue with the JSON files... I had to get a bit creative to solve that one. This is the solution that I implemented in the second commit:

- At the end of the `build` task we run a script that transforms those JSON files in minified string (on separate js assets that go directly under `dist/specs/generated`), then and only if the SmoldotProvider is needed, we dynamically import the only string that it's needed for that chain, while at the same time in parallel request we are loading the SmoldotProvider. Also, we never parse that string to a JS Object in the main thread, because there is no need for doing that.

These changes should make a significant difference when it comes to the loading times of the App that's using `substrate-connect`.