### PR TITLE
Add `chainId` into `ToApplication` interface

### DIFF
--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -23,6 +23,8 @@
 export interface ToApplication {
   /** origin is used to determine which side sent the message **/
   origin: "content-script"
+  /** The uniqueId for extension multiplexing **/
+  chainId: number
   /** Type of the message. Defines how to interpret the {@link payload} */
   type: "error" | "rpc"
   /** Payload of the message. Either a JSON encoded RPC response or an error message **/

--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -23,7 +23,7 @@
 export interface ToApplication {
   /** origin is used to determine which side sent the message **/
   origin: "content-script"
-  /** The uniqueId for extension multiplexing **/
+  /** Which chain this message applies to **/
   chainId: number
   /** Type of the message. Defines how to interpret the {@link payload} */
   type: "error" | "rpc"

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -119,6 +119,7 @@ test("disconnects and emits an error when it receives an error message", async (
   await waitForMessageToBePosted()
   sendMessage({
     origin: "content-script",
+    chainId: ep.chainId,
     type: "error",
     payload: "disconnected",
   })
@@ -133,6 +134,7 @@ test("emits error when it receives an error message", async () => {
   await waitForMessageToBePosted()
   const errorMessage: ToApplication = {
     origin: "content-script",
+    chainId: ep.chainId,
     type: "error",
     payload: "Boom!",
   }
@@ -144,4 +146,62 @@ test("emits error when it receives an error message", async () => {
   expect(errorHandler).toHaveBeenCalled()
   const error = errorHandler.mock.calls[0][0] as Error
   expect(error.message).toEqual(errorMessage.payload)
+})
+
+test("it routes incoming messages to the correct Provider", async () => {
+  const ep1 = new ExtensionProvider("ExtensionProvider1", westendSpec)
+  await ep1.connect()
+
+  const ep2 = new ExtensionProvider("ExtensionProvider2", westendSpec)
+  await ep2.connect()
+  await waitForMessageToBePosted()
+
+  let extensionProvider1Response: string | undefined = undefined
+  let extensionProvider2Response: string | undefined = undefined
+
+  ep1
+    .send("requestSomeData", [])
+    .then((response: string) => {
+      extensionProvider1Response = response
+    })
+    .catch(() => {
+      extensionProvider1Response = "Error"
+    })
+  await waitForMessageToBePosted()
+
+  ep2
+    .send("requestOtherData", [])
+    .then((response: string) => {
+      extensionProvider2Response = response
+    })
+    .catch(() => {
+      extensionProvider2Response = "Error"
+    })
+  await waitForMessageToBePosted()
+
+  const latestRequest = handler.mock.calls[
+    handler.mock.calls.length - 1
+  ][0] as MessageEvent<{ payload: string }>
+
+  const latestRequestRpcId = (
+    JSON.parse(latestRequest?.data.payload ?? "{}") as {
+      id: number
+    }
+  ).id
+
+  sendMessage({
+    origin: "content-script",
+    chainId: ep2.chainId,
+    type: "rpc",
+    payload: JSON.stringify({
+      id: latestRequestRpcId,
+      jsonrpc: "2.0",
+      result: "hi ExtensionProvider2!",
+    }),
+  })
+
+  await waitForMessageToBePosted()
+
+  expect(extensionProvider2Response).toBe("hi ExtensionProvider2!")
+  expect(extensionProvider1Response).toBe(undefined)
 })

--- a/projects/extension/src/content/ExtensionMessageRouter.test.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.test.ts
@@ -153,6 +153,7 @@ describe("Connection and forward cases", () => {
     expect(handler).toHaveBeenCalled()
     const forwarded = handler.mock.calls[0][0] as MessageEvent
     expect(forwarded.data).toEqual({
+      chainId: 1,
       origin: "content-script",
       type: "rpc",
       payload: '{"id:":1,"jsonrpc:"2.0","result":666}',
@@ -180,6 +181,7 @@ describe("Connection and forward cases", () => {
     const forwarded = handler.mock.calls[0][0] as MessageEvent
     expect(forwarded.data).toEqual({
       origin: "content-script",
+      chainId: 1,
       type: "error",
       payload: "Boom!",
     })

--- a/projects/extension/src/content/ExtensionMessageRouter.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.ts
@@ -63,6 +63,7 @@ export class ExtensionMessageRouter {
       sendMessage({
         type,
         payload,
+        chainId,
         origin: CONTENT_SCRIPT_ORIGIN,
       })
     })
@@ -71,6 +72,7 @@ export class ExtensionMessageRouter {
     port.onDisconnect.addListener(() => {
       sendMessage({
         origin: "content-script",
+        chainId,
         type: "error",
         payload: "Lost communication with substrate-connect extension",
       })
@@ -132,6 +134,7 @@ export class ExtensionMessageRouter {
       } catch (_) {
         sendMessage({
           origin: "content-script",
+          chainId: data.chainId,
           type: "error",
           payload: "Error parsing relayChain spec",
         })


### PR DESCRIPTION
Following task #572 this PR is fixing the following:

- The `chainId` field should be present in the `ToApplication` interface so that the listener can filter-out those messages that were not targeting its chain.

This also addresses the "routing" issue that's described in #550 