### PR TITLE
Merge and rename interfaces

### DIFF
--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -11,7 +11,7 @@
  * You can think of the protocol types like layers of an onion. The innermost
  * layer is the original JSON RPC request/responses. Then we wrap extra layers
  * (types) for the other 2 hops which then get peeled off at each hop.
- * The {@link ProviderMessageToExtension} and {@link ToApplication} represents
+ * The {@link ToExtension} and {@link ToApplication} represents
  * communication between the PolkadotJS provider in the app and the extension
  * (content and background scripts).
  *
@@ -74,10 +74,10 @@ export const extension = {
  * @remarks The browser wraps the message putting it in {@link data}
  */
 export interface ProviderMessage {
-  data: ProviderMessageToExtension
+  data: ToExtension
 }
 
-export interface ProviderMessageToExtension {
+export interface ToExtension {
   /** origin is used to determine which side sent the message **/
   origin: "extension-provider"
   /** The name of the app to be used for display purposes in the extension UI **/
@@ -110,7 +110,7 @@ export type ProviderListenHandler = (message: ExtensionMessage) => void
  */
 export const provider = {
   /** send a message from the app to the extension **/
-  send: (message: ProviderMessageToExtension): void => {
+  send: (message: ToExtension): void => {
     window.postMessage(message, "*")
   },
   /**

--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -86,10 +86,10 @@ export const extension = {
  * @remarks The browser wraps the message putting it in {@link data}
  */
 export interface ProviderMessage {
-  data: ProviderMessageData
+  data: ProviderMessageToExtension
 }
 
-export interface ProviderMessageData {
+export interface ProviderMessageToExtension {
   /** origin is used to determine which side sent the message **/
   origin: "extension-provider"
   /** The name of the app to be used for display purposes in the extension UI **/
@@ -101,18 +101,10 @@ export interface ProviderMessageData {
   /** What action the `ExtensionMessageRouter` should take **/
   action: "forward" | "connect" | "disconnect"
   /** The message the `ExtensionMessageRouter` should forward to the background **/
-  message?: MessageToManager
-}
-
-/**
- * The message from the `ExtensionProvider` in the app that is intended to be
- * sent on to the manager in the extension background.
- */
-export interface MessageToManager {
   /** Type of the message. Defines how to interpret the {@link payload} */
-  type: "rpc" | "spec"
+  type?: "rpc" | "spec"
   /** Payload of the message -  a JSON encoded RPC request **/
-  payload: string
+  payload?: string
   parachainPayload?: string
 }
 
@@ -130,7 +122,7 @@ export type ProviderListenHandler = (message: ExtensionMessage) => void
  */
 export const provider = {
   /** send a message from the app to the extension **/
-  send: (message: ProviderMessageData): void => {
+  send: (message: ProviderMessageToExtension): void => {
     window.postMessage(message, "*")
   },
   /**

--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -10,29 +10,15 @@
  *
  * You can think of the protocol types like layers of an onion. The innermost
  * layer is the original JSON RPC request/responses. Then we wrap extra layers
- * (types) for the other 2 hops which then get peeled off at each hop. The
- * {@link MessageToManager} / {@link MessageFromManager} representing the
- * extension communication content script \<\> background. Then the outermost
- * {@link ExtensionMessage} / {@link ProviderMessage} representing the
- * communication between the PolkadotJS provider in the app and the content
- * script.
+ * (types) for the other 2 hops which then get peeled off at each hop.
+ * The {@link ProviderMessageToExtension} and {@link ToApplication} represents
+ * communication between the PolkadotJS provider in the app and the extension
+ * (content and background scripts).
  *
  * The {@link ExtensionProvider} is the class in the app.
  * The {@link ExtensionMessageRouter} is the class in the content script.
  * The {@link ConnectionManager} is the class in the extension background.
  */
-
-/**
- * `MessageFromManager` represents messages from the manager in the extension
- * background that are intended to be sent on to the `ExtensionProvider` in the
- * app.
- */
-export interface MessageFromManager {
-  /** Type of the message. Defines how to interpret the {@link payload} */
-  type: "error" | "rpc"
-  /** Payload of the message. Either a JSON encoded RPC response or an error message **/
-  payload: string
-}
 
 /**
  * ExtensionMessage represents messages sent via
@@ -42,15 +28,17 @@ export interface MessageFromManager {
  * @remarks The browser wraps the message putting it in {@link data}
  */
 export interface ExtensionMessage {
-  data: ExtensionMessageData
+  data: ToApplication
 }
-export interface ExtensionMessageData {
+export interface ToApplication {
   /** origin is used to determine which side sent the message **/
   origin: "content-script"
   /** message is telling the `ExtensionProvider` the port has been closed **/
   disconnect?: boolean
-  /** message is the message from the manager to be forwarded to the app **/
-  message?: MessageFromManager
+  /** Type of the message. Defines how to interpret the {@link payload} */
+  type?: "error" | "rpc"
+  /** Payload of the message. Either a JSON encoded RPC response or an error message **/
+  payload?: string
 }
 
 /**
@@ -67,7 +55,7 @@ export type ExtensionListenHandler = (message: ProviderMessage) => void
  */
 export const extension = {
   /** send a message from the extension to the app **/
-  send: (message: ExtensionMessageData): void => {
+  send: (message: ToApplication): void => {
     window.postMessage(message, "*")
   },
   /**

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -4,10 +4,9 @@
 import { jest } from "@jest/globals"
 import { ExtensionProvider } from "./ExtensionProvider"
 import {
-  MessageFromManager,
   ProviderMessage,
   ProviderMessageToExtension,
-  ExtensionMessageData,
+  ToApplication,
   extension,
 } from "@substrate/connect-extension-protocol"
 
@@ -164,12 +163,10 @@ test("emits error when it receives an error message", async () => {
   const ep = new ExtensionProvider("test", westendSpec)
   await ep.connect()
   await waitForMessageToBePosted()
-  const errorMessage: ExtensionMessageData = {
+  const errorMessage: ToApplication = {
     origin: "content-script",
-    message: {
-      type: "error",
-      payload: "Boom!",
-    },
+    type: "error",
+    payload: "Boom!",
   }
   const errorHandler = jest.fn()
   ep.on("error", errorHandler)
@@ -178,6 +175,5 @@ test("emits error when it receives an error message", async () => {
 
   expect(errorHandler).toHaveBeenCalled()
   const error = errorHandler.mock.calls[0][0] as Error
-  const innerMessage = errorMessage.message as MessageFromManager
-  expect(error.message).toEqual(innerMessage.payload)
+  expect(error.message).toEqual(errorMessage.payload)
 })

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -5,7 +5,7 @@ import { jest } from "@jest/globals"
 import { ExtensionProvider } from "./ExtensionProvider"
 import {
   ProviderMessage,
-  ProviderMessageToExtension,
+  ToExtension,
   ToApplication,
   extension,
 } from "@substrate/connect-extension-protocol"
@@ -36,7 +36,7 @@ test("connected and sends correct spec message", async () => {
   await ep.connect()
   await waitForMessageToBePosted()
 
-  const expectedMessage: Partial<ProviderMessageToExtension> = {
+  const expectedMessage: Partial<ToExtension> = {
     appName: "test",
     chainName: "Westend",
     action: "forward",
@@ -61,7 +61,7 @@ test("connected multiple chains and sends correct spec message", async () => {
   await ep2.connect()
   await waitForMessageToBePosted()
 
-  const expectedMessage1: Partial<ProviderMessageToExtension> = {
+  const expectedMessage1: Partial<ToExtension> = {
     appName: "test",
     chainName: "Westend",
     action: "forward",
@@ -69,7 +69,7 @@ test("connected multiple chains and sends correct spec message", async () => {
     payload: '{"name":"Westend","id":"westend2"}',
     type: "spec",
   }
-  const expectedMessage2: Partial<ProviderMessageToExtension> = {
+  const expectedMessage2: Partial<ToExtension> = {
     appName: "test2",
     chainName: "Rococo",
     action: "forward",
@@ -92,7 +92,7 @@ test("connected parachain sends correct spec message", async () => {
   await ep.connect()
   await waitForMessageToBePosted()
 
-  const expectedMessage: Partial<ProviderMessageToExtension> = {
+  const expectedMessage: Partial<ToExtension> = {
     appName: "test",
     chainName: "Westend",
     action: "forward",
@@ -110,7 +110,7 @@ test("connect sends connect message and emits connected", async () => {
   await ep.connect()
   await waitForMessageToBePosted()
 
-  const expectedMessage: Partial<ProviderMessageToExtension> = {
+  const expectedMessage: Partial<ToExtension> = {
     appName: "test",
     chainName: "Westend",
     action: "connect",
@@ -130,7 +130,7 @@ test("disconnect sends disconnect message and emits disconnected", async () => {
   void ep.disconnect()
   await waitForMessageToBePosted()
 
-  const expectedMessage: Partial<ProviderMessageToExtension> = {
+  const expectedMessage: Partial<ToExtension> = {
     appName: "test",
     chainName: "Westend",
     action: "disconnect",

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -6,7 +6,7 @@ import { ExtensionProvider } from "./ExtensionProvider"
 import {
   MessageFromManager,
   ProviderMessage,
-  ProviderMessageData,
+  ProviderMessageToExtension,
   ExtensionMessageData,
   extension,
 } from "@substrate/connect-extension-protocol"
@@ -37,15 +37,13 @@ test("connected and sends correct spec message", async () => {
   await ep.connect()
   await waitForMessageToBePosted()
 
-  const expectedMessage: Partial<ProviderMessageData> = {
+  const expectedMessage: Partial<ProviderMessageToExtension> = {
     appName: "test",
     chainName: "Westend",
     action: "forward",
     origin: "extension-provider",
-    message: {
-      payload: '{"name":"Westend","id":"westend2"}',
-      type: "spec",
-    },
+    payload: '{"name":"Westend","id":"westend2"}',
+    type: "spec",
   }
   expect(handler).toHaveBeenCalledTimes(2)
   const { data } = handler.mock.calls[1][0] as ProviderMessage
@@ -64,25 +62,21 @@ test("connected multiple chains and sends correct spec message", async () => {
   await ep2.connect()
   await waitForMessageToBePosted()
 
-  const expectedMessage1: Partial<ProviderMessageData> = {
+  const expectedMessage1: Partial<ProviderMessageToExtension> = {
     appName: "test",
     chainName: "Westend",
     action: "forward",
     origin: "extension-provider",
-    message: {
-      payload: '{"name":"Westend","id":"westend2"}',
-      type: "spec",
-    },
+    payload: '{"name":"Westend","id":"westend2"}',
+    type: "spec",
   }
-  const expectedMessage2: Partial<ProviderMessageData> = {
+  const expectedMessage2: Partial<ProviderMessageToExtension> = {
     appName: "test2",
     chainName: "Rococo",
     action: "forward",
     origin: "extension-provider",
-    message: {
-      payload: '{"name":"Rococo","id":"rococo"}',
-      type: "spec",
-    },
+    payload: '{"name":"Rococo","id":"rococo"}',
+    type: "spec",
   }
 
   expect(handler).toHaveBeenCalledTimes(4)
@@ -99,15 +93,13 @@ test("connected parachain sends correct spec message", async () => {
   await ep.connect()
   await waitForMessageToBePosted()
 
-  const expectedMessage: Partial<ProviderMessageData> = {
+  const expectedMessage: Partial<ProviderMessageToExtension> = {
     appName: "test",
     chainName: "Westend",
     action: "forward",
     origin: "extension-provider",
-    message: {
-      payload: '{"name":"Westend","id":"westend2"}',
-      type: "spec",
-    },
+    payload: '{"name":"Westend","id":"westend2"}',
+    type: "spec",
   }
   expect(handler).toHaveBeenCalledTimes(2)
   const { data } = handler.mock.calls[1][0] as ProviderMessage
@@ -119,7 +111,7 @@ test("connect sends connect message and emits connected", async () => {
   await ep.connect()
   await waitForMessageToBePosted()
 
-  const expectedMessage: Partial<ProviderMessageData> = {
+  const expectedMessage: Partial<ProviderMessageToExtension> = {
     appName: "test",
     chainName: "Westend",
     action: "connect",
@@ -139,7 +131,7 @@ test("disconnect sends disconnect message and emits disconnected", async () => {
   void ep.disconnect()
   await waitForMessageToBePosted()
 
-  const expectedMessage: Partial<ProviderMessageData> = {
+  const expectedMessage: Partial<ProviderMessageToExtension> = {
     appName: "test",
     chainName: "Westend",
     action: "disconnect",

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
@@ -14,7 +14,7 @@ import EventEmitter from "eventemitter3"
 import { isUndefined, eraseRecord } from "../utils/index.js"
 import { HealthCheckError } from "../errors.js"
 import {
-  ProviderMessageToExtension,
+  ToExtension,
   ExtensionMessage,
   ToApplication,
   provider,
@@ -80,7 +80,7 @@ export class ExtensionProvider implements ProviderInterface {
   #chainSpecs: string
   #parachainSpecs: string
   #commonMessageData: Pick<
-    ProviderMessageToExtension,
+    ToExtension,
     "appName" | "chainId" | "chainName" | "origin"
   >
 
@@ -286,7 +286,7 @@ export class ExtensionProvider implements ProviderInterface {
    * @remarks this is async to fulfill the interface with PolkadotJS
    */
   public connect(): Promise<void> {
-    const connectMsg: ProviderMessageToExtension = {
+    const connectMsg: ToExtension = {
       ...this.#commonMessageData,
       action: "connect",
     }
@@ -294,7 +294,7 @@ export class ExtensionProvider implements ProviderInterface {
 
     // Once connect is sent - send rpc to extension that will contain the chainSpecs
     // for the extension to call addChain on smoldot
-    const specMsg: ProviderMessageToExtension = {
+    const specMsg: ToExtension = {
       ...this.#commonMessageData,
       action: "forward",
       type: "spec",
@@ -323,7 +323,7 @@ export class ExtensionProvider implements ProviderInterface {
    * telling it to disconnect the port with the background manager.
    */
   public disconnect(): Promise<void> {
-    const disconnectMsg: ProviderMessageToExtension = {
+    const disconnectMsg: ToExtension = {
       ...this.#commonMessageData,
       action: "disconnect",
     }
@@ -393,7 +393,7 @@ export class ExtensionProvider implements ProviderInterface {
         subscription,
       }
 
-      const rpcMsg: ProviderMessageToExtension = {
+      const rpcMsg: ToExtension = {
         ...this.#commonMessageData,
         action: "forward",
         type: "rpc",

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -14,10 +14,7 @@ import EventEmitter from "eventemitter3"
 import { StateEmitter, State } from "./types"
 import { NetworkMainInfo, Network } from "../types"
 import { logger } from "@polkadot/util"
-import {
-  MessageFromManager,
-  ProviderMessageToExtension,
-} from "@substrate/connect-extension-protocol"
+import { ProviderMessageToExtension } from "@substrate/connect-extension-protocol"
 
 const l = logger("Extension Connection Manager")
 
@@ -121,8 +118,7 @@ export class ConnectionManager
     const splitIdx = incPort.name.indexOf("::")
     if (splitIdx === -1) {
       const payload = `Invalid port name ${incPort.name} expected <app_name>::<chain_name>`
-      const error: MessageFromManager = { type: "error", payload }
-      incPort.postMessage(error)
+      incPort.postMessage({ type: "error", payload })
       incPort.disconnect()
       throw new Error(payload)
     }
@@ -299,8 +295,7 @@ export class ConnectionManager
   }
 
   #handleError = (app: App, e: Error): void => {
-    const error: MessageFromManager = { type: "error", payload: e.message }
-    app.port.postMessage(error)
+    app.port.postMessage({ type: "error", payload: e.message })
     app.port.disconnect()
     this.unregisterApp(app)
   }

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -16,7 +16,7 @@ import { NetworkMainInfo, Network } from "../types"
 import { logger } from "@polkadot/util"
 import {
   MessageFromManager,
-  MessageToManager,
+  ProviderMessageToExtension,
 } from "@substrate/connect-extension-protocol"
 
 const l = logger("Extension Connection Manager")
@@ -306,7 +306,7 @@ export class ConnectionManager
   }
 
   /** Handles the incoming message that contains Spec. */
-  #handleSpecMessage = (msg: MessageToManager, app: App): void => {
+  #handleSpecMessage = (msg: any, app: App): void => {
     if (!msg.payload) {
       const error: Error = new Error("Relay chain spec was not found")
       this.#handleError(app, error)
@@ -373,7 +373,10 @@ export class ConnectionManager
     )
   }
 
-  #handleMessage = (msg: MessageToManager, port: chrome.runtime.Port): void => {
+  #handleMessage = (
+    msg: ProviderMessageToExtension,
+    port: chrome.runtime.Port,
+  ): void => {
     if (msg.type !== "rpc" && msg.type !== "spec") {
       console.warn(
         `Unrecognised message type ${msg.type} received from content script`,
@@ -384,6 +387,10 @@ export class ConnectionManager
     if (app) {
       if (msg.type === "spec" && app.chainName) {
         return this.#handleSpecMessage(msg, app)
+      }
+
+      if (!msg.payload) {
+        return
       }
 
       if (app.chain === undefined) {

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -14,7 +14,7 @@ import EventEmitter from "eventemitter3"
 import { StateEmitter, State } from "./types"
 import { NetworkMainInfo, Network } from "../types"
 import { logger } from "@polkadot/util"
-import { ProviderMessageToExtension } from "@substrate/connect-extension-protocol"
+import { ToExtension } from "@substrate/connect-extension-protocol"
 
 const l = logger("Extension Connection Manager")
 
@@ -368,10 +368,7 @@ export class ConnectionManager
     )
   }
 
-  #handleMessage = (
-    msg: ProviderMessageToExtension,
-    port: chrome.runtime.Port,
-  ): void => {
+  #handleMessage = (msg: ToExtension, port: chrome.runtime.Port): void => {
     if (msg.type !== "rpc" && msg.type !== "spec") {
       console.warn(
         `Unrecognised message type ${msg.type} received from content script`,

--- a/projects/extension/src/content/ExtensionMessageRouter.test.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.test.ts
@@ -1,7 +1,7 @@
 import { jest } from "@jest/globals"
 import { ExtensionMessageRouter } from "./ExtensionMessageRouter"
 import {
-  ProviderMessageData,
+  ProviderMessageToExtension,
   MessageFromManager,
   ExtensionMessage,
   ExtensionMessageData,
@@ -137,23 +137,25 @@ describe("Connection and forward cases", () => {
     await waitForMessageToBePosted()
 
     // rpc
-    const rpcMessage: ProviderMessageData = {
+    const rpcMessage: ProviderMessageToExtension = {
       chainId: 1,
       appName: "test-app",
       chainName: "westend",
       action: "forward",
-      message: {
-        type: "rpc",
-        payload:
-          '{"id":1,"jsonrpc":"2.0","method":"state_getStorage","params":["<hash>"]}',
-      },
+      type: "rpc",
+      payload:
+        '{"id":1,"jsonrpc":"2.0","method":"state_getStorage","params":["<hash>"]}',
       origin: "extension-provider",
     }
     provider.send(rpcMessage)
     await waitForMessageToBePosted()
     expect(chrome.runtime.connect).toHaveBeenCalledTimes(1)
     expect(router.connections.length).toBe(1)
-    expect(port.postMessage).toHaveBeenCalledWith(rpcMessage.message)
+    const sample = {
+      type: rpcMessage.type,
+      payload: rpcMessage.payload,
+    }
+    expect(port.postMessage).toHaveBeenCalledWith(sample)
   })
 
   test("forwards rpc message from extension -> app", async () => {

--- a/projects/extension/src/content/ExtensionMessageRouter.test.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.test.ts
@@ -1,7 +1,7 @@
 import { jest } from "@jest/globals"
 import { ExtensionMessageRouter } from "./ExtensionMessageRouter"
 import {
-  ProviderMessageToExtension,
+  ToExtension,
   ExtensionMessage,
   ToApplication,
   provider,
@@ -136,7 +136,7 @@ describe("Connection and forward cases", () => {
     await waitForMessageToBePosted()
 
     // rpc
-    const rpcMessage: ProviderMessageToExtension = {
+    const rpcMessage: ToExtension = {
       chainId: 1,
       appName: "test-app",
       chainName: "westend",

--- a/projects/extension/src/content/ExtensionMessageRouter.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.ts
@@ -53,8 +53,13 @@ export class ExtensionMessageRouter {
 
     // forward any messages: extension -> page
     port.onMessage.addListener((data): void => {
+      const { type, payload } = data
       debug(`RECEIVED MESSAGE FROM ${chainName} PORT`, data)
-      extension.send({ message: data, origin: CONTENT_SCRIPT_ORIGIN })
+      extension.send({
+        type,
+        payload,
+        origin: CONTENT_SCRIPT_ORIGIN,
+      })
     })
 
     // tell the page when the port disconnects

--- a/projects/extension/src/content/ExtensionMessageRouter.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import {
-  MessageToManager,
   ProviderMessage,
   extension,
 } from "@substrate/connect-extension-protocol"
@@ -46,7 +45,7 @@ export class ExtensionMessageRouter {
   }
 
   #establishNewConnection = ({ data }: ProviderMessage): void => {
-    const { chainName, chainId, appName, message } = data
+    const { chainName, chainId, appName } = data
     const port = chrome.runtime.connect({
       name: `${appName}::${chainName}`,
     })
@@ -65,11 +64,11 @@ export class ExtensionMessageRouter {
     })
 
     this.#ports[chainId] = port
-    debug(`CONNECTED TO ${chainName} PORT`, message)
+    debug(`CONNECTED TO ${chainName} PORT`)
   }
 
   #forwardRpcMessage = ({ data }: ProviderMessage): void => {
-    const { chainName, chainId, message } = data
+    const { chainName, chainId, type, payload, parachainPayload } = data
     const port = this.#ports[chainId]
     if (!port) {
       // this is probably someone trying to abuse the extension.
@@ -79,8 +78,10 @@ export class ExtensionMessageRouter {
       return
     }
 
-    debug(`SENDING RPC MESSAGE TO ${chainName} PORT`, message)
-    port.postMessage(message)
+    const msg = { type, payload, parachainPayload }
+
+    debug(`SENDING RPC MESSAGE TO ${chainName} PORT`, msg)
+    port.postMessage(msg)
   }
 
   #disconnectPort = ({ data }: ProviderMessage): void => {
@@ -101,7 +102,7 @@ export class ExtensionMessageRouter {
 
   #handleMessage = (msg: ProviderMessage): void => {
     const data = msg.data
-    const { origin, action, message } = data
+    const { origin, action, type } = data
     if (!origin || origin !== EXTENSION_PROVIDER_ORIGIN) {
       return
     }
@@ -121,14 +122,13 @@ export class ExtensionMessageRouter {
     }
 
     if (action === "forward") {
-      const innerMessage = message as MessageToManager
-      if (!innerMessage.type) {
+      if (!type) {
         // probably someone abusing the extension
         console.warn("Malformed message - missing message.type", data)
         return
       }
 
-      if (innerMessage.type === "rpc" || innerMessage.type === "spec") {
+      if (type === "rpc" || type === "spec") {
         return this.#forwardRpcMessage(msg)
       }
 

--- a/projects/extension/src/mocks.ts
+++ b/projects/extension/src/mocks.ts
@@ -4,7 +4,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { jest } from "@jest/globals"
 import { App, ConnectionManagerInterface } from "./background/types"
-import { MessageFromManager } from "@substrate/connect-extension-protocol"
 import { Chain } from "@substrate/smoldot-light"
 import { Network } from "./types"
 

--- a/projects/extension/src/mocks.ts
+++ b/projects/extension/src/mocks.ts
@@ -4,10 +4,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { jest } from "@jest/globals"
 import { App, ConnectionManagerInterface } from "./background/types"
-import {
-  MessageToManager,
-  MessageFromManager,
-} from "@substrate/connect-extension-protocol"
+import { MessageFromManager } from "@substrate/connect-extension-protocol"
 import { Chain } from "@substrate/smoldot-light"
 import { Network } from "./types"
 
@@ -29,7 +26,7 @@ export class MockPort implements chrome.runtime.Port {
     this.sender.tab.id = id
   }
 
-  triggerMessage(message: MessageFromManager | MessageToManager): void {
+  triggerMessage(message: any): void {
     this.#messageListeners.forEach((l: any) => {
       l(message, this)
     })


### PR DESCRIPTION
Following up tasks on #572 :
> Right now the protocol mentions the web page, the content script, and the extension as layers of an onion. This is technically correct, but this is _not_ what the `connection-extension-protocol` package is about. This package is only about the communication between the web page and the content script. What happens between the content script and the extension is an implementation detail of the extension and shouldn't be mentioned in `connection-extension-protocol` because it's out of scope.
>    - Consequently, we should merge the `ProviderMessageData` and `MessageToManager` interfaces into one single interface, and `ExtensionMessageData` and `MessageFromManager` into one single interface.
>    - Afterwards, we can rename them to something more simple such as `ToExtension` and `ToWebpage` or something like that. The words `Provider` and `Manager` shouldn't be used because they're implementation details.