### PR TITLE
Add connect() in each project demo

### DIFF
--- a/projects/burnr/src/hooks/api/useApiCreate.ts
+++ b/projects/burnr/src/hooks/api/useApiCreate.ts
@@ -22,6 +22,7 @@ export default function useApiCreate(): ApiPromise {
     const choseSmoldot = async (endpoint: string): Promise<void> => {
       try {
         const provider = new ScProvider("burnr wallet", endpoint)
+        await provider.connect()
         const api = await ApiPromise.create({ provider })
         l.log(`Burnr is now connected to ${endpoint}`)
         mountedRef.current && setApi(api)

--- a/projects/multiple-network-demo/src/index.ts
+++ b/projects/multiple-network-demo/src/index.ts
@@ -13,6 +13,7 @@ window.onload = () => {
           "Multiple Network Demo",
           SupportedChains.westend,
         )
+        await provider.connect()
         const westend = await ApiPromise.create({ provider })
         const westendUI = document.getElementById("westend")
         const westendHead = await westend.rpc.chain.getHeader()
@@ -29,6 +30,7 @@ window.onload = () => {
           "Multiple Network Demo",
           SupportedChains.kusama,
         )
+        await provider.connect()
         const kusama = await ApiPromise.create({ provider })
         const kusamaUI = document.getElementById("kusama")
         const kusamaHead = await kusama.rpc.chain.getHeader()
@@ -45,6 +47,7 @@ window.onload = () => {
           "Multiple Network Demo",
           SupportedChains.polkadot,
         )
+        await provider.connect()
         const polkadot = await ApiPromise.create({ provider })
         const polkadotUI = document.getElementById("polkadot")
         const polkadotHead = await polkadot.rpc.chain.getHeader()
@@ -61,6 +64,7 @@ window.onload = () => {
           "Multiple Network Demo",
           SupportedChains.rococo,
         )
+        await provider.connect()
         const rococo = await ApiPromise.create({ provider })
         const rococoUI = document.getElementById("rococo")
         const rococoHead = await rococo.rpc.chain.getHeader()

--- a/projects/parachain-demo/src/index.ts
+++ b/projects/parachain-demo/src/index.ts
@@ -20,6 +20,7 @@ window.onload = () => {
         SupportedChains.westend,
         JSON.stringify(westmint),
       )
+      await provider.connect()
       const api = await ApiPromise.create({ provider })
 
       const [chain, nodeName, nodeVersion, properties] = await Promise.all([

--- a/projects/smoldot-browser-demo/src/index.ts
+++ b/projects/smoldot-browser-demo/src/index.ts
@@ -17,9 +17,9 @@ window.onload = () => {
         "Smoldot Browser Demo",
         SupportedChains.westend,
       )
+      await provider.connect()
       const api = await ApiPromise.create({ provider })
 
-      // const api = await ApiPromise.create({ provider })
       const header = await api.rpc.chain.getHeader()
       const chainName = await api.rpc.system.chain()
 


### PR DESCRIPTION
There have been a miss on this [PR](https://github.com/paritytech/substrate-connect/pull/554) that  is exposing the provider.
This has to do with the initiation of the light client.
At the moment, the provider is returned when the `new ScProvider(name, chain)` is called but there is no action that initiates the Smoldot Client. That initiation is taking place with `connect()`.
There are 2 approaches that we could follow to fix this:
a) Increase the lines of code from 2 to 3, from the dApp, in order to init the smoldot light client, meaning:
```javascript
const provider = new ScProvider("Smoldot Browser Demo", SupportedChains.westend,)
provider.connect()  // <--- added line
const api = await ApiPromise.create({ provider })
```  
b) call the `connect()` in the constructor of the ScProvider (`ScProvider.ts`), meaning:
 ```javascript
this.#providerP = this.internalProvider(displayName, isExtension, chainSpec, parachainSpec)
    .then(async (provider) => {
          await provider.connect()  // <--- added line
          return (this.#provider = provider)
   })
```
Following the (a) approach adds "extra effort" to the dApp developer from writing 2 lines to 3, but at the same time makes it more "I can init the light client whenever I want" controllable (or forget to do so)
From the other hand - following (b) - defaults the init of smoldot light client during the `new ScProvider` (as was happening before). 

In both cases the provider is exposed, with main difference is who is responsible on initiating the light client. 
This PR is solving the (a) case