### PR TITLE
remove `chainName` field from `ToExtension`

### DIFF
--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -34,8 +34,6 @@ export interface ToExtension {
   origin: "extension-provider"
   /** The uniqueId for extension multiplexing **/
   chainId: number
-  /** The name of the blockchain network the app is talking to **/
-  chainName: string
   /** The message the `ExtensionMessageRouter` should forward to the background **/
   /** Type of the message. Defines how to interpret the {@link payload} */
   type: "rpc" | "spec"

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -41,7 +41,6 @@ test("connected and sends correct spec message", async () => {
   await waitForMessageToBePosted()
 
   const expectedMessage: Partial<ToExtension> = {
-    chainName: "Westend",
     origin: "extension-provider",
     payload: '{"name":"Westend","id":"westend2"}',
     type: "spec",
@@ -64,13 +63,11 @@ test("connected multiple chains and sends correct spec message", async () => {
   await waitForMessageToBePosted()
 
   const expectedMessage1: Partial<ToExtension> = {
-    chainName: "Westend",
     origin: "extension-provider",
     payload: '{"name":"Westend","id":"westend2"}',
     type: "spec",
   }
   const expectedMessage2: Partial<ToExtension> = {
-    chainName: "Rococo",
     origin: "extension-provider",
     payload: '{"name":"Rococo","id":"rococo"}',
     type: "spec",
@@ -91,7 +88,6 @@ test("connected parachain sends correct spec message", async () => {
   await waitForMessageToBePosted()
 
   const expectedMessage: Partial<ToExtension> = {
-    chainName: "Westend",
     origin: "extension-provider",
     payload: '{"name":"Westend","id":"westend2"}',
     type: "spec",

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
@@ -81,7 +81,7 @@ export class ExtensionProvider implements ProviderInterface {
 
   #chainSpecs: string
   #parachainSpecs: string
-  #commonMessageData: Pick<ToExtension, "chainId" | "chainName" | "origin">
+  #commonMessageData: Pick<ToExtension, "chainId" | "origin">
 
   /*
    * How frequently to see if we have any peers
@@ -89,12 +89,6 @@ export class ExtensionProvider implements ProviderInterface {
   healthPingerInterval = CONNECTION_STATE_PINGER_INTERVAL
 
   public constructor(relayChain: string, parachain?: string) {
-    /**
-     * TODO: we should remove the chainName from the payload of the messages,
-     * since this is information that doesn't have to be sent on every message and
-     * the Extension can extract it from the chainSpecs, also that way we avoid
-     * parsing a large JSON on the main thread.
-     */
     this.#chainSpecs = relayChain
     this.#connectionStatePingerId = null
     this.#parachainSpecs = ""
@@ -103,7 +97,6 @@ export class ExtensionProvider implements ProviderInterface {
     }
     this.#commonMessageData = {
       chainId: nextChainId++,
-      chainName: JSON.parse(relayChain).name,
       origin: EXTENSION_PROVIDER_ORIGIN,
     }
   }

--- a/projects/extension/src/content/ExtensionMessageRouter.test.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.test.ts
@@ -38,9 +38,8 @@ describe("Disconnect and incorrect cases", () => {
     connect.mockImplementation(() => port)
     sendMessage({
       chainId: 1,
-      chainName: "westend",
       type: "spec",
-      payload: "westend",
+      payload: '{"name:":"westend"}',
       origin: "extension-provider",
     })
     await waitForMessageToBePosted()
@@ -87,9 +86,8 @@ describe("Connection and forward cases", () => {
   test("connect establishes a port", async () => {
     sendMessage({
       chainId: 1,
-      chainName: "westend",
       type: "spec",
-      payload: "westend",
+      payload: '{"name:":"westend"}',
       origin: "extension-provider",
     })
 
@@ -105,9 +103,8 @@ describe("Connection and forward cases", () => {
     // connect
     sendMessage({
       chainId: 1,
-      chainName: "westend",
       type: "spec",
-      payload: "westend",
+      payload: '{"name:":"westend"}',
       origin: "extension-provider",
     })
     await waitForMessageToBePosted()
@@ -115,7 +112,6 @@ describe("Connection and forward cases", () => {
     // rpc
     const rpcMessage: ToExtension = {
       chainId: 1,
-      chainName: "westend",
       type: "rpc",
       payload:
         '{"id":1,"jsonrpc":"2.0","method":"state_getStorage","params":["<hash>"]}',
@@ -138,9 +134,8 @@ describe("Connection and forward cases", () => {
     // connect
     sendMessage({
       chainId: 1,
-      chainName: "westend",
       type: "spec",
-      payload: "westend",
+      payload: '{"name:":"westend"}',
       origin: "extension-provider",
     })
     await waitForMessageToBePosted()
@@ -170,9 +165,8 @@ describe("Connection and forward cases", () => {
     // connect
     sendMessage({
       chainId: 1,
-      chainName: "westend",
       type: "spec",
-      payload: "westend",
+      payload: '{"name:":"westend"}',
       origin: "extension-provider",
     })
     await waitForMessageToBePosted()


### PR DESCRIPTION
Following task #572 this PR is fixing the following:

- Remove the `chainName` field. Instead the extension should use the chain name found in the chain spec.

While I was working on splitting the message type `spec` into `add-chain`/`add-well-known-chain`, I realized that change was going to be a lot smaller and simpler if the `chainName` field had already been removed, so I decided to tackle this one first.