### PR TITLE
chore: rework connection-extension-protocol

### DIFF
--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -1,143 +1,98 @@
-/**
- * @packageDocumentation
- *
- * In order to understand the protocol you should realise there are actually
- * 2 hops that happen in communication because of the architecture of browser
- * extensions.  The app has to `window.postMessage` messages to the content
- * script that gets injected by the extension. It is the content script that
- * has access to the extension APIs to be able to post messages to the
- * extension background.
- *
- * You can think of the protocol types like layers of an onion. The innermost
- * layer is the original JSON RPC request/responses. Then we wrap extra layers
- * (types) for the other 2 hops which then get peeled off at each hop. The
- * {@link MessageToManager} / {@link MessageFromManager} representing the
- * extension communication content script \<\> background. Then the outermost
- * {@link ExtensionMessage} / {@link ProviderMessage} representing the
- * communication between the PolkadotJS provider in the app and the content
- * script.
- *
- * The {@link ExtensionProvider} is the class in the app.
- * The {@link ExtensionMessageRouter} is the class in the content script.
- * The {@link ConnectionManager} is the class in the extension background.
- */
+type EventHandler<T> = (message: MessageEvent<T>) => void
 
-/**
- * `MessageFromManager` represents messages from the manager in the extension
- * background that are intended to be sent on to the `ExtensionProvider` in the
- * app.
- */
-export interface MessageFromManager {
-  /** Type of the message. Defines how to interpret the {@link payload} */
-  type: "error" | "rpc"
-  /** Payload of the message. Either a JSON encoded RPC response or an error message **/
+export interface ToWebpageHeader {
+  origin: "content-script"
+  providerId: number
+}
+
+export enum ToWebpageMessageType {
+  Disconnect = "disconnect",
+  Rpc = "rpc",
+  Error = "error",
+}
+
+interface ToWebpageDisconnect {
+  type: ToWebpageMessageType.Disconnect
+}
+
+interface ToWebpageRpc {
+  type: ToWebpageMessageType.Rpc
   payload: string
 }
 
-/**
- * ExtensionMessage represents messages sent via
- * `window.postMessage` from `ExtensionMessageRouter` to `ExtensionProvider`
- * as recieved by the `ExtensionProvider`.
- *
- * @remarks The browser wraps the message putting it in {@link data}
- */
-export interface ExtensionMessage {
-  data: ExtensionMessageData
-}
-export interface ExtensionMessageData {
-  /** origin is used to determine which side sent the message **/
-  origin: "content-script"
-  /** message is telling the `ExtensionProvider` the port has been closed **/
-  disconnect?: boolean
-  /** message is the message from the manager to be forwarded to the app **/
-  message?: MessageFromManager
+interface ToWebpageError {
+  type: ToWebpageMessageType.Error
+  payload: string
 }
 
-/**
- * ExtensionListenHandler is a message handler type for receiving
- * `ProviderMessage` messages from the \@substrate/connect `ExtensionProvider`
- * in the extension.
- */
-export type ExtensionListenHandler = (message: ProviderMessage) => void
+export type ToWebpageBody = ToWebpageDisconnect | ToWebpageRpc | ToWebpageError
 
-/**
- * extension provides strongly typed convenience wrappers around
- * the `window.postMessage` and `window.addEventListener` APIs used for
- * message passing on the extension side of communication.
- */
+export type ToWebpage = {
+  header: ToWebpageHeader
+  body: ToWebpageBody
+}
+
 export const extension = {
-  /** send a message from the extension to the app **/
-  send: (message: ExtensionMessageData): void => {
+  send: (message: ToWebpage): void => {
     window.postMessage(message, "*")
   },
-  /**
-   * Listen to messages from the `ExtensionProvider` in the app sent to
-   * the extension.
-   */
-  listen: (handler: ExtensionListenHandler): void => {
+  listen: (handler: EventHandler<ToExtension>): void => {
     window.addEventListener("message", handler)
   },
 }
 
-/**
- * ProviderMessage represents messages sent via `window.postMessage` from
- * `ExtensionProvider` to `ExtensionMessageRouter` as received by the extension.
- *
- * @remarks The browser wraps the message putting it in {@link data}
- */
-export interface ProviderMessage {
-  data: ProviderMessageData
-}
-
-export interface ProviderMessageData {
-  /** origin is used to determine which side sent the message **/
+export interface ToExtensionHeader {
   origin: "extension-provider"
-  /** The name of the app to be used for display purposes in the extension UI **/
-  appName: string
-  /** The uniqueId for extension multiplexing **/
-  chainId: number
-  /** The name of the blockchain network the app is talking to **/
-  chainName: string
-  /** What action the `ExtensionMessageRouter` should take **/
-  action: "forward" | "connect" | "disconnect"
-  /** The message the `ExtensionMessageRouter` should forward to the background **/
-  message?: MessageToManager
+  providerId: number
 }
 
-/**
- * The message from the `ExtensionProvider` in the app that is intended to be
- * sent on to the manager in the extension background.
- */
-export interface MessageToManager {
-  /** Type of the message. Defines how to interpret the {@link payload} */
-  type: "rpc" | "spec"
-  /** Payload of the message -  a JSON encoded RPC request **/
+export enum ToExtensionMessageType {
+  Connect = "connect",
+  Disconnect = "disconnect",
+  Spec = "spec",
+  Rpc = "rpc",
+}
+
+interface ToExtensionConnect {
+  type: ToExtensionMessageType.Connect
+  payload: {
+    displayName: string
+  }
+}
+
+interface ToExtensionDisconnect {
+  type: ToExtensionMessageType.Disconnect
+}
+
+interface ToExtensionSpec {
+  type: ToExtensionMessageType.Spec
+  payload: {
+    relaychain: string
+    parachain?: string
+  }
+}
+
+interface ToExtensionRpc {
+  type: ToExtensionMessageType.Rpc
   payload: string
-  parachainPayload?: string
 }
 
-/**
- * ProviderListenHandler is a message handler type for receiving
- * `ExtensionMessage` messages from the extension in the \@substrate/connect
- * `ExtensionProvider`.
- */
-export type ProviderListenHandler = (message: ExtensionMessage) => void
+export type ToExtensionBody =
+  | ToExtensionConnect
+  | ToExtensionDisconnect
+  | ToExtensionSpec
+  | ToExtensionRpc
 
-/**
- * provider provides properly typed convenience wrappers around the
- * `window.postMessage` and `window.addEventListener` APIs used for message
- * passing on the \@substrate/connect `ExtensionProvider` end of communication.
- */
+export type ToExtension = {
+  header: ToExtensionHeader
+  body: ToExtensionBody
+}
+
 export const provider = {
-  /** send a message from the app to the extension **/
-  send: (message: ProviderMessageData): void => {
+  send: (message: ToExtension): void => {
     window.postMessage(message, "*")
   },
-  /**
-   * Listen to messages from the `ExtensionMessageRouter` in the extension sent
-   * to the app.
-   */
-  listen: (handler: ProviderListenHandler): void => {
+  listen: (handler: EventHandler<ToWebpage>): void => {
     window.addEventListener("message", handler)
   },
 }

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -221,3 +221,65 @@ test("emits error when it receives an error message", async () => {
   const innerMessage = errorMessage.body.payload
   expect(error.message).toEqual(innerMessage)
 })
+
+test("it routes incoming messages to the correct Provider", async () => {
+  const ep1 = new ExtensionProvider("ExtensionProvider1", westendSpec)
+  await ep1.connect()
+
+  const ep2 = new ExtensionProvider("ExtensionProvider2", westendSpec)
+  await ep2.connect()
+  await waitForMessageToBePosted()
+
+  let extensionProvider1Response: string | undefined = undefined
+  let extensionProvider2Response: string | undefined = undefined
+
+  ep1
+    .send("requestSomeData", [])
+    .then((response: string) => {
+      extensionProvider1Response = response
+    })
+    .catch(() => {
+      extensionProvider1Response = "Error"
+    })
+  await waitForMessageToBePosted()
+
+  ep2
+    .send("requestOtherData", [])
+    .then((response: string) => {
+      extensionProvider2Response = response
+    })
+    .catch(() => {
+      extensionProvider2Response = "Error"
+    })
+  await waitForMessageToBePosted()
+
+  const latestRequest = handler.mock.calls[
+    handler.mock.calls.length - 1
+  ][0] as any
+
+  const latestRequestRpcId = (
+    JSON.parse(latestRequest.data.body?.payload ?? "{}") as {
+      id: number
+    }
+  ).id
+
+  extension.send({
+    header: {
+      origin: "content-script" as const,
+      providerId: ep2.providerId,
+    },
+    body: {
+      type: ToWebpageMessageType.Rpc,
+      payload: JSON.stringify({
+        id: latestRequestRpcId,
+        jsonrpc: "2.0",
+        result: "hi ExtensionProvider2!",
+      }),
+    },
+  })
+
+  await waitForMessageToBePosted()
+
+  expect(extensionProvider2Response).toBe("hi ExtensionProvider2!")
+  expect(extensionProvider1Response).toBe(undefined)
+})

--- a/projects/extension/src/mocks.ts
+++ b/projects/extension/src/mocks.ts
@@ -5,8 +5,8 @@
 import { jest } from "@jest/globals"
 import { App, ConnectionManagerInterface } from "./background/types"
 import {
-  MessageToManager,
-  MessageFromManager,
+  ToExtensionBody,
+  ToWebpageBody,
 } from "@substrate/connect-extension-protocol"
 import { Chain } from "@substrate/smoldot-light"
 import { Network } from "./types"
@@ -29,7 +29,7 @@ export class MockPort implements chrome.runtime.Port {
     this.sender.tab.id = id
   }
 
-  triggerMessage(message: MessageFromManager | MessageToManager): void {
+  triggerMessage(message: ToExtensionBody | ToWebpageBody): void {
     this.#messageListeners.forEach((l: any) => {
       l(message, this)
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -9567,7 +9567,7 @@ jest@^26.6.3:
     import-local "^3.0.2"
     jest-cli "^26.6.3"
 
-jest@^27.0.5, jest@^27.4.2, jest@^27.4.3:
+jest@^27.0.5, jest@^27.4.3:
   version "27.4.3"
   resolved "https://registry.yarnpkg.com/jest/-/jest-27.4.3.tgz#cf7d1876a84c70efece2e01e4f9dfc2e464d9cbb"
   integrity sha512-jwsfVABBzuN3Atm+6h6vIEpTs9+VApODLt4dk2qv1WMOpb1weI1IIZfuwpMiWZ62qvWj78MvdvMHIYdUfqrFaA==


### PR DESCRIPTION
It addresses the second bullet point of #572:

> * Right now the protocol mentions the web page, the content script, and the extension as layers of an onion. This is technically correct, but this is _not_ what the `connection-extension-protocol` package is about. This package is only about the communication between the web page and the content script. What happens between the content script and the extension is an implementation detail of the extension and shouldn't be mentioned in `connection-extension-protocol` because it's out of scope.
>   
>   * [ ]  Consequently, we should merge the `ProviderMessageData` and `MessageToManager` interfaces into one single interface, and `ExtensionMessageData` and `MessageFromManager` into one single interface.
>   * [ ]  Afterwards, we can rename them to something more simple such as `ToExtension` and `ToWebpage` or something like that. The words `Provider` and `Manager` shouldn't be used because they're implementation details.
>   * [ ]  Also remove the `ExtensionMessage` and `ProviderMessage` interfaces, again to simplify. The actual type that the callback passed to `addEventListener` receives is [`MessageEvent`](https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent) (which as a field named `data`), and not `ExtensionMessage` or `ProviderMessage`. You can't actually know in advance what the `data` field contains in this context.

with one extra goodie that also solves #550 and probably the security concerns that we had with 3rd party scripts running on iframes.