### PR TITLE
remove `action` field from `ExtensionProvider`

### DIFF
--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -36,12 +36,10 @@ export interface ToExtension {
   chainId: number
   /** The name of the blockchain network the app is talking to **/
   chainName: string
-  /** What action the `ExtensionMessageRouter` should take **/
-  action: "forward" | "disconnect"
   /** The message the `ExtensionMessageRouter` should forward to the background **/
   /** Type of the message. Defines how to interpret the {@link payload} */
-  type?: "rpc" | "spec"
+  type: "rpc" | "spec"
   /** Payload of the message -  a JSON encoded RPC request **/
-  payload?: string
+  payload: string
   parachainPayload?: string
 }

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -42,7 +42,6 @@ test("connected and sends correct spec message", async () => {
 
   const expectedMessage: Partial<ToExtension> = {
     chainName: "Westend",
-    action: "forward",
     origin: "extension-provider",
     payload: '{"name":"Westend","id":"westend2"}',
     type: "spec",
@@ -66,14 +65,12 @@ test("connected multiple chains and sends correct spec message", async () => {
 
   const expectedMessage1: Partial<ToExtension> = {
     chainName: "Westend",
-    action: "forward",
     origin: "extension-provider",
     payload: '{"name":"Westend","id":"westend2"}',
     type: "spec",
   }
   const expectedMessage2: Partial<ToExtension> = {
     chainName: "Rococo",
-    action: "forward",
     origin: "extension-provider",
     payload: '{"name":"Rococo","id":"rococo"}',
     type: "spec",
@@ -95,7 +92,6 @@ test("connected parachain sends correct spec message", async () => {
 
   const expectedMessage: Partial<ToExtension> = {
     chainName: "Westend",
-    action: "forward",
     origin: "extension-provider",
     payload: '{"name":"Westend","id":"westend2"}',
     type: "spec",
@@ -114,14 +110,6 @@ test("disconnect sends disconnect message and emits disconnected", async () => {
   void ep.disconnect()
   await waitForMessageToBePosted()
 
-  const expectedMessage: Partial<ToExtension> = {
-    chainName: "Westend",
-    action: "disconnect",
-    origin: "extension-provider",
-  }
-  expect(handler).toHaveBeenCalledTimes(2)
-  const { data } = handler.mock.calls[1][0] as MessageEvent
-  expect(data).toMatchObject(expectedMessage)
   expect(ep.isConnected).toBe(false)
   expect(emitted).toHaveBeenCalledTimes(1)
 })

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
@@ -280,7 +280,6 @@ export class ExtensionProvider implements ProviderInterface {
     // for the extension to call addChain on smoldot
     const specMsg: ToExtension = {
       ...this.#commonMessageData,
-      action: "forward",
       type: "spec",
       payload: this.#chainSpecs || "",
     }
@@ -309,12 +308,6 @@ export class ExtensionProvider implements ProviderInterface {
    * telling it to disconnect the port with the background manager.
    */
   public disconnect(): Promise<void> {
-    const disconnectMsg: ToExtension = {
-      ...this.#commonMessageData,
-      action: "disconnect",
-    }
-
-    sendMessage(disconnectMsg)
     if (this.#connectionStatePingerId !== null) {
       clearInterval(this.#connectionStatePingerId)
     }
@@ -381,7 +374,6 @@ export class ExtensionProvider implements ProviderInterface {
 
       const rpcMsg: ToExtension = {
         ...this.#commonMessageData,
-        action: "forward",
         type: "rpc",
         payload: json,
       }

--- a/projects/extension/src/content/ExtensionMessageRouter.test.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.test.ts
@@ -40,7 +40,6 @@ describe("Disconnect and incorrect cases", () => {
       chainId: 1,
       chainName: "westend",
       type: "spec",
-      action: "forward",
       payload: "westend",
       origin: "extension-provider",
     })
@@ -70,29 +69,6 @@ describe("Disconnect and incorrect cases", () => {
     expect(chrome.runtime.connect).not.toHaveBeenCalled()
     expect(router.connections.length).toBe(0)
   })
-
-  test("disconnect disconnects established connection", async () => {
-    sendMessage({
-      chainId: 1,
-      chainName: "westend",
-      type: "spec",
-      action: "forward",
-      payload: "westend",
-      origin: "extension-provider",
-    })
-    await waitForMessageToBePosted()
-
-    sendMessage({
-      chainId: 1,
-      chainName: "westend",
-      action: "disconnect",
-      origin: "extension-provider",
-    })
-    await waitForMessageToBePosted()
-
-    expect(chrome.runtime.connect).toHaveBeenCalledTimes(1)
-    expect(router.connections.length).toBe(0)
-  })
 })
 
 describe("Connection and forward cases", () => {
@@ -113,7 +89,6 @@ describe("Connection and forward cases", () => {
       chainId: 1,
       chainName: "westend",
       type: "spec",
-      action: "forward",
       payload: "westend",
       origin: "extension-provider",
     })
@@ -132,7 +107,6 @@ describe("Connection and forward cases", () => {
       chainId: 1,
       chainName: "westend",
       type: "spec",
-      action: "forward",
       payload: "westend",
       origin: "extension-provider",
     })
@@ -142,7 +116,6 @@ describe("Connection and forward cases", () => {
     const rpcMessage: ToExtension = {
       chainId: 1,
       chainName: "westend",
-      action: "forward",
       type: "rpc",
       payload:
         '{"id":1,"jsonrpc":"2.0","method":"state_getStorage","params":["<hash>"]}',
@@ -167,7 +140,6 @@ describe("Connection and forward cases", () => {
       chainId: 1,
       chainName: "westend",
       type: "spec",
-      action: "forward",
       payload: "westend",
       origin: "extension-provider",
     })
@@ -200,7 +172,6 @@ describe("Connection and forward cases", () => {
       chainId: 1,
       chainName: "westend",
       type: "spec",
-      action: "forward",
       payload: "westend",
       origin: "extension-provider",
     })


### PR DESCRIPTION
Following task #572 this PR is fixing the following:

- Remove the `action` field, because all messages are automatically considered as `forward`. There's no need for the `connect` and `disconnect` messages. The code of `disconnect` can simply be removed for now. Update the content script of the extension to simply connect to the extension and forward messages back and forth. It doesn't have to do anything more.