### PR TITLE
remove `ExtensionMessageData.disconnect`

### DIFF
--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -23,8 +23,6 @@
 export interface ToApplication {
   /** origin is used to determine which side sent the message **/
   origin: "content-script"
-  /** message is telling the `ExtensionProvider` the port has been closed **/
-  disconnect?: boolean
   /** Type of the message. Defines how to interpret the {@link payload} */
   type?: "error" | "rpc"
   /** Payload of the message. Either a JSON encoded RPC response or an error message **/

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -147,16 +147,17 @@ test("disconnect sends disconnect message and emits disconnected", async () => {
   expect(emitted).toHaveBeenCalledTimes(1)
 })
 
-test("disconnects and emits disconnected when it receives a disconnect message", async () => {
+test("disconnects and emits an error when it receives an error message", async () => {
   const ep = new ExtensionProvider("test", westendSpec)
   const emitted = jest.fn()
   await ep.connect()
 
-  ep.on("disconnected", emitted)
+  ep.on("error", emitted)
   await waitForMessageToBePosted()
   sendMessage({
     origin: "content-script",
-    disconnect: true,
+    type: "error",
+    payload: "disconnected",
   })
   await waitForMessageToBePosted()
   expect(emitted).toHaveBeenCalled()

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
@@ -137,19 +137,15 @@ export class ExtensionProvider implements ProviderInterface {
   }
 
   #handleMessage = (data: ToApplication): void => {
-    if (data.disconnect && data.disconnect === true) {
+    const { type, payload } = data
+    if (type === "error") {
       this.#isConnected = false
-      this.emit("disconnected")
-      const error = new Error("Disconnected from the extension")
+      const error = new Error(payload)
+      this.emit("error", error)
       // reject all hanging requests
       eraseRecord(this.#handlers, (h) => h.callback(error, undefined))
       eraseRecord(this.#waitingForId)
       return
-    }
-
-    const { type, payload } = data
-    if (type === "error") {
-      return this.emit("error", new Error(payload))
     }
 
     if (type === "rpc" && payload) {

--- a/projects/extension/src/content/ExtensionMessageRouter.test.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.test.ts
@@ -32,7 +32,7 @@ describe("Disconnect and incorrect cases", () => {
     router.stop()
   })
 
-  test("port disconnecting sends disconnect message and removes port", async () => {
+  test("port disconnecting sends an error message and removes port", async () => {
     const port = new MockPort("test-app::westend")
     const connect = chrome.runtime.connect
     connect.mockImplementation(() => port)
@@ -52,12 +52,12 @@ describe("Disconnect and incorrect cases", () => {
 
     const expectedMessage: ToApplication = {
       origin: "content-script",
-      disconnect: true,
+      type: "error",
     }
 
     expect(router.connections.length).toBe(0)
     const { data } = handler.mock.calls[0][0] as MessageEvent
-    expect(data).toEqual(expectedMessage)
+    expect(data).toMatchObject(expectedMessage)
   })
 
   test("incorrect origin does nothing to connections", async () => {

--- a/projects/extension/src/content/ExtensionMessageRouter.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.ts
@@ -71,7 +71,11 @@ export class ExtensionMessageRouter {
 
     // tell the page when the port disconnects
     port.onDisconnect.addListener(() => {
-      sendMessage({ origin: "content-script", disconnect: true })
+      sendMessage({
+        origin: "content-script",
+        type: "error",
+        payload: "Lost communication with substrate-connect extension",
+      })
       delete this.#ports[chainId]
     })
 


### PR DESCRIPTION
Following task #572 this PR is fixing the following:

- Remove the `ExtensionMessageData.disconnect` field, because it's exactly the same thing as `MessageFromManager.type` being equal to `error`.