### PR TITLE
chore: merge CommonProviderMessageData and ProviderMessageData

### DIFF
--- a/packages/connect-extension-protocol/package.json
+++ b/packages/connect-extension-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@substrate/connect-extension-protocol",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Protocol for connect message passing with the extension",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -89,7 +89,7 @@ export interface ProviderMessage {
   data: ProviderMessageData
 }
 
-export interface CommonProviderMessageData {
+export interface ProviderMessageData {
   /** origin is used to determine which side sent the message **/
   origin: "extension-provider"
   /** The name of the app to be used for display purposes in the extension UI **/
@@ -98,8 +98,6 @@ export interface CommonProviderMessageData {
   chainId: number
   /** The name of the blockchain network the app is talking to **/
   chainName: string
-}
-export interface ProviderMessageData extends CommonProviderMessageData {
   /** What action the `ExtensionMessageRouter` should take **/
   action: "forward" | "connect" | "disconnect"
   /** The message the `ExtensionMessageRouter` should forward to the background **/

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@polkadot/rpc-provider": "^6.10.3",
-    "@substrate/connect-extension-protocol": "^0.3.0",
+    "@substrate/connect-extension-protocol": "^0.4.0",
     "@substrate/smoldot-light": "0.5.7",
     "eventemitter3": "^4.0.7"
   },

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -19,7 +19,6 @@ const waitForMessageToBePosted = (): Promise<null> => {
 
 const westendSpec = JSON.stringify({ name: "Westend", id: "westend2" })
 const rococoSpec = JSON.stringify({ name: "Rococo", id: "rococo" })
-const westmintSpec = JSON.stringify({ name: "Westmint", id: "westmint" })
 
 let handler = jest.fn()
 beforeEach(() => {
@@ -29,11 +28,6 @@ beforeEach(() => {
 
 afterEach(() => {
   window.removeEventListener("message", handler)
-})
-
-test("constructor sets properties", () => {
-  const ep = new ExtensionProvider("test", westendSpec)
-  expect(ep.name).toBe("test")
 })
 
 test("connected and sends correct spec message", async () => {
@@ -96,12 +90,6 @@ test("connected multiple chains and sends correct spec message", async () => {
   const data2 = handler.mock.calls[3][0] as ProviderMessage
   expect(data1.data).toMatchObject(expectedMessage1)
   expect(data2.data).toMatchObject(expectedMessage2)
-})
-
-test("constructor sets properties for parachain", () => {
-  const ep = new ExtensionProvider("test", westmintSpec)
-  expect(ep.name).toBe("test")
-  expect(ep.chainSpecs).toBe(westmintSpec)
 })
 
 test("connected parachain sends correct spec message", async () => {

--- a/projects/extension/package.json
+++ b/projects/extension/package.json
@@ -71,7 +71,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/styles": "^4.11.3",
     "@polkadot/rpc-provider": "^4.10.1",
-    "@substrate/connect-extension-protocol": "^0.3.0",
+    "@substrate/connect-extension-protocol": "^0.4.0",
     "@substrate/smoldot-light": "0.5.7",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",


### PR DESCRIPTION
It addresses the first bullet point of #572

> Merge CommonProviderMessageData and ProviderMessageData into one interface. I suspect that the reason why they're two separate thing is to make the code in ExtensionProvider easier, but that's really not the problem of connection-extension-protocol

I also took that chance to remove the public properties `name` and `chainSpec` from the ExtensionProvider, since those properties shouldn't be exposed... I could (and perhaps should) do that in a separate PR, though.