### PR TITLE
Remove node_esm script from bin

### DIFF
--- a/bin/node-esm
+++ b/bin/node-esm
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-node --no-warnings --experimental-vm-modules "$@"

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -25,7 +25,7 @@
     "checkSpecs": "node ../../bin/checkSpecs.js",
     "prebuild": "yarn clean && yarn checkSpecs",
     "pretest": "yarn build",
-    "test": "../../bin/node-esm $(yarn bin)/jest --colors --coverage",
+    "test": "node --no-warnings --experimental-vm-modules $(yarn bin)/jest --colors --coverage",
     "deep-clean": "yarn clean && rm -rf node_modules",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "build": "tsc -b && node ./src/specs/generate-specs.js",

--- a/projects/extension/package.json
+++ b/projects/extension/package.json
@@ -11,7 +11,7 @@
     "deep-clean": "yarn clean && rm -rf node_modules",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "compile": "tsc -b",
-    "test": "../../bin/node-esm $(yarn bin)/jest --colors --silent --coverage",
+    "test": "node --no-warnings --experimental-vm-modules $(yarn bin)/jest --colors --silent --coverage",
     "prebuild": "yarn clean && yarn checkSpecs",
     "build": "webpack --config webpack.prod.js && zip -r ./dist/substrate-connect.zip ./dist/*",
     "dev": "yarn run prebuild && webpack --node-env development --config webpack.dev.js",


### PR DESCRIPTION
Reasons to remove are:

- It's really not worth have a separate script just for passing two flags to `node`.
- There's fundamentally no reason why the `connect` package and the `extension` package would always use the same flags. There's no "DRY" argument for this script, because you _should_ repeat yourself here.
- It adds an indirection when reading the `package.json`. Instead of knowing what `npm test` does, you have to additionally open another file.
