### PR TITLE
remove `ExtensionMessage` and `ProviderMessage`

### DIFF
--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -20,16 +20,6 @@
  * The {@link ConnectionManager} is the class in the extension background.
  */
 
-/**
- * ExtensionMessage represents messages sent via
- * `window.postMessage` from `ExtensionMessageRouter` to `ExtensionProvider`
- * as recieved by the `ExtensionProvider`.
- *
- * @remarks The browser wraps the message putting it in {@link data}
- */
-export interface ExtensionMessage {
-  data: ToApplication
-}
 export interface ToApplication {
   /** origin is used to determine which side sent the message **/
   origin: "content-script"
@@ -39,23 +29,6 @@ export interface ToApplication {
   type?: "error" | "rpc"
   /** Payload of the message. Either a JSON encoded RPC response or an error message **/
   payload?: string
-}
-
-/**
- * ExtensionListenHandler is a message handler type for receiving
- * `ProviderMessage` messages from the \@substrate/connect `ExtensionProvider`
- * in the extension.
- */
-export type ExtensionListenHandler = (message: ProviderMessage) => void
-
-/**
- * ProviderMessage represents messages sent via `window.postMessage` from
- * `ExtensionProvider` to `ExtensionMessageRouter` as received by the extension.
- *
- * @remarks The browser wraps the message putting it in {@link data}
- */
-export interface ProviderMessage {
-  data: ToExtension
 }
 
 export interface ToExtension {
@@ -76,10 +49,3 @@ export interface ToExtension {
   payload?: string
   parachainPayload?: string
 }
-
-/**
- * ProviderListenHandler is a message handler type for receiving
- * `ExtensionMessage` messages from the extension in the \@substrate/connect
- * `ExtensionProvider`.
- */
-export type ProviderListenHandler = (message: ExtensionMessage) => void

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -1,10 +1,11 @@
 /*
  * @jest-environment jsdom
  */
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { jest } from "@jest/globals"
 import { ExtensionProvider } from "./ExtensionProvider"
 import {
-  ProviderMessage,
   ToExtension,
   ToApplication,
 } from "@substrate/connect-extension-protocol"
@@ -48,7 +49,7 @@ test("connected and sends correct spec message", async () => {
     type: "spec",
   }
   expect(handler).toHaveBeenCalledTimes(2)
-  const { data } = handler.mock.calls[1][0] as ProviderMessage
+  const { data } = handler.mock.calls[1][0] as MessageEvent
   expect(data).toMatchObject(expectedMessage)
 })
 
@@ -82,8 +83,8 @@ test("connected multiple chains and sends correct spec message", async () => {
   }
 
   expect(handler).toHaveBeenCalledTimes(4)
-  const data1 = handler.mock.calls[1][0] as ProviderMessage
-  const data2 = handler.mock.calls[3][0] as ProviderMessage
+  const data1 = handler.mock.calls[1][0] as MessageEvent
+  const data2 = handler.mock.calls[3][0] as MessageEvent
   expect(data1.data).toMatchObject(expectedMessage1)
   expect(data2.data).toMatchObject(expectedMessage2)
 })
@@ -104,7 +105,7 @@ test("connected parachain sends correct spec message", async () => {
     type: "spec",
   }
   expect(handler).toHaveBeenCalledTimes(2)
-  const { data } = handler.mock.calls[1][0] as ProviderMessage
+  const { data } = handler.mock.calls[1][0] as MessageEvent
   expect(data).toMatchObject(expectedMessage)
 })
 
@@ -120,7 +121,7 @@ test("connect sends connect message and emits connected", async () => {
     origin: "extension-provider",
   }
   expect(handler).toHaveBeenCalledTimes(2)
-  const { data } = handler.mock.calls[0][0] as ProviderMessage
+  const { data } = handler.mock.calls[0][0] as MessageEvent
   expect(data).toMatchObject(expectedMessage)
 })
 
@@ -140,7 +141,7 @@ test("disconnect sends disconnect message and emits disconnected", async () => {
     origin: "extension-provider",
   }
   expect(handler).toHaveBeenCalledTimes(3)
-  const { data } = handler.mock.calls[2][0] as ProviderMessage
+  const { data } = handler.mock.calls[2][0] as MessageEvent
   expect(data).toMatchObject(expectedMessage)
   expect(ep.isConnected).toBe(false)
   expect(emitted).toHaveBeenCalledTimes(1)

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
@@ -15,7 +15,6 @@ import { isUndefined, eraseRecord } from "../utils/index.js"
 import { HealthCheckError } from "../errors.js"
 import {
   ToExtension,
-  ExtensionMessage,
   ToApplication,
 } from "@substrate/connect-extension-protocol"
 
@@ -307,11 +306,14 @@ export class ExtensionProvider implements ProviderInterface {
       specMsg.parachainPayload = this.#parachainSpecs
     }
     sendMessage(specMsg)
-    window.addEventListener("message", ({ data }: ExtensionMessage) => {
-      if (data.origin && data.origin === CONTENT_SCRIPT_ORIGIN) {
-        this.#handleMessage(data)
-      }
-    })
+    window.addEventListener(
+      "message",
+      ({ data }: MessageEvent<ToApplication>) => {
+        if (data.origin && data.origin === CONTENT_SCRIPT_ORIGIN) {
+          this.#handleMessage(data)
+        }
+      },
+    )
     this.#connectionStatePingerId = setInterval(
       this.#checkClientPeercount,
       this.healthPingerInterval,

--- a/projects/extension/src/content/ExtensionMessageRouter.test.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.test.ts
@@ -1,8 +1,8 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { jest } from "@jest/globals"
 import { ExtensionMessageRouter } from "./ExtensionMessageRouter"
 import {
   ToExtension,
-  ExtensionMessage,
   ToApplication,
 } from "@substrate/connect-extension-protocol"
 import { MockPort } from "../mocks"
@@ -56,7 +56,7 @@ describe("Disconnect and incorrect cases", () => {
     }
 
     expect(router.connections.length).toBe(0)
-    const { data } = handler.mock.calls[0][0] as ExtensionMessage
+    const { data } = handler.mock.calls[0][0] as MessageEvent
     expect(data).toEqual(expectedMessage)
   })
 
@@ -181,7 +181,7 @@ describe("Connection and forward cases", () => {
     expect(chrome.runtime.connect).toHaveBeenCalledTimes(1)
     expect(port.disconnect).not.toHaveBeenCalled()
     expect(handler).toHaveBeenCalled()
-    const forwarded = handler.mock.calls[0][0] as ExtensionMessage
+    const forwarded = handler.mock.calls[0][0] as MessageEvent
     expect(forwarded.data).toEqual({
       origin: "content-script",
       type: "rpc",
@@ -208,7 +208,7 @@ describe("Connection and forward cases", () => {
     await waitForMessageToBePosted()
 
     expect(handler).toHaveBeenCalled()
-    const forwarded = handler.mock.calls[0][0] as ExtensionMessage
+    const forwarded = handler.mock.calls[0][0] as MessageEvent
     expect(forwarded.data).toEqual({
       origin: "content-script",
       type: "error",


### PR DESCRIPTION
Following task #572 this PR is fixing the following:

- Also remove the `ExtensionMessage` and `ProviderMessage` interfaces, again to simplify. The actual type that the callback passed to `addEventListener` receives is [`MessageEvent`](https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent) (which as a field named `data`), and not `ExtensionMessage` or `ProviderMessage`. You can't actually know in advance what the `data` field contains in this context.