### PR TITLE
remove `connect` action from `ExtensionProvider`

### DIFF
--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -37,7 +37,7 @@ export interface ToExtension {
   /** The name of the blockchain network the app is talking to **/
   chainName: string
   /** What action the `ExtensionMessageRouter` should take **/
-  action: "forward" | "connect" | "disconnect"
+  action: "forward" | "disconnect"
   /** The message the `ExtensionMessageRouter` should forward to the background **/
   /** Type of the message. Defines how to interpret the {@link payload} */
   type?: "rpc" | "spec"

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -47,8 +47,8 @@ test("connected and sends correct spec message", async () => {
     payload: '{"name":"Westend","id":"westend2"}',
     type: "spec",
   }
-  expect(handler).toHaveBeenCalledTimes(2)
-  const { data } = handler.mock.calls[1][0] as MessageEvent
+  expect(handler).toHaveBeenCalledTimes(1)
+  const { data } = handler.mock.calls[0][0] as MessageEvent
   expect(data).toMatchObject(expectedMessage)
 })
 
@@ -79,9 +79,9 @@ test("connected multiple chains and sends correct spec message", async () => {
     type: "spec",
   }
 
-  expect(handler).toHaveBeenCalledTimes(4)
-  const data1 = handler.mock.calls[1][0] as MessageEvent
-  const data2 = handler.mock.calls[3][0] as MessageEvent
+  expect(handler).toHaveBeenCalledTimes(2)
+  const data1 = handler.mock.calls[0][0] as MessageEvent
+  const data2 = handler.mock.calls[1][0] as MessageEvent
   expect(data1.data).toMatchObject(expectedMessage1)
   expect(data2.data).toMatchObject(expectedMessage2)
 })
@@ -100,22 +100,7 @@ test("connected parachain sends correct spec message", async () => {
     payload: '{"name":"Westend","id":"westend2"}',
     type: "spec",
   }
-  expect(handler).toHaveBeenCalledTimes(2)
-  const { data } = handler.mock.calls[1][0] as MessageEvent
-  expect(data).toMatchObject(expectedMessage)
-})
-
-test("connect sends connect message and emits connected", async () => {
-  const ep = new ExtensionProvider(westendSpec)
-  await ep.connect()
-  await waitForMessageToBePosted()
-
-  const expectedMessage: Partial<ToExtension> = {
-    chainName: "Westend",
-    action: "connect",
-    origin: "extension-provider",
-  }
-  expect(handler).toHaveBeenCalledTimes(2)
+  expect(handler).toHaveBeenCalledTimes(1)
   const { data } = handler.mock.calls[0][0] as MessageEvent
   expect(data).toMatchObject(expectedMessage)
 })
@@ -134,8 +119,8 @@ test("disconnect sends disconnect message and emits disconnected", async () => {
     action: "disconnect",
     origin: "extension-provider",
   }
-  expect(handler).toHaveBeenCalledTimes(3)
-  const { data } = handler.mock.calls[2][0] as MessageEvent
+  expect(handler).toHaveBeenCalledTimes(2)
+  const { data } = handler.mock.calls[1][0] as MessageEvent
   expect(data).toMatchObject(expectedMessage)
   expect(ep.isConnected).toBe(false)
   expect(emitted).toHaveBeenCalledTimes(1)

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
@@ -276,12 +276,6 @@ export class ExtensionProvider implements ProviderInterface {
    * @remarks this is async to fulfill the interface with PolkadotJS
    */
   public connect(): Promise<void> {
-    const connectMsg: ToExtension = {
-      ...this.#commonMessageData,
-      action: "connect",
-    }
-    sendMessage(connectMsg)
-
     // Once connect is sent - send rpc to extension that will contain the chainSpecs
     // for the extension to call addChain on smoldot
     const specMsg: ToExtension = {

--- a/projects/extension/src/content/ExtensionMessageRouter.test.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.test.ts
@@ -39,7 +39,9 @@ describe("Disconnect and incorrect cases", () => {
     sendMessage({
       chainId: 1,
       chainName: "westend",
-      action: "connect",
+      type: "spec",
+      action: "forward",
+      payload: "westend",
       origin: "extension-provider",
     })
     await waitForMessageToBePosted()
@@ -73,7 +75,9 @@ describe("Disconnect and incorrect cases", () => {
     sendMessage({
       chainId: 1,
       chainName: "westend",
-      action: "connect",
+      type: "spec",
+      action: "forward",
+      payload: "westend",
       origin: "extension-provider",
     })
     await waitForMessageToBePosted()
@@ -108,7 +112,9 @@ describe("Connection and forward cases", () => {
     sendMessage({
       chainId: 1,
       chainName: "westend",
-      action: "connect",
+      type: "spec",
+      action: "forward",
+      payload: "westend",
       origin: "extension-provider",
     })
 
@@ -125,7 +131,9 @@ describe("Connection and forward cases", () => {
     sendMessage({
       chainId: 1,
       chainName: "westend",
-      action: "connect",
+      type: "spec",
+      action: "forward",
+      payload: "westend",
       origin: "extension-provider",
     })
     await waitForMessageToBePosted()
@@ -158,7 +166,9 @@ describe("Connection and forward cases", () => {
     sendMessage({
       chainId: 1,
       chainName: "westend",
-      action: "connect",
+      type: "spec",
+      action: "forward",
+      payload: "westend",
       origin: "extension-provider",
     })
     await waitForMessageToBePosted()
@@ -189,7 +199,9 @@ describe("Connection and forward cases", () => {
     sendMessage({
       chainId: 1,
       chainName: "westend",
-      action: "connect",
+      type: "spec",
+      action: "forward",
+      payload: "westend",
       origin: "extension-provider",
     })
     await waitForMessageToBePosted()

--- a/projects/extension/src/content/ExtensionMessageRouter.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.ts
@@ -129,10 +129,6 @@ export class ExtensionMessageRouter {
       return console.warn("Malformed message - missing action", msg)
     }
 
-    if (action === "connect") {
-      return this.#establishNewConnection(data)
-    }
-
     if (action === "disconnect") {
       return this.#disconnectPort(data)
     }
@@ -143,6 +139,8 @@ export class ExtensionMessageRouter {
         console.warn("Malformed message - missing message.type", data)
         return
       }
+
+      if (type === "spec") this.#establishNewConnection(data)
 
       if (type === "rpc" || type === "spec") {
         return this.#forwardRpcMessage(data)


### PR DESCRIPTION
Following task #572 this PR is fixing the following:

- Remove from the `ExtensionProvider` the code that was sending a message with the `connect` action. The extension can do what it was doing when receiving a `connect` event at initialization and/or the first time it receives an actual message.