### PR TITLE
Update CSP of extension to include unsafe-eval

### DIFF
--- a/projects/extension/public/manifest.json
+++ b/projects/extension/public/manifest.json
@@ -29,6 +29,6 @@
     "16": "icons/icon-16.png",
     "32": "icons/icon-32.png"
   },
-  "content_security_policy": "script-src 'self'; object-src 'self'",
+  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
   "web_accessible_resources": ["page.js"]
 }


### PR DESCRIPTION
At the moment Extension (on chrome) throws error:
`CompileError: WebAssembly.instantiate(): Wasm code generation disallowed by embedder`
This addition to the manifest will allow extension to run correctly on chrome.

In a following revision (manifest v3) this should be replaced with [sandboxed file](https://developer.chrome.com/docs/extensions/mv3/sandboxingEval/) 