### PR TITLE
Add connect() in ScProvider constructor

### DIFF
--- a/packages/connect/src/ScProvider.ts
+++ b/packages/connect/src/ScProvider.ts
@@ -95,7 +95,10 @@ export class ScProvider implements ProviderInterface {
       isExtension,
       chainSpec,
       parachainSpec,
-    ).then((provider) => (this.#provider = provider))
+    ).then(async (provider) => {
+      await provider.connect()
+      return (this.#provider = provider)
+    })
   }
 
   /**

--- a/packages/connect/src/ScProvider.ts
+++ b/packages/connect/src/ScProvider.ts
@@ -57,7 +57,7 @@ export class ScProvider implements ProviderInterface {
    * @param displayName - a display name that will be used from the dev-tools of the Extension (if installed)
    * @param knownChain - the name of a supported chain ({@link SupportedChains})
    * @param parachainSpec - optional param of the parachain chainSpecs to connect to
-   * @param autoConnect - optional param that defaults to True,
+   * @param autoConnect - whether the ScProvider should eagerly connect while its being instantiated. Defaults to `true`
    *
    * @remarks
    *
@@ -74,6 +74,7 @@ export class ScProvider implements ProviderInterface {
    * @param displayName - a display name that will be used from the dev-tools of the Extension (if installed)
    * @param chainSpec - a string with the spec of the chain
    * @param parachainSpec - optional param of the parachain chainSpecs to connect to
+   * @param autoConnect - whether the ScProvider should eagerly connect while its being instantiated. Defaults to `true`
    *
    * @remarks
    *
@@ -90,7 +91,7 @@ export class ScProvider implements ProviderInterface {
     displayName: string,
     chainSpec: string,
     parachainSpec?: string,
-    autoConnect: boolean = true,
+    autoConnect = true,
   ) {
     const isExtension = !!document.getElementById("substrateExtension")
 
@@ -101,7 +102,10 @@ export class ScProvider implements ProviderInterface {
       parachainSpec,
     ).then((provider) => (this.#provider = provider))
 
-    if (autoConnect) this.#providerP.then((provider) => provider.connect())
+    if (autoConnect)
+      this.#providerP
+        .then((provider) => provider.connect())
+        .catch((e) => console.log(e))
   }
 
   /**

--- a/packages/connect/src/ScProvider.ts
+++ b/packages/connect/src/ScProvider.ts
@@ -57,6 +57,7 @@ export class ScProvider implements ProviderInterface {
    * @param displayName - a display name that will be used from the dev-tools of the Extension (if installed)
    * @param knownChain - the name of a supported chain ({@link SupportedChains})
    * @param parachainSpec - optional param of the parachain chainSpecs to connect to
+   * @param autoConnect - optional param that defaults to True,
    *
    * @remarks
    *
@@ -67,6 +68,7 @@ export class ScProvider implements ProviderInterface {
     displayName: string,
     knownChain: SupportedChains,
     parachainSpec?: string,
+    autoConnect?: boolean,
   )
   /**
    * @param displayName - a display name that will be used from the dev-tools of the Extension (if installed)
@@ -82,11 +84,13 @@ export class ScProvider implements ProviderInterface {
     displayName: string,
     chainSpec: string,
     parachainSpec?: string,
+    autoConnect?: boolean,
   )
   public constructor(
     displayName: string,
     chainSpec: string,
     parachainSpec?: string,
+    autoConnect: boolean = true,
   ) {
     const isExtension = !!document.getElementById("substrateExtension")
 
@@ -95,10 +99,9 @@ export class ScProvider implements ProviderInterface {
       isExtension,
       chainSpec,
       parachainSpec,
-    ).then(async (provider) => {
-      await provider.connect()
-      return (this.#provider = provider)
-    })
+    ).then((provider) => (this.#provider = provider))
+
+    if (autoConnect) this.#providerP.then((provider) => provider.connect())
   }
 
   /**

--- a/projects/smoldot-browser-demo/src/index.ts
+++ b/projects/smoldot-browser-demo/src/index.ts
@@ -19,7 +19,6 @@ window.onload = () => {
       )
       const api = await ApiPromise.create({ provider })
 
-      // const api = await ApiPromise.create({ provider })
       const header = await api.rpc.chain.getHeader()
       const chainName = await api.rpc.system.chain()
 


### PR DESCRIPTION
There have been a miss on this [PR](https://github.com/paritytech/substrate-connect/pull/554) that  is exposing the provider.
This has to do with the initiation of the light client.
At the moment, the provider is returned when the `new ScProvider(name, chain)` is called but there is no action that initiates the Smoldot Client. That initiation is taking place with `connect()`.
There are 2 approaches that we could follow to fix this:
a) Increase the lines of code from 2 to 3, from the dApp, in order to init the smoldot light client, meaning:
```javascript
const provider = new ScProvider("Smoldot Browser Demo", SupportedChains.westend,)
provider.connect()  // <--- added line
const api = await ApiPromise.create({ provider })
```  
b) call the `connect()` in the constructor of the ScProvider (`ScProvider.ts`), meaning:
 ```javascript
this.#providerP = this.internalProvider(displayName, isExtension, chainSpec, parachainSpec)
    .then(async (provider) => {
          await provider.connect()  // <--- added line
          return (this.#provider = provider)
   })
```
Following the (a) approach adds "extra effort" to the dApp developer from writing 2 lines to 3, but at the same time makes it more "I can init the light client whenever I want" controllable (or forget to do so)
From the other hand - following (b) - defaults the init of smoldot light client during the `new ScProvider` (as was happening before). 

In both cases the provider is exposed, with main difference is who is responsible on initiating the light client. 
This PR is solving the (b) case