### PR TITLE
Enforce frozen lockfile in CI

### DIFF
--- a/.github/workflows/yarn.CI.yml
+++ b/.github/workflows/yarn.CI.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: yarn install
+    - run: yarn install --frozen-lockfile
     - run: yarn lint
     - run: yarn build
     - run: yarn test


### PR DESCRIPTION
https://classic.yarnpkg.com/en/docs/cli/install#toc-yarn-install

Assuming it works correctly (you never know with JS), this make sure that any update to the `package.json` must come with its associated changes in `yarn.lock` in the same PR.