### PR TITLE
remove `appName` field

### DIFF
--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -32,8 +32,6 @@ export interface ToApplication {
 export interface ToExtension {
   /** origin is used to determine which side sent the message **/
   origin: "extension-provider"
-  /** The name of the app to be used for display purposes in the extension UI **/
-  appName: string
   /** The uniqueId for extension multiplexing **/
   chainId: number
   /** The name of the blockchain network the app is talking to **/

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -34,14 +34,13 @@ afterEach(() => {
 })
 
 test("connected and sends correct spec message", async () => {
-  const ep = new ExtensionProvider("test", westendSpec)
+  const ep = new ExtensionProvider(westendSpec)
   const emitted = jest.fn()
   ep.on("connected", emitted)
   await ep.connect()
   await waitForMessageToBePosted()
 
   const expectedMessage: Partial<ToExtension> = {
-    appName: "test",
     chainName: "Westend",
     action: "forward",
     origin: "extension-provider",
@@ -54,8 +53,8 @@ test("connected and sends correct spec message", async () => {
 })
 
 test("connected multiple chains and sends correct spec message", async () => {
-  const ep1 = new ExtensionProvider("test", westendSpec)
-  const ep2 = new ExtensionProvider("test2", rococoSpec)
+  const ep1 = new ExtensionProvider(westendSpec)
+  const ep2 = new ExtensionProvider(rococoSpec)
   const emitted1 = jest.fn()
   const emitted2 = jest.fn()
   ep1.on("connected", emitted1)
@@ -66,7 +65,6 @@ test("connected multiple chains and sends correct spec message", async () => {
   await waitForMessageToBePosted()
 
   const expectedMessage1: Partial<ToExtension> = {
-    appName: "test",
     chainName: "Westend",
     action: "forward",
     origin: "extension-provider",
@@ -74,7 +72,6 @@ test("connected multiple chains and sends correct spec message", async () => {
     type: "spec",
   }
   const expectedMessage2: Partial<ToExtension> = {
-    appName: "test2",
     chainName: "Rococo",
     action: "forward",
     origin: "extension-provider",
@@ -90,14 +87,13 @@ test("connected multiple chains and sends correct spec message", async () => {
 })
 
 test("connected parachain sends correct spec message", async () => {
-  const ep = new ExtensionProvider("test", westendSpec)
+  const ep = new ExtensionProvider(westendSpec)
   const emitted = jest.fn()
   ep.on("connected", emitted)
   await ep.connect()
   await waitForMessageToBePosted()
 
   const expectedMessage: Partial<ToExtension> = {
-    appName: "test",
     chainName: "Westend",
     action: "forward",
     origin: "extension-provider",
@@ -110,12 +106,11 @@ test("connected parachain sends correct spec message", async () => {
 })
 
 test("connect sends connect message and emits connected", async () => {
-  const ep = new ExtensionProvider("test", westendSpec)
+  const ep = new ExtensionProvider(westendSpec)
   await ep.connect()
   await waitForMessageToBePosted()
 
   const expectedMessage: Partial<ToExtension> = {
-    appName: "test",
     chainName: "Westend",
     action: "connect",
     origin: "extension-provider",
@@ -126,7 +121,7 @@ test("connect sends connect message and emits connected", async () => {
 })
 
 test("disconnect sends disconnect message and emits disconnected", async () => {
-  const ep = new ExtensionProvider("test", westendSpec)
+  const ep = new ExtensionProvider(westendSpec)
   const emitted = jest.fn()
   await ep.connect()
 
@@ -135,7 +130,6 @@ test("disconnect sends disconnect message and emits disconnected", async () => {
   await waitForMessageToBePosted()
 
   const expectedMessage: Partial<ToExtension> = {
-    appName: "test",
     chainName: "Westend",
     action: "disconnect",
     origin: "extension-provider",
@@ -148,7 +142,7 @@ test("disconnect sends disconnect message and emits disconnected", async () => {
 })
 
 test("disconnects and emits an error when it receives an error message", async () => {
-  const ep = new ExtensionProvider("test", westendSpec)
+  const ep = new ExtensionProvider(westendSpec)
   const emitted = jest.fn()
   await ep.connect()
 
@@ -165,7 +159,7 @@ test("disconnects and emits an error when it receives an error message", async (
 })
 
 test("emits error when it receives an error message", async () => {
-  const ep = new ExtensionProvider("test", westendSpec)
+  const ep = new ExtensionProvider(westendSpec)
   await ep.connect()
   await waitForMessageToBePosted()
   const errorMessage: ToApplication = {

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
@@ -81,21 +81,14 @@ export class ExtensionProvider implements ProviderInterface {
 
   #chainSpecs: string
   #parachainSpecs: string
-  #commonMessageData: Pick<
-    ToExtension,
-    "appName" | "chainId" | "chainName" | "origin"
-  >
+  #commonMessageData: Pick<ToExtension, "chainId" | "chainName" | "origin">
 
   /*
    * How frequently to see if we have any peers
    */
   healthPingerInterval = CONNECTION_STATE_PINGER_INTERVAL
 
-  public constructor(
-    displayName: string,
-    relayChain: string,
-    parachain?: string,
-  ) {
+  public constructor(relayChain: string, parachain?: string) {
     /**
      * TODO: we should remove the chainName from the payload of the messages,
      * since this is information that doesn't have to be sent on every message and
@@ -109,7 +102,6 @@ export class ExtensionProvider implements ProviderInterface {
       this.#parachainSpecs = parachain
     }
     this.#commonMessageData = {
-      appName: displayName,
       chainId: nextChainId++,
       chainName: JSON.parse(relayChain).name,
       origin: EXTENSION_PROVIDER_ORIGIN,

--- a/packages/connect/src/ScProvider.ts
+++ b/packages/connect/src/ScProvider.ts
@@ -54,41 +54,28 @@ export class ScProvider implements ProviderInterface {
   }
 
   /**
-   * @param displayName - a display name that will be used from the dev-tools of the Extension (if installed)
    * @param knownChain - the name of a supported chain ({@link SupportedChains})
    * @param parachainSpec - optional param of the parachain chainSpecs to connect to
    * @param autoConnect - whether the ScProvider should eagerly connect while its being instantiated. Defaults to `true`
    *
-   * @remarks
-   *
-   * You should make a best effort to make the displayName of your app name unique to avoid
-   * confusion for users in the extension user interface
    */
   public constructor(
-    displayName: string,
     knownChain: SupportedChains,
     parachainSpec?: string,
     autoConnect?: boolean,
   )
   /**
-   * @param displayName - a display name that will be used from the dev-tools of the Extension (if installed)
    * @param chainSpec - a string with the spec of the chain
    * @param parachainSpec - optional param of the parachain chainSpecs to connect to
    * @param autoConnect - whether the ScProvider should eagerly connect while its being instantiated. Defaults to `true`
    *
-   * @remarks
-   *
-   * You should make a best effort to make the displayName of your app name unique to avoid
-   * confusion for users in the extension user interface
    */
   public constructor(
-    displayName: string,
     chainSpec: string,
     parachainSpec?: string,
     autoConnect?: boolean,
   )
   public constructor(
-    displayName: string,
     chainSpec: string,
     parachainSpec?: string,
     autoConnect = true,
@@ -96,7 +83,6 @@ export class ScProvider implements ProviderInterface {
     const isExtension = !!document.getElementById("substrateExtension")
 
     this.#providerP = this.internalProvider(
-      displayName,
       isExtension,
       chainSpec,
       parachainSpec,
@@ -111,7 +97,6 @@ export class ScProvider implements ProviderInterface {
   /**
    * Detects and returns an appropriate PolkadotJS provider depending on whether the user has the substrate connect extension installed
    *
-   * @param displayName - a display name used by the dev-tools of the extension
    * @param isExtension - whether the extension is installed
    * @param chain - either a string with the spec of the chain or the name of a supported chain ({@link SupportedChains})
    * @param parachainSpec - optional param of the parachain chainSpecs to connect to
@@ -123,7 +108,6 @@ export class ScProvider implements ProviderInterface {
    * This is used internally for advanced PolkadotJS use cases and is not supported.  Use {@link connect} instead.
    */
   private internalProvider = async (
-    displayName: string,
     isExtension: boolean,
     chain: string | SupportedChains,
     parachainSpec?: string,
@@ -147,7 +131,6 @@ export class ScProvider implements ProviderInterface {
       ])
 
       return new ExtensionProvider(
-        displayName,
         chainSpec,
         parachainSpec,
       ) as ProviderInterface

--- a/projects/burnr/src/hooks/api/useApiCreate.ts
+++ b/projects/burnr/src/hooks/api/useApiCreate.ts
@@ -21,7 +21,7 @@ export default function useApiCreate(): ApiPromise {
   useEffect((): void => {
     const choseSmoldot = async (endpoint: string): Promise<void> => {
       try {
-        const provider = new ScProvider("burnr wallet", endpoint)
+        const provider = new ScProvider(endpoint)
         const api = await ApiPromise.create({ provider })
         l.log(`Burnr is now connected to ${endpoint}`)
         mountedRef.current && setApi(api)

--- a/projects/extension/src/content/ExtensionMessageRouter.test.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.test.ts
@@ -38,7 +38,6 @@ describe("Disconnect and incorrect cases", () => {
     connect.mockImplementation(() => port)
     sendMessage({
       chainId: 1,
-      appName: "test-app",
       chainName: "westend",
       action: "connect",
       origin: "extension-provider",
@@ -73,7 +72,6 @@ describe("Disconnect and incorrect cases", () => {
   test("disconnect disconnects established connection", async () => {
     sendMessage({
       chainId: 1,
-      appName: "test-app",
       chainName: "westend",
       action: "connect",
       origin: "extension-provider",
@@ -82,7 +80,6 @@ describe("Disconnect and incorrect cases", () => {
 
     sendMessage({
       chainId: 1,
-      appName: "test-app",
       chainName: "westend",
       action: "disconnect",
       origin: "extension-provider",
@@ -110,7 +107,6 @@ describe("Connection and forward cases", () => {
   test("connect establishes a port", async () => {
     sendMessage({
       chainId: 1,
-      appName: "test-app",
       chainName: "westend",
       action: "connect",
       origin: "extension-provider",
@@ -128,7 +124,6 @@ describe("Connection and forward cases", () => {
     // connect
     sendMessage({
       chainId: 1,
-      appName: "test-app",
       chainName: "westend",
       action: "connect",
       origin: "extension-provider",
@@ -138,7 +133,6 @@ describe("Connection and forward cases", () => {
     // rpc
     const rpcMessage: ToExtension = {
       chainId: 1,
-      appName: "test-app",
       chainName: "westend",
       action: "forward",
       type: "rpc",
@@ -163,7 +157,6 @@ describe("Connection and forward cases", () => {
     // connect
     sendMessage({
       chainId: 1,
-      appName: "test-app",
       chainName: "westend",
       action: "connect",
       origin: "extension-provider",
@@ -195,7 +188,6 @@ describe("Connection and forward cases", () => {
     // connect
     sendMessage({
       chainId: 1,
-      appName: "test-app",
       chainName: "westend",
       action: "connect",
       origin: "extension-provider",

--- a/projects/extension/src/content/ExtensionMessageRouter.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.ts
@@ -48,13 +48,9 @@ export class ExtensionMessageRouter {
     window.removeEventListener("message", this.#handleMessage)
   }
 
-  #establishNewConnection = ({
-    chainName,
-    chainId,
-    appName,
-  }: ToExtension): void => {
+  #establishNewConnection = ({ chainName, chainId }: ToExtension): void => {
     const port = chrome.runtime.connect({
-      name: `${appName}::${chainName}`,
+      name: `${window.location.href}::${chainName}`,
     })
     debug(`CONNECTED ${chainName} PORT`, port)
 

--- a/projects/multiple-network-demo/src/index.ts
+++ b/projects/multiple-network-demo/src/index.ts
@@ -9,10 +9,7 @@ window.onload = () => {
   void (async () => {
     try {
       const westend = async () => {
-        const provider = new ScProvider(
-          "Multiple Network Demo",
-          SupportedChains.westend,
-        )
+        const provider = new ScProvider(SupportedChains.westend)
         const westend = await ApiPromise.create({ provider })
         const westendUI = document.getElementById("westend")
         const westendHead = await westend.rpc.chain.getHeader()
@@ -25,10 +22,7 @@ window.onload = () => {
       }
 
       const kusama = async () => {
-        const provider = new ScProvider(
-          "Multiple Network Demo",
-          SupportedChains.kusama,
-        )
+        const provider = new ScProvider(SupportedChains.kusama)
         const kusama = await ApiPromise.create({ provider })
         const kusamaUI = document.getElementById("kusama")
         const kusamaHead = await kusama.rpc.chain.getHeader()
@@ -41,10 +35,7 @@ window.onload = () => {
       }
 
       const polkadot = async () => {
-        const provider = new ScProvider(
-          "Multiple Network Demo",
-          SupportedChains.polkadot,
-        )
+        const provider = new ScProvider(SupportedChains.polkadot)
         const polkadot = await ApiPromise.create({ provider })
         const polkadotUI = document.getElementById("polkadot")
         const polkadotHead = await polkadot.rpc.chain.getHeader()
@@ -57,10 +48,7 @@ window.onload = () => {
       }
 
       const rococo = async () => {
-        const provider = new ScProvider(
-          "Multiple Network Demo",
-          SupportedChains.rococo,
-        )
+        const provider = new ScProvider(SupportedChains.rococo)
         const rococo = await ApiPromise.create({ provider })
         const rococoUI = document.getElementById("rococo")
         const rococoHead = await rococo.rpc.chain.getHeader()

--- a/projects/parachain-demo/src/index.ts
+++ b/projects/parachain-demo/src/index.ts
@@ -16,7 +16,6 @@ window.onload = () => {
   ;(async () => {
     try {
       const provider = new ScProvider(
-        "Parachain Demo",
         SupportedChains.westend,
         JSON.stringify(westmint),
       )

--- a/projects/smoldot-browser-demo/src/index.ts
+++ b/projects/smoldot-browser-demo/src/index.ts
@@ -13,10 +13,7 @@ window.onload = () => {
   ui.showSyncing()
   ;(async () => {
     try {
-      const provider = new ScProvider(
-        "Smoldot Browser Demo",
-        SupportedChains.westend,
-      )
+      const provider = new ScProvider(SupportedChains.westend)
       const api = await ApiPromise.create({ provider })
 
       const header = await api.rpc.chain.getHeader()


### PR DESCRIPTION
Following task #572 this PR is fixing the following:
- Remove the `appName` field. Instead the extension should simply use the tab URL. We can always revisit later the decision of removing app names, but for now let's get rid of this field in order to unlock progress.