### PR TITLE
test: fix flaky test on ConnectionManager

### DIFF
--- a/projects/extension/src/background/ConnectionManager.test.ts
+++ b/projects/extension/src/background/ConnectionManager.test.ts
@@ -311,7 +311,7 @@ describe("Check storage and send notification when adding an app", () => {
     expect(chrome.storage.sync.get).toHaveBeenCalledTimes(1)
   })
 
-  test("Sends a notification", () => {
+  test("Sends a notification", async () => {
     port.triggerMessage({ type: "spec", payload: westendPayload })
     const notificationData = {
       message: "App test-app-7 connected to westend.",
@@ -320,6 +320,7 @@ describe("Check storage and send notification when adding an app", () => {
       type: "basic",
     }
 
+    await waitForMessageToBePosted()
     expect(chrome.notifications.create).toHaveBeenCalledTimes(1)
     expect(chrome.notifications.create).toHaveBeenCalledWith(
       "test-app-7::westend",


### PR DESCRIPTION
We've seen a [task inconsistently failing on a particular test](https://github.com/paritytech/substrate-connect/runs/4301859471), which seems to indicate that's a flaky test. This PR is an attempt to address that issue. Although, IMO using this `waitForMessageToBePosted` is far from ideal. However, this is the method used in all the other tests to "prevent" the race condition... So, for now that should do the trick. Although, it would be worth it to review these tests in the future and see if we can find a better way to handle these kinds of situations.