### PR TITLE
`chainId` counter -> random string

### DIFF
--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -24,7 +24,7 @@ export interface ToApplication {
   /** origin is used to determine which side sent the message **/
   origin: "content-script"
   /** Which chain this message applies to **/
-  chainId: number
+  chainId: string
   /** Type of the message. Defines how to interpret the {@link payload} */
   type: "error" | "rpc"
   /** Payload of the message. Either a JSON encoded RPC response or an error message **/
@@ -35,7 +35,7 @@ export interface ToExtension {
   /** origin is used to determine which side sent the message **/
   origin: "extension-provider"
   /** The uniqueId for extension multiplexing **/
-  chainId: number
+  chainId: string
   /** The message the `ExtensionMessageRouter` should forward to the background **/
   /** Type of the message. Defines how to interpret the {@link payload} */
   type: "rpc" | "add-chain" | "add-well-known-chain"

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
@@ -18,6 +18,7 @@ import {
   ToApplication,
 } from "@substrate/connect-extension-protocol"
 import { SupportedChains } from "../specs/index.js"
+import { getRandomChainId } from "./getRandomChainId.js"
 
 const CONTENT_SCRIPT_ORIGIN = "content-script"
 const EXTENSION_PROVIDER_ORIGIN = "extension-provider"
@@ -60,7 +61,6 @@ const ANGLICISMS: { [index: string]: string } = {
  * connected peers in the smoldot client
  */
 const CONNECTION_STATE_PINGER_INTERVAL = 2000
-let nextChainId = 1
 
 const sendMessage = (msg: ToExtension): void => {
   window.postMessage(msg, "*")
@@ -77,7 +77,7 @@ export class ExtensionProvider implements ProviderInterface {
   readonly #handlers: Record<string, RpcStateAwaiting> = {}
   readonly #subscriptions: Record<string, StateSubscription> = {}
   readonly #waitingForId: Record<string, JsonRpcResponse> = {}
-  readonly #chainId: number
+  readonly #chainId: string
   #connectionStatePingerId: ReturnType<typeof setInterval> | null
   #isConnected = false
 
@@ -96,11 +96,7 @@ export class ExtensionProvider implements ProviderInterface {
     if (parachain) {
       this.#parachainSpecs = parachain
     }
-    this.#chainId = nextChainId++
-  }
-
-  public get chainId(): number {
-    return this.#chainId
+    this.#chainId = getRandomChainId()
   }
 
   /**
@@ -450,3 +446,5 @@ export class ExtensionProvider implements ProviderInterface {
     this.#eventemitter.emit(type, ...args)
   }
 }
+
+export type ExtensionProviderClass = typeof ExtensionProvider

--- a/packages/connect/src/ExtensionProvider/getRandomChainId.ts
+++ b/packages/connect/src/ExtensionProvider/getRandomChainId.ts
@@ -1,0 +1,7 @@
+export function getRandomChainId(): string {
+  const arr = new BigUint64Array(2)
+  // It can only be used from the browser, so this is fine.
+  crypto.getRandomValues(arr)
+  const result = (arr[1] << BigInt(64)) | arr[0]
+  return result.toString(36)
+}

--- a/projects/extension/src/content/ExtensionMessageRouter.test.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.test.ts
@@ -37,7 +37,7 @@ describe("Disconnect and incorrect cases", () => {
     const connect = chrome.runtime.connect
     connect.mockImplementation(() => port)
     sendMessage({
-      chainId: 1,
+      chainId: "test",
       type: "add-well-known-chain",
       payload: "westend",
       origin: "extension-provider",
@@ -84,8 +84,9 @@ describe("Connection and forward cases", () => {
   })
 
   test("connect establishes a port", async () => {
+    const chainId = "test"
     sendMessage({
-      chainId: 1,
+      chainId,
       type: "add-well-known-chain",
       payload: "westend",
       origin: "extension-provider",
@@ -94,7 +95,7 @@ describe("Connection and forward cases", () => {
     await waitForMessageToBePosted()
     expect(chrome.runtime.connect).toHaveBeenCalledTimes(1)
     expect(router.connections.length).toBe(1)
-    expect(router.connections[0]).toBe("1")
+    expect(router.connections[0]).toBe(chainId)
   })
 
   test("forwards rpc message from app -> extension", async () => {
@@ -102,7 +103,7 @@ describe("Connection and forward cases", () => {
     chrome.runtime.connect.mockImplementation(() => port)
     // connect
     sendMessage({
-      chainId: 1,
+      chainId: "test",
       type: "add-well-known-chain",
       payload: "westend",
       origin: "extension-provider",
@@ -111,7 +112,7 @@ describe("Connection and forward cases", () => {
 
     // rpc
     const rpcMessage: ToExtension = {
-      chainId: 1,
+      chainId: "test",
       type: "rpc",
       payload:
         '{"id":1,"jsonrpc":"2.0","method":"state_getStorage","params":["<hash>"]}',
@@ -133,7 +134,7 @@ describe("Connection and forward cases", () => {
     chrome.runtime.connect.mockImplementation(() => port)
     // connect
     sendMessage({
-      chainId: 1,
+      chainId: "test",
       type: "add-well-known-chain",
       payload: "westend",
       origin: "extension-provider",
@@ -153,7 +154,7 @@ describe("Connection and forward cases", () => {
     expect(handler).toHaveBeenCalled()
     const forwarded = handler.mock.calls[0][0] as MessageEvent
     expect(forwarded.data).toEqual({
-      chainId: 1,
+      chainId: "test",
       origin: "content-script",
       type: "rpc",
       payload: '{"id:":1,"jsonrpc:"2.0","result":666}',
@@ -165,7 +166,7 @@ describe("Connection and forward cases", () => {
     chrome.runtime.connect.mockImplementation(() => port)
     // connect
     sendMessage({
-      chainId: 1,
+      chainId: "test",
       type: "add-well-known-chain",
       payload: "westend",
       origin: "extension-provider",
@@ -181,7 +182,7 @@ describe("Connection and forward cases", () => {
     const forwarded = handler.mock.calls[0][0] as MessageEvent
     expect(forwarded.data).toEqual({
       origin: "content-script",
-      chainId: 1,
+      chainId: "test",
       type: "error",
       payload: "Boom!",
     })

--- a/projects/extension/src/content/ExtensionMessageRouter.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.ts
@@ -49,7 +49,7 @@ export class ExtensionMessageRouter {
     window.removeEventListener("message", this.#handleMessage)
   }
 
-  #establishNewConnection = (chainId: number, chainName: string): void => {
+  #establishNewConnection = (chainId: string, chainName: string): void => {
     const port = chrome.runtime.connect({
       name: `${window.location.href}::${chainName}`,
     })


### PR DESCRIPTION
Following task #572 this PR is fixing the following:

  - [ ] The `chainId` field should become a string, and its value is decided by the web page by [generating a big random number](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues). Its value is here to identify which chain amongst the list of all chains that the web page has opened.