### PR TITLE
Update smoldot to 0.5.13

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@polkadot/rpc-provider": "^6.10.3",
     "@substrate/connect-extension-protocol": "^0.4.0",
-    "@substrate/smoldot-light": "0.5.12",
+    "@substrate/smoldot-light": "0.5.13",
     "eventemitter3": "^4.0.7"
   },
   "devDependencies": {

--- a/packages/smoldot-test-utils/package.json
+++ b/packages/smoldot-test-utils/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint . --ext .js,.ts"
   },
   "dependencies": {
-    "@substrate/smoldot-light": "0.5.12",
+    "@substrate/smoldot-light": "0.5.13",
     "asap": "^2.0.6"
   },
   "devDependencies": {

--- a/projects/extension/package.json
+++ b/projects/extension/package.json
@@ -72,7 +72,7 @@
     "@material-ui/styles": "^4.11.3",
     "@polkadot/rpc-provider": "^4.10.1",
     "@substrate/connect-extension-protocol": "^0.4.0",
-    "@substrate/smoldot-light": "0.5.12",
+    "@substrate/smoldot-light": "0.5.13",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-hot-loader": "^4.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2874,10 +2874,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@substrate/smoldot-light@0.5.12":
-  version "0.5.12"
-  resolved "https://registry.yarnpkg.com/@substrate/smoldot-light/-/smoldot-light-0.5.12.tgz#bc4ae85d38abb0fec132124d64cb2a4e1c3e4262"
-  integrity sha512-7D/Z3X51SuVEZ5HZeuAnLTfX24D6rZb6LxnyqVkJjFq24EEUJu8mF+RUaJQqOSqpAaS234X4by3YQJP3buCi4g==
+"@substrate/smoldot-light@0.5.13":
+  version "0.5.13"
+  resolved "https://registry.yarnpkg.com/@substrate/smoldot-light/-/smoldot-light-0.5.13.tgz#ccd020ba636b1d9f6f7495c97666790acbaaac75"
+  integrity sha512-fc68YI0AtTprt+5WA1yrI/J6s/oXLXdCIup5UaJmdAqdTbCQ8oV61raocJW9PiVVSjbBRWCQcEmFNj+/MNJ72Q==
   dependencies:
     buffer "^6.0.1"
     pako "^2.0.4"


### PR DESCRIPTION
This makes us compatible with the "new" chain spec format where `codeSubstitutes` contains a block number (https://github.com/paritytech/substrate/pull/10600)