### PR TITLE
Connection manager rework

### DIFF
--- a/projects/extension/src/background/ConnectionManager.test.ts
+++ b/projects/extension/src/background/ConnectionManager.test.ts
@@ -380,6 +380,7 @@ describe("Tests with actual ConnectionManager", () => {
 
   test("Smoldot throws error when it does not exist", async () => {
     try {
+      await manager.shutdown()
       await manager.addChain(JSON.stringify(kusama), doNothing)
     } catch (err: any) {
       expect(err.message).toBe("Smoldot client does not exist.")

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -49,6 +49,29 @@ export class ConnectionManager
   #networks: Network[] = []
   smoldotLogLevel = 3
 
+  constructor() {
+    super()
+    this.initSmoldot()
+    const promises = []
+    for (const [key, value] of relayChains.entries()) {
+      const jsonRpcCallback = (rpc: string) => {
+        console.warn(`Got RPC from ${key} dummy chain: ${rpc}`)
+      }
+      const promise = this.#client
+        ?.addChain({
+          chainSpec: value,
+          jsonRpcCallback,
+        })
+        .catch((err) => {
+          console.error("Error", err)
+        })
+      promises.push(promise)
+    }
+    Promise.all(promises).catch((err) =>
+      console.log("Error creating smoldot:", err),
+    )
+  }
+
   /** registeredApps
    *
    * @returns a list of the names of apps that are currently connected
@@ -230,32 +253,6 @@ export class ConnectionManager
   async shutdown(): Promise<void> {
     await this.#client?.terminate()
     this.#client = undefined
-  }
-
-  /**
-   * init Runs on onStartup and onInstalled of extension and
-   * connects the default relayChains to smoldot
-   */
-  init = () => {
-    this.initSmoldot()
-    const promises = []
-    for (const [key, value] of relayChains.entries()) {
-      const jsonRpcCallback = (rpc: string) => {
-        console.warn(`Got RPC from ${key} dummy chain: ${rpc}`)
-      }
-      const promise = this.#client
-        ?.addChain({
-          chainSpec: value,
-          jsonRpcCallback,
-        })
-        .catch((err) => {
-          console.error("Error", err)
-        })
-      promises.push(promise)
-    }
-    Promise.all(promises)
-      .then(() => console.log("all run"))
-      .catch((err) => console.log("Error creating smoldot:", err))
   }
 
   /**

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -236,23 +236,26 @@ export class ConnectionManager
    * init Runs on onStartup and onInstalled of extension and
    * connects the default relayChains to smoldot
    */
-  init = async () => {
-    try {
-      this.initSmoldot()
-      for (const [key, value] of relayChains.entries()) {
-        const jsonRpcCallback = (rpc: string) => {
-          console.warn(`Got RPC from ${key} dummy chain: ${rpc}`)
-        }
-        await this.#client
-          ?.addChain({
-            chainSpec: value,
-            jsonRpcCallback,
-          })
-          .catch((err) => console.error("Error", err))
+  init = () => {
+    this.initSmoldot()
+    const promises = []
+    for (const [key, value] of relayChains.entries()) {
+      const jsonRpcCallback = (rpc: string) => {
+        console.warn(`Got RPC from ${key} dummy chain: ${rpc}`)
       }
-    } catch (e) {
-      console.error(`Error creating smoldot: ${e}`)
+      const promise = this.#client
+        ?.addChain({
+          chainSpec: value,
+          jsonRpcCallback,
+        })
+        .catch((err) => {
+          console.error("Error", err)
+        })
+      promises.push(promise)
     }
+    Promise.all(promises)
+      .then(() => console.log("all run"))
+      .catch((err) => console.log("Error creating smoldot:", err))
   }
 
   /**

--- a/projects/extension/src/background/index.ts
+++ b/projects/extension/src/background/index.ts
@@ -11,11 +11,11 @@ declare let window: Background
 const manager = (window.manager = new ConnectionManager())
 
 chrome.runtime.onInstalled.addListener(() => {
-  manager.init().catch(console.error)
+  manager.init()
 })
 
 chrome.runtime.onStartup.addListener(() => {
-  manager.init().catch(console.error)
+  manager.init()
 })
 
 chrome.runtime.onConnect.addListener((port) => {

--- a/projects/extension/src/background/index.ts
+++ b/projects/extension/src/background/index.ts
@@ -1,9 +1,4 @@
 import { ConnectionManager } from "./ConnectionManager"
-import westend from "../../public/assets/westend.json"
-import kusama from "../../public/assets/kusama.json"
-import polkadot from "../../public/assets/polkadot.json"
-import rococo from "../../public/assets/rococo.json"
-import { logger } from "@polkadot/util"
 import { isEmpty } from "../utils/utils"
 import settings from "./settings.json"
 
@@ -15,43 +10,12 @@ declare let window: Background
 
 const manager = (window.manager = new ConnectionManager())
 
-type RelayType = Map<string, string>
-
-export const relayChains: RelayType = new Map<string, string>([
-  ["polkadot", JSON.stringify(polkadot)],
-  ["kusama", JSON.stringify(kusama)],
-  ["rococo", JSON.stringify(rococo)],
-  ["westend", JSON.stringify(westend)],
-])
-
-const l = logger("Extension")
-export interface RequestRpcSend {
-  method: string
-  params: unknown[]
-}
-
-const init = async () => {
-  try {
-    manager.initSmoldot()
-    for (const [key, value] of relayChains.entries()) {
-      const rpcCallback = (rpc: string) => {
-        console.warn(`Got RPC from ${key} dummy chain: ${rpc}`)
-      }
-      await manager
-        .addChain(value, rpcCallback)
-        .catch((err) => l.error("Error", err))
-    }
-  } catch (e) {
-    l.error(`Error creating smoldot: ${e}`)
-  }
-}
-
 chrome.runtime.onInstalled.addListener(() => {
-  init().catch(console.error)
+  manager.init().catch(console.error)
 })
 
 chrome.runtime.onStartup.addListener(() => {
-  init().catch(console.error)
+  manager.init().catch(console.error)
 })
 
 chrome.runtime.onConnect.addListener((port) => {

--- a/projects/extension/src/background/index.ts
+++ b/projects/extension/src/background/index.ts
@@ -10,14 +10,6 @@ declare let window: Background
 
 const manager = (window.manager = new ConnectionManager())
 
-chrome.runtime.onInstalled.addListener(() => {
-  manager.init()
-})
-
-chrome.runtime.onStartup.addListener(() => {
-  manager.init()
-})
-
 chrome.runtime.onConnect.addListener((port) => {
   manager.addApp(port)
 })


### PR DESCRIPTION
This PR is a rework on the connection manager part of the extension. Major changes have:
- Adjust the Mapping of known chains (polkadot, kusama, rococo, westend) to use Ids (e.g. ksmcc3) instead of names (e.g. kusama);
- Split flow when extension inits for default chains from the external chainspecs (makes flow faster and removes non-needed steps);
- Move all actions from the background `index.js` to `ConnectionManager` class.
- Add fixes concerning linter (TS-y a bit more the code) in order to remove the disable comments from the file
- Replace `substr` deprecated javascript function