### PR TITLE
Remove extension and provider variables from connect-extension-protocol

### DIFF
--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -49,25 +49,6 @@ export interface ToApplication {
 export type ExtensionListenHandler = (message: ProviderMessage) => void
 
 /**
- * extension provides strongly typed convenience wrappers around
- * the `window.postMessage` and `window.addEventListener` APIs used for
- * message passing on the extension side of communication.
- */
-export const extension = {
-  /** send a message from the extension to the app **/
-  send: (message: ToApplication): void => {
-    window.postMessage(message, "*")
-  },
-  /**
-   * Listen to messages from the `ExtensionProvider` in the app sent to
-   * the extension.
-   */
-  listen: (handler: ExtensionListenHandler): void => {
-    window.addEventListener("message", handler)
-  },
-}
-
-/**
  * ProviderMessage represents messages sent via `window.postMessage` from
  * `ExtensionProvider` to `ExtensionMessageRouter` as received by the extension.
  *

--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -83,22 +83,3 @@ export interface ToExtension {
  * `ExtensionProvider`.
  */
 export type ProviderListenHandler = (message: ExtensionMessage) => void
-
-/**
- * provider provides properly typed convenience wrappers around the
- * `window.postMessage` and `window.addEventListener` APIs used for message
- * passing on the \@substrate/connect `ExtensionProvider` end of communication.
- */
-export const provider = {
-  /** send a message from the app to the extension **/
-  send: (message: ToExtension): void => {
-    window.postMessage(message, "*")
-  },
-  /**
-   * Listen to messages from the `ExtensionMessageRouter` in the extension sent
-   * to the app.
-   */
-  listen: (handler: ProviderListenHandler): void => {
-    window.addEventListener("message", handler)
-  },
-}

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -7,7 +7,6 @@ import {
   ProviderMessage,
   ToExtension,
   ToApplication,
-  extension,
 } from "@substrate/connect-extension-protocol"
 
 const waitForMessageToBePosted = (): Promise<null> => {
@@ -16,13 +15,17 @@ const waitForMessageToBePosted = (): Promise<null> => {
   return new Promise((resolve) => setTimeout(resolve, 10, null))
 }
 
+const sendMessage = (msg: ToApplication): void => {
+  window.postMessage(msg, "*")
+}
+
 const westendSpec = JSON.stringify({ name: "Westend", id: "westend2" })
 const rococoSpec = JSON.stringify({ name: "Rococo", id: "rococo" })
 
 let handler = jest.fn()
 beforeEach(() => {
   handler = jest.fn()
-  extension.listen(handler)
+  window.addEventListener("message", handler)
 })
 
 afterEach(() => {
@@ -150,7 +153,7 @@ test("disconnects and emits disconnected when it receives a disconnect message",
 
   ep.on("disconnected", emitted)
   await waitForMessageToBePosted()
-  extension.send({
+  sendMessage({
     origin: "content-script",
     disconnect: true,
   })
@@ -170,7 +173,7 @@ test("emits error when it receives an error message", async () => {
   }
   const errorHandler = jest.fn()
   ep.on("error", errorHandler)
-  window.postMessage(errorMessage, "*")
+  sendMessage(errorMessage)
   await waitForMessageToBePosted()
 
   expect(errorHandler).toHaveBeenCalled()

--- a/projects/extension/src/content/ExtensionMessageRouter.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.ts
@@ -2,12 +2,16 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import {
   ProviderMessage,
-  extension,
+  ToApplication,
 } from "@substrate/connect-extension-protocol"
 import { debug } from "../utils/debug"
 
 const CONTENT_SCRIPT_ORIGIN = "content-script"
 const EXTENSION_PROVIDER_ORIGIN = "extension-provider"
+
+const sendMessage = (msg: ToApplication): void => {
+  window.postMessage(msg, "*")
+}
 
 /* ExtensionMessageRouter is the part of the content script that listens for
  * messages that the ExtensionProvider in an app sends using `window.postMessage`.
@@ -36,7 +40,7 @@ export class ExtensionMessageRouter {
 
   /** listen starts listening for messages sent by an app.  */
   listen(): void {
-    extension.listen(this.#handleMessage)
+    window.addEventListener("message", this.#handleMessage)
   }
 
   /** stop stops listening for messages sent by apps.  */
@@ -55,7 +59,7 @@ export class ExtensionMessageRouter {
     port.onMessage.addListener((data): void => {
       const { type, payload } = data
       debug(`RECEIVED MESSAGE FROM ${chainName} PORT`, data)
-      extension.send({
+      sendMessage({
         type,
         payload,
         origin: CONTENT_SCRIPT_ORIGIN,
@@ -64,7 +68,7 @@ export class ExtensionMessageRouter {
 
     // tell the page when the port disconnects
     port.onDisconnect.addListener(() => {
-      extension.send({ origin: "content-script", disconnect: true })
+      sendMessage({ origin: "content-script", disconnect: true })
       delete this.#ports[chainId]
     })
 


### PR DESCRIPTION
Following task #572 this PR is fixing the following:

- Remove the `extension` and `provider` variables. It doesn't make sense to use the variable `provider` when in the extension and vice versa, so why are they available? Again, sending and listening is out of scope of the `connection-extension-protocol` package which should only provide the protocol.
