### PR TITLE
Remove the "engines" requirement from package.json

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -8,9 +8,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "engines": {
-    "node": ">=14 <=16.13.0"
-  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": {


### PR DESCRIPTION
I don't really see why it's there?

The `>=14` seems completely arbitrary (do we use a feature that was added in Node 14?), and `<=16.13.0` seems completely arbitrary as well considering that `v16.13.1` and `v17` exist.
