### PR TITLE
split `MessageToManager.type` into `add-chain` and `add-well-known-chain`

### DIFF
--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -36,7 +36,7 @@ export interface ToExtension {
   chainId: number
   /** The message the `ExtensionMessageRouter` should forward to the background **/
   /** Type of the message. Defines how to interpret the {@link payload} */
-  type: "rpc" | "spec"
+  type: "rpc" | "add-chain" | "add-well-known-chain"
   /** Payload of the message -  a JSON encoded RPC request **/
   payload: string
   parachainPayload?: string

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -43,7 +43,7 @@ test("connected and sends correct spec message", async () => {
   const expectedMessage: Partial<ToExtension> = {
     origin: "extension-provider",
     payload: '{"name":"Westend","id":"westend2"}',
-    type: "spec",
+    type: "add-chain",
   }
   expect(handler).toHaveBeenCalledTimes(1)
   const { data } = handler.mock.calls[0][0] as MessageEvent
@@ -65,12 +65,12 @@ test("connected multiple chains and sends correct spec message", async () => {
   const expectedMessage1: Partial<ToExtension> = {
     origin: "extension-provider",
     payload: '{"name":"Westend","id":"westend2"}',
-    type: "spec",
+    type: "add-chain",
   }
   const expectedMessage2: Partial<ToExtension> = {
     origin: "extension-provider",
     payload: '{"name":"Rococo","id":"rococo"}',
-    type: "spec",
+    type: "add-chain",
   }
 
   expect(handler).toHaveBeenCalledTimes(2)
@@ -90,7 +90,7 @@ test("connected parachain sends correct spec message", async () => {
   const expectedMessage: Partial<ToExtension> = {
     origin: "extension-provider",
     payload: '{"name":"Westend","id":"westend2"}',
-    type: "spec",
+    type: "add-chain",
   }
   expect(handler).toHaveBeenCalledTimes(1)
   const { data } = handler.mock.calls[0][0] as MessageEvent

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
@@ -17,6 +17,7 @@ import {
   ToExtension,
   ToApplication,
 } from "@substrate/connect-extension-protocol"
+import { SupportedChains } from "../specs/index.js"
 
 const CONTENT_SCRIPT_ORIGIN = "content-script"
 const EXTENSION_PROVIDER_ORIGIN = "extension-provider"
@@ -273,8 +274,10 @@ export class ExtensionProvider implements ProviderInterface {
     // for the extension to call addChain on smoldot
     const specMsg: ToExtension = {
       ...this.#commonMessageData,
-      type: "spec",
-      payload: this.#chainSpecs || "",
+      type: SupportedChains[this.#chainSpecs as SupportedChains]
+        ? "add-well-known-chain"
+        : "add-chain",
+      payload: this.#chainSpecs,
     }
     if (this.#parachainSpecs) {
       specMsg.parachainPayload = this.#parachainSpecs

--- a/packages/connect/src/ScProvider.ts
+++ b/packages/connect/src/ScProvider.ts
@@ -120,21 +120,17 @@ export class ScProvider implements ProviderInterface {
       )
     }
 
+    if (isExtension) {
+      const { ExtensionProvider } = await import(
+        "./ExtensionProvider/ExtensionProvider.js"
+      )
+
+      return new ExtensionProvider(chain, parachainSpec) as ProviderInterface
+    }
+
     const chainSpecPromise = SupportedChains[chain as SupportedChains]
       ? getSpec(chain as SupportedChains)
       : Promise.resolve(chain)
-
-    if (isExtension) {
-      const [{ ExtensionProvider }, chainSpec] = await Promise.all([
-        import("./ExtensionProvider/ExtensionProvider.js"),
-        chainSpecPromise,
-      ])
-
-      return new ExtensionProvider(
-        chainSpec,
-        parachainSpec,
-      ) as ProviderInterface
-    }
 
     const [{ SmoldotProvider }, chainSpec] = await Promise.all([
       import("./SmoldotProvider/SmoldotProvider.js"),

--- a/projects/extension/src/background/ConnectionManager.test.ts
+++ b/projects/extension/src/background/ConnectionManager.test.ts
@@ -168,7 +168,7 @@ test("Tries to connect to a parachain with unknown Relay Chain", async () => {
   await waitForMessageToBePosted()
 
   port.triggerMessage({
-    type: "spec",
+    type: "add-chain",
     payload: "",
     parachainPayload: JSON.stringify({
       name: "parachainSpec",
@@ -301,17 +301,17 @@ describe("Check storage and send notification when adding an app", () => {
   })
 
   test("Sends a message with empty payload ", () => {
-    port.triggerMessage({ type: "spec", payload: "" })
+    port.triggerMessage({ type: "add-chain", payload: "" })
     expect(chrome.storage.sync.get).toHaveBeenCalledTimes(0)
   })
 
   test("Checks storage for notifications preferences", () => {
-    port.triggerMessage({ type: "spec", payload: westendPayload })
+    port.triggerMessage({ type: "add-chain", payload: westendPayload })
     expect(chrome.storage.sync.get).toHaveBeenCalledTimes(1)
   })
 
   test("Sends a notification", () => {
-    port.triggerMessage({ type: "spec", payload: westendPayload })
+    port.triggerMessage({ type: "add-chain", payload: westendPayload })
     const notificationData = {
       message: "App test-app-7 connected to westend.",
       title: "Substrate Connect",
@@ -344,7 +344,7 @@ describe("Tests with actual ConnectionManager", () => {
 
   test("Connected state", () => {
     app = manager.createApp(port)
-    port.triggerMessage({ type: "spec", payload: "westend" })
+    port.triggerMessage({ type: "add-well-known-chain", payload: "westend" })
     port.triggerMessage({ type: "rpc", payload: '{ "id": 1 }' })
 
     expect(app.state).toBe("connected")
@@ -352,7 +352,7 @@ describe("Tests with actual ConnectionManager", () => {
 
   test("Disconnect cleans up properly", async () => {
     app = manager.createApp(port)
-    port.triggerMessage({ type: "spec", payload: "westend" })
+    port.triggerMessage({ type: "add-well-known-chain", payload: "westend" })
     await waitForMessageToBePosted()
     manager.disconnect(app)
     await waitForMessageToBePosted()
@@ -373,7 +373,7 @@ describe("Tests with actual ConnectionManager", () => {
   })
 
   test("Connected state", () => {
-    port.triggerMessage({ type: "spec", payload: "westend" })
+    port.triggerMessage({ type: "add-well-known-chain", payload: "westend" })
     port.triggerMessage({ type: "rpc", payload: '{ "id": 1 }' })
     expect(app.state).toBe("connected")
   })
@@ -387,7 +387,7 @@ describe("Tests with actual ConnectionManager", () => {
   })
 
   test("Spec message adds a chain", async () => {
-    port.triggerMessage({ type: "spec", payload: "westend" })
+    port.triggerMessage({ type: "add-well-known-chain", payload: "westend" })
     await waitForMessageToBePosted()
     expect(app.healthChecker).toBeDefined()
   })
@@ -397,13 +397,13 @@ describe("Tests with actual ConnectionManager", () => {
     port.triggerMessage({ type: "rpc", payload: message1 })
     const message2 = JSON.stringify({ id: 2, jsonrpc: "2.0", result: {} })
     port.triggerMessage({ type: "rpc", payload: message2 })
-    port.triggerMessage({ type: "spec", payload: "westend" })
+    port.triggerMessage({ type: "add-well-known-chain", payload: "westend" })
     await waitForMessageToBePosted()
     expect(app.healthChecker).toBeDefined()
   })
 
   test("RPC port message sends the message to the chain", async () => {
-    port.triggerMessage({ type: "spec", payload: "westend" })
+    port.triggerMessage({ type: "add-well-known-chain", payload: "westend" })
     await waitForMessageToBePosted()
     const message = JSON.stringify({ id: 1, jsonrpc: "2.0", result: {} })
     port.triggerMessage({ type: "rpc", payload: message })
@@ -412,7 +412,7 @@ describe("Tests with actual ConnectionManager", () => {
 
   test("App already disconnected", async () => {
     app = manager.createApp(port)
-    port.triggerMessage({ type: "spec", payload: "westend" })
+    port.triggerMessage({ type: "add-well-known-chain", payload: "westend" })
     await waitForMessageToBePosted()
     manager.disconnect(app)
     await waitForMessageToBePosted()

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -20,7 +20,7 @@ import kusama from "../../public/assets/kusama.json"
 import polkadot from "../../public/assets/polkadot.json"
 import rococo from "../../public/assets/rococo.json"
 
-export const relayChains: Map<string, string> = new Map<string, string>([
+export const wellKnownChains: Map<string, string> = new Map<string, string>([
   ["polkadot", JSON.stringify(polkadot)],
   ["kusama", JSON.stringify(kusama)],
   ["rococo", JSON.stringify(rococo)],
@@ -406,12 +406,12 @@ export class ConnectionManager
       return app.healthChecker?.sendJsonRpc(msg.payload)
     }
 
-    const relayChain =
+    const chainSpec =
       msg.type === "add-chain"
         ? msg.payload
-        : relayChains.get(msg.payload) ?? ""
+        : wellKnownChains.get(msg.payload) ?? ""
 
-    return this.#handleSpecMessage(app, relayChain, msg.parachainPayload)
+    return this.#handleSpecMessage(app, chainSpec, msg.parachainPayload)
   }
 
   /**

--- a/projects/extension/src/background/index.ts
+++ b/projects/extension/src/background/index.ts
@@ -1,8 +1,4 @@
-import { ConnectionManager } from "./ConnectionManager"
-import westend from "../../public/assets/westend.json"
-import kusama from "../../public/assets/kusama.json"
-import polkadot from "../../public/assets/polkadot.json"
-import rococo from "../../public/assets/rococo.json"
+import { relayChains, ConnectionManager } from "./ConnectionManager"
 import { logger } from "@polkadot/util"
 import { isEmpty } from "../utils/utils"
 import settings from "./settings.json"
@@ -14,15 +10,6 @@ export interface Background extends Window {
 declare let window: Background
 
 const manager = (window.manager = new ConnectionManager())
-
-type RelayType = Map<string, string>
-
-export const relayChains: RelayType = new Map<string, string>([
-  ["polkadot", JSON.stringify(polkadot)],
-  ["kusama", JSON.stringify(kusama)],
-  ["rococo", JSON.stringify(rococo)],
-  ["westend", JSON.stringify(westend)],
-])
 
 const l = logger("Extension")
 export interface RequestRpcSend {

--- a/projects/extension/src/background/index.ts
+++ b/projects/extension/src/background/index.ts
@@ -1,4 +1,4 @@
-import { relayChains, ConnectionManager } from "./ConnectionManager"
+import { wellKnownChains, ConnectionManager } from "./ConnectionManager"
 import { logger } from "@polkadot/util"
 import { isEmpty } from "../utils/utils"
 import settings from "./settings.json"
@@ -20,7 +20,7 @@ export interface RequestRpcSend {
 const init = async () => {
   try {
     manager.initSmoldot()
-    for (const [key, value] of relayChains.entries()) {
+    for (const [key, value] of wellKnownChains.entries()) {
       const rpcCallback = (rpc: string) => {
         console.warn(`Got RPC from ${key} dummy chain: ${rpc}`)
       }

--- a/projects/extension/src/content/ExtensionMessageRouter.test.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.test.ts
@@ -38,8 +38,8 @@ describe("Disconnect and incorrect cases", () => {
     connect.mockImplementation(() => port)
     sendMessage({
       chainId: 1,
-      type: "spec",
-      payload: '{"name:":"westend"}',
+      type: "add-well-known-chain",
+      payload: "westend",
       origin: "extension-provider",
     })
     await waitForMessageToBePosted()
@@ -86,8 +86,8 @@ describe("Connection and forward cases", () => {
   test("connect establishes a port", async () => {
     sendMessage({
       chainId: 1,
-      type: "spec",
-      payload: '{"name:":"westend"}',
+      type: "add-well-known-chain",
+      payload: "westend",
       origin: "extension-provider",
     })
 
@@ -103,8 +103,8 @@ describe("Connection and forward cases", () => {
     // connect
     sendMessage({
       chainId: 1,
-      type: "spec",
-      payload: '{"name:":"westend"}',
+      type: "add-well-known-chain",
+      payload: "westend",
       origin: "extension-provider",
     })
     await waitForMessageToBePosted()
@@ -134,8 +134,8 @@ describe("Connection and forward cases", () => {
     // connect
     sendMessage({
       chainId: 1,
-      type: "spec",
-      payload: '{"name:":"westend"}',
+      type: "add-well-known-chain",
+      payload: "westend",
       origin: "extension-provider",
     })
     await waitForMessageToBePosted()
@@ -165,8 +165,8 @@ describe("Connection and forward cases", () => {
     // connect
     sendMessage({
       chainId: 1,
-      type: "spec",
-      payload: '{"name:":"westend"}',
+      type: "add-well-known-chain",
+      payload: "westend",
       origin: "extension-provider",
     })
     await waitForMessageToBePosted()

--- a/projects/extension/src/content/ExtensionMessageRouter.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.ts
@@ -111,25 +111,36 @@ export class ExtensionMessageRouter {
 
     debug(`RECEIVED MESSAGE FROM ${EXTENSION_PROVIDER_ORIGIN}`, data)
 
-    if (!type) {
+    if (
+      type !== "rpc" &&
+      type !== "add-chain" &&
+      type !== "add-well-known-chain"
+    ) {
       // probably someone abusing the extension
-      console.warn("Malformed message - missing message.type", data)
+      console.warn("Malformed message - unrecognised message.type", data)
       return
     }
 
-    if (type === "spec") {
+    if (type === "add-well-known-chain") {
+      this.#establishNewConnection(data.chainId, data.payload)
+    }
+
+    if (type === "add-chain") {
       let name = "unknown name"
       try {
         name = JSON.parse(data.payload).name || name
-      } catch (_) {}
+      } catch (_) {
+        sendMessage({
+          origin: "content-script",
+          type: "error",
+          payload: "Error parsing relayChain spec",
+        })
+        console.warn("Error parsing relayChain spec", data)
+        return
+      }
       this.#establishNewConnection(data.chainId, name)
     }
 
-    if (type === "rpc" || type === "spec") {
-      return this.#forwardRpcMessage(data)
-    }
-
-    // probably someone abusing the extension
-    return console.warn("Malformed message - unrecognised message.type", data)
+    return this.#forwardRpcMessage(data)
   }
 }


### PR DESCRIPTION
Following task #572 this PR is fixing the following:

-  `MessageToManager.type` equal to `spec` should instead be two different variants: `add-chain` or `add-well-known-chain`. Depending on which one, you pass either a chain spec or the id of a well known name ("rococo_1_3", "westend", "polkadot", or "ksmcc3").