### PR TITLE
refactor ConnectionManager

### DIFF
--- a/projects/extension/package.json
+++ b/projects/extension/package.json
@@ -11,7 +11,7 @@
     "deep-clean": "yarn clean && rm -rf node_modules",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "compile": "tsc -b",
-    "test": "node --no-warnings --experimental-vm-modules $(yarn bin)/jest --colors --silent --coverage",
+    "test": "node --no-warnings --experimental-vm-modules $(yarn bin)/jest --colors --coverage",
     "prebuild": "yarn clean && yarn checkSpecs",
     "build": "webpack --config webpack.prod.js && zip -r ./dist/substrate-connect.zip ./dist/*",
     "dev": "yarn run prebuild && webpack --node-env development --config webpack.dev.js",

--- a/projects/extension/src/background/ConnectionManager.test.ts
+++ b/projects/extension/src/background/ConnectionManager.test.ts
@@ -2,422 +2,380 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-floating-promises */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
 import { jest } from "@jest/globals"
 import { ConnectionManager } from "./ConnectionManager"
-import westend from "../../public/assets/westend.json"
-import kusama from "../../public/assets/kusama.json"
-import { MockPort } from "../mocks"
-import { chrome } from "jest-chrome"
-import { App } from "./types"
-import { NetworkMainInfo } from "../types"
+import { ExposedChainConnection } from "./types"
+import { MockedChain, MockPort, MockSmoldotClient, TEST_URL } from "../mocks"
+import { ToExtension } from "@substrate/connect-extension-protocol"
 
-let port: MockPort
-let manager: ConnectionManager
+const wait = (ms: number) => new Promise((res) => setTimeout(res, ms))
 
-const waitForMessageToBePosted = (): Promise<null> => {
-  // window.postMessge is async so we must do a short setTimeout to yield to
-  // the event loop
-  return new Promise((resolve) => setTimeout(resolve, 10, null))
+const createHelper = () => {
+  const client = new MockSmoldotClient()
+  const manager = new ConnectionManager(client)
+
+  return {
+    manager,
+    client,
+    connectPort: (
+      chainId: string,
+      tabId: number,
+      addChainMsg: Omit<ToExtension, "origin" | "chainId"> | null = null,
+      url = TEST_URL,
+    ) => {
+      const port = new MockPort(chainId, tabId)
+      manager.addChainConnection(port)
+
+      let chain: MockedChain | null = null
+      if (addChainMsg) {
+        port._sendExtensionMessage(addChainMsg)
+        const chains = [...client.chains]
+        chain = chains[chains.length - 1]
+      }
+
+      return {
+        chainId,
+        tabId,
+        url,
+        port,
+        chain,
+      }
+    },
+  }
 }
 
-const connectApp = (
-  manager: ConnectionManager,
-  tabId: number,
-  name: string,
-  network: string,
-): MockPort => {
-  const port = new MockPort(`${name}::${network}`)
-  port.setTabId(tabId)
-  manager.addApp(port)
-  return port
-}
-
-const doNothing = () => {
-  // Do nothing
-}
-
-test("adding and removing apps changes state", async () => {
-  //setup connection manager with 2 chains
-  const manager = new ConnectionManager()
-  manager.smoldotLogLevel = 1
-  manager.initSmoldot()
-  await manager.addChain(JSON.stringify(westend), doNothing)
-  await manager.addChain(JSON.stringify(kusama), doNothing)
-
-  const handler = jest.fn()
-  manager.on("stateChanged", handler)
-
-  // app connects to first network
-  connectApp(manager, 42, "test-app", "westend")
-  expect(handler).toHaveBeenCalledTimes(1)
-  expect(manager.getState()).toEqual({
-    apps: [
-      {
-        name: "test-app",
-        tabId: 42,
-        networks: [{ name: "westend" }],
-      },
-    ],
+describe("ConnectionManager", () => {
+  let helper: ReturnType<typeof createHelper>
+  const originalError = console.error
+  beforeEach(() => {
+    helper = createHelper()
+    console.error = jest.fn()
+  })
+  afterEach(() => {
+    console.error = originalError
+    helper.manager.shutdown()
   })
 
-  // app connects to second network
-  handler.mockClear()
-  connectApp(manager, 42, "test-app", "kusama")
-  expect(handler).toHaveBeenCalledTimes(1)
-  expect(manager.getState()).toEqual({
-    apps: [
-      {
-        name: "test-app",
-        tabId: 42,
-        networks: [{ name: "westend" }, { name: "kusama" }],
-      },
-    ],
-  })
+  it("it emits after the add-chain message has been posted", async () => {
+    const { client, manager, connectPort } = helper
+    const onStateChanged = jest.fn()
+    manager.on("stateChanged", onStateChanged)
 
-  // different app connects to second network
-  handler.mockClear()
-  const port = connectApp(manager, 43, "another-app", "kusama")
-  expect(handler).toHaveBeenCalledTimes(1)
-  expect(manager.getState()).toEqual({
-    apps: [
-      {
-        name: "test-app",
-        tabId: 42,
-        networks: [{ name: "westend" }, { name: "kusama" }],
-      },
-      {
-        name: "another-app",
-        tabId: 43,
-        networks: [{ name: "kusama" }],
-      },
-    ],
-  })
+    const { chainId, tabId, port, url } = connectPort("chainId", 1)
 
-  // disconnect second app
-  handler.mockClear()
-  port.triggerDisconnect()
-  expect(handler).toHaveBeenCalled()
-  expect(manager.getState()).toEqual({
-    apps: [
-      {
-        name: "test-app",
-        tabId: 42,
-        networks: [{ name: "westend" }, { name: "kusama" }],
-      },
-    ],
-  })
+    expect(client.chains.size).toBe(0)
+    expect(manager.connections.length).toBe(0)
+    expect(onStateChanged).not.toHaveBeenCalled()
 
-  handler.mockClear()
-  manager.disconnectTab(42)
-  expect(handler).toHaveBeenCalledTimes(2)
-  expect(manager.getState()).toEqual({ apps: [] })
-
-  // Connect 2 apps on the same network and 2nd one on another network
-  // in order to test disconnectAll functionality
-  handler.mockClear()
-  // first app connects to network
-  connectApp(manager, 1, "test-app-1", "westend")
-  expect(handler).toHaveBeenCalledTimes(1)
-  expect(manager.getState()).toEqual({
-    apps: [
-      {
-        name: "test-app-1",
-        tabId: 1,
-        networks: [{ name: "westend" }],
-      },
-    ],
-  })
-
-  // second app connects to same network
-  handler.mockClear()
-  connectApp(manager, 2, "test-app-2", "westend")
-  connectApp(manager, 2, "test-app-2", "kusama")
-  expect(handler).toHaveBeenCalledTimes(2)
-  expect(manager.getState()).toEqual({
-    apps: [
-      {
-        name: "test-app-1",
-        tabId: 1,
-        networks: [{ name: "westend" }],
-      },
-      {
-        name: "test-app-2",
-        tabId: 2,
-        networks: [{ name: "westend" }, { name: "kusama" }],
-      },
-    ],
-  })
-  handler.mockClear()
-  // disconnect all apps;
-  manager.disconnectAll()
-  expect(handler).toHaveBeenCalledTimes(3)
-  expect(manager.getState()).toEqual({ apps: [] })
-  await manager.shutdown()
-})
-
-test("Tries to connect to a parachain with unknown Relay Chain", async () => {
-  const port = new MockPort("test-app-7::westend")
-  const manager = new ConnectionManager()
-  const handler = jest.fn()
-
-  manager.smoldotLogLevel = 1
-  manager.initSmoldot()
-  await manager.addChain(JSON.stringify(westend), doNothing)
-  manager.on("stateChanged", handler)
-  manager.addApp(port)
-  await waitForMessageToBePosted()
-
-  port.triggerMessage({
-    type: "add-chain",
-    payload: "",
-    parachainPayload: JSON.stringify({
-      name: "parachainSpec",
-      relay_chain: "someRelayChain",
-    }),
-  })
-  await waitForMessageToBePosted()
-  expect(port.postMessage).toHaveBeenCalledTimes(0)
-
-  await manager.shutdown()
-})
-
-describe("Unit tests", () => {
-  const manager = new ConnectionManager()
-  const handler = jest.fn()
-
-  beforeAll(async () => {
-    manager.smoldotLogLevel = 1
-    //setup connection manager with 2 networks
-    manager.initSmoldot()
-    await manager.addChain(JSON.stringify(westend), doNothing)
-    await manager.addChain(JSON.stringify(kusama), doNothing)
-    manager.on("stateChanged", handler)
-
-    //add 4 apps in clients
-    connectApp(manager, 11, "test-app-1", "westend")
-    connectApp(manager, 12, "test-app-2", "kusama")
-    connectApp(manager, 13, "test-app-3", "westend")
-    connectApp(manager, 14, "test-app-4", "kusama")
-  })
-
-  afterAll(async () => {
-    await manager.shutdown()
-  })
-
-  test("Get registered apps", () => {
-    expect(manager.registeredApps).toEqual([
-      "test-app-1::westend",
-      "test-app-2::kusama",
-      "test-app-3::westend",
-      "test-app-4::kusama",
-    ])
-  })
-
-  test("Get registered clients", () => {
-    expect(manager.registeredNetworks).toEqual([
-      { name: "westend", status: "connected", id: "westend2" },
-      { name: "kusama", status: "connected", id: "ksmcc3" },
-    ])
-  })
-
-  test("Get apps", () => {
-    expect(manager.apps).toHaveLength(4)
-  })
-
-  test("Get networks/chains", () => {
-    // With this look the "chain" is removed intentionally as "chain"
-    // object cannot be compared with jest
-    const tmpChains = manager.registeredNetworks.map((n: NetworkMainInfo) => ({
-      name: n.name,
-      status: n.status,
-    }))
-
-    expect(tmpChains).toEqual([
-      { name: "westend", status: "connected" },
-      { name: "kusama", status: "connected" },
-    ])
-
-    expect(manager.registeredNetworks).toHaveLength(2)
-  })
-
-  test("Adding an app that already exists sends an error and disconnects", () => {
-    const port = connectApp(manager, 13, "test-app-3", "westend")
-    expect(port.postMessage).toHaveBeenCalledTimes(1)
-    expect(port.postMessage).toHaveBeenLastCalledWith({
-      type: "error",
-      payload: "App test-app-3::westend already exists.",
+    port._sendExtensionMessage({
+      type: "add-well-known-chain",
+      payload: "polkadot",
     })
-    expect(port.disconnect).toHaveBeenCalled()
-  })
-})
 
-describe("When the manager is shutdown", () => {
-  const manager = new ConnectionManager()
+    await wait(0)
 
-  beforeEach(() => {
-    manager.smoldotLogLevel = 1
-    manager.initSmoldot()
-  })
-
-  test("adding an app after the manager is shutdown throws an error", async () => {
-    const port = new MockPort("test-app-5::westend")
-    port.setTabId(15)
-    await expect(async () => {
-      await manager.shutdown()
-      manager.addApp(port)
-    }).rejects.toThrowError("Smoldot client does not exist.")
-  })
-})
-
-describe("Check storage and send notification when adding an app", () => {
-  const westendPayload = JSON.stringify({ name: "Westend", id: "westend2" })
-  const port = new MockPort("test-app-7::westend")
-  const manager = new ConnectionManager()
-  const handler = jest.fn()
-  let app: App
-
-  chrome.storage.sync.get.mockImplementation((keys, callback) => {
-    callback({ notifications: true })
-  })
-
-  beforeEach(() => {
-    chrome.storage.sync.get.mockClear()
-    chrome.notifications.create.mockClear()
-  })
-
-  beforeAll(async () => {
-    manager.smoldotLogLevel = 1
-    manager.initSmoldot()
-    await manager.addChain(JSON.stringify(westend), doNothing)
-    await manager.addChain(JSON.stringify(kusama), doNothing)
-    manager.on("stateChanged", handler)
-
-    manager.addApp(port)
-    await waitForMessageToBePosted()
-  })
-
-  afterAll(async () => {
-    await manager.shutdown()
-  })
-
-  test("Sends a message with empty payload ", () => {
-    port.triggerMessage({ type: "add-chain", payload: "" })
-    expect(chrome.storage.sync.get).toHaveBeenCalledTimes(0)
-  })
-
-  test("Checks storage for notifications preferences", () => {
-    port.triggerMessage({ type: "add-chain", payload: westendPayload })
-    expect(chrome.storage.sync.get).toHaveBeenCalledTimes(1)
-  })
-
-  test("Sends a notification", () => {
-    port.triggerMessage({ type: "add-chain", payload: westendPayload })
-    const notificationData = {
-      message: "App test-app-7 connected to westend.",
-      title: "Substrate Connect",
-      iconUrl: "./icons/icon-32.png",
-      type: "basic",
+    const expectedConnection: ExposedChainConnection = {
+      chainId,
+      tabId,
+      chainName: "polkadot",
+      url,
+      healthStatus: undefined,
     }
 
-    expect(chrome.notifications.create).toHaveBeenCalledTimes(1)
-    expect(chrome.notifications.create).toHaveBeenCalledWith(
-      "test-app-7::westend",
-      notificationData,
+    expect(onStateChanged).toHaveBeenCalledWith([expectedConnection])
+    expect(manager.connections).toEqual([expectedConnection])
+    expect(client.chains.size).toBe(1)
+    expect(port.postedMessages.length).toBe(0)
+  })
+
+  it("does not emit if the port gets disconnected before the chain has been instantiated", async () => {
+    const { client, manager, connectPort } = helper
+    const onStateChanged = jest.fn()
+    manager.on("stateChanged", onStateChanged)
+
+    const { port } = connectPort("chainId", 1)
+
+    expect(client.chains.size).toBe(0)
+    expect(manager.connections.length).toBe(0)
+    expect(onStateChanged).not.toHaveBeenCalled()
+    expect(port.connected).toBe(true)
+
+    port.disconnect()
+    await wait(0)
+
+    expect(onStateChanged).not.toHaveBeenCalled()
+    expect(manager.connections).toEqual([])
+    expect(client.chains.size).toBe(0)
+    expect(port.postedMessages.length).toBe(0)
+  })
+
+  it("receives a system_health request from the health-checker immediately after the chain is instantiated", async () => {
+    const { connectPort, client } = helper
+
+    const { port } = connectPort("chainId", 1)
+
+    expect(client.chains.size).toBe(0)
+
+    port._sendExtensionMessage({
+      type: "add-well-known-chain",
+      payload: "polkadot",
+    })
+    await wait(0)
+
+    expect(client.chains.size).toBe(1)
+
+    const [chain] = [...client.chains]
+
+    expect(chain.receivedMessages).toEqual([
+      '{"jsonrpc":"2.0","id":"health-checker:0","method":"system_health","params":[]}',
+    ])
+  })
+
+  it("the 'rpc' messages received before 'add-chain' get processed as soon as the chain is instantiated", async () => {
+    const { connectPort, client } = helper
+
+    const { port } = connectPort("chainId", 1)
+
+    expect(client.chains.size).toBe(0)
+
+    port._sendExtensionMessage({
+      type: "rpc",
+      payload: JSON.stringify({ jsonrpc: "2.0", id: "1" }),
+    })
+
+    port._sendExtensionMessage({
+      type: "rpc",
+      payload: JSON.stringify({ jsonrpc: "2.0", id: "2" }),
+    })
+
+    port._sendExtensionMessage({
+      type: "add-well-known-chain",
+      payload: "polkadot",
+    })
+    await wait(0)
+
+    const [chain] = [...client.chains]
+    expect(chain.receivedMessages).toEqual([
+      '{"jsonrpc":"2.0","id":"health-checker:0","method":"system_health","params":[]}',
+      '{"jsonrpc":"2.0","id":"extern:\\"1\\""}',
+      '{"jsonrpc":"2.0","id":"extern:\\"2\\""}',
+    ])
+  })
+
+  it("passes the messages from the chain to the port", async () => {
+    const { connectPort } = helper
+
+    const { port, chain } = connectPort("chainId", 1, {
+      type: "add-well-known-chain",
+      payload: "polkadot",
+    })
+
+    await wait(0)
+
+    port._sendExtensionMessage({
+      type: "rpc",
+      payload: JSON.stringify({ jsonrpc: "2.0", id: "1" }),
+    })
+
+    await wait(0)
+
+    expect(chain!.receivedMessages).toEqual([
+      '{"jsonrpc":"2.0","id":"health-checker:0","method":"system_health","params":[]}',
+      '{"jsonrpc":"2.0","id":"extern:\\"1\\""}',
+    ])
+    expect(port.postedMessages).toEqual([])
+
+    chain!._sendResponse(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: 'extern:"1"',
+        result: "{}",
+      }),
     )
-  })
-})
 
-describe("Tests with actual ConnectionManager", () => {
-  let app: App
-  beforeEach(() => {
-    port = new MockPort("test-app::westend")
-    manager = new ConnectionManager()
-    app = manager.createApp(port)
-  })
+    await wait(0)
 
-  test("Construction parses the port name and gets port information", () => {
-    expect(app.name).toBe("test-app::westend")
-    expect(app.appName).toBe("test-app")
-    expect(app.url).toBe(port.sender.url)
-    expect(app.tabId).toBe(port.sender.tab.id)
+    expect(port.postedMessages).toEqual([
+      {
+        type: "rpc",
+        payload: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "1",
+          result: "{}",
+        }),
+      },
+    ])
   })
 
-  test("Connected state", () => {
-    app = manager.createApp(port)
-    port.triggerMessage({ type: "add-well-known-chain", payload: "westend" })
-    port.triggerMessage({ type: "rpc", payload: '{ "id": 1 }' })
+  it("correctly errors when passed a malformed message", () => {
+    const { connectPort } = helper
+    const { port } = connectPort("chainId", 1)
 
-    expect(app.state).toBe("connected")
+    port._sendExtensionMessage({
+      type: "foo" as "rpc",
+      payload: "",
+    })
+
+    expect(port.postedMessages).toEqual([
+      {
+        type: "error",
+        payload: `Unrecognised message type 'foo' or payload '' received from content script`,
+      },
+    ])
   })
 
-  test("Disconnect cleans up properly", async () => {
-    app = manager.createApp(port)
-    port.triggerMessage({ type: "add-well-known-chain", payload: "westend" })
-    await waitForMessageToBePosted()
-    manager.disconnect(app)
-    await waitForMessageToBePosted()
-    expect(app.state).toBe("disconnected")
+  it("correctly errors when passed a wrong well-known-chain", async () => {
+    const { connectPort } = helper
+    const { port } = connectPort("chainId", 1, {
+      type: "add-well-known-chain",
+      payload: "nonexisting",
+    })
+
+    await wait(0)
+
+    expect(port.postedMessages).toEqual([
+      {
+        type: "error",
+        payload: "Relay chain spec was not found",
+      },
+    ])
   })
 
-  test("Invalid port name sends an error and disconnects", () => {
-    port = new MockPort("invalid")
-    const errorMsg = {
-      type: "error",
-      payload: "Invalid port name invalid expected <app_name>::<chain_name>",
+  it("emits the correct state when it receives a health update", async () => {
+    const { manager, connectPort } = helper
+    const onStateChanged = jest.fn()
+    manager.on("stateChanged", onStateChanged)
+
+    const { chain, chainId, tabId, url } = connectPort("chainId", 1, {
+      type: "add-well-known-chain",
+      payload: "polkadot",
+    })
+
+    await wait(0)
+
+    const expectedConnection: ExposedChainConnection = {
+      chainId,
+      tabId,
+      chainName: "polkadot",
+      url,
+      healthStatus: undefined,
     }
-    expect(() => {
-      manager.createApp(port)
-    }).toThrow(errorMsg.payload)
-    expect(port.postMessage).toHaveBeenCalledWith(errorMsg)
-    expect(port.disconnect).toHaveBeenCalled()
-  })
 
-  test("Connected state", () => {
-    port.triggerMessage({ type: "add-well-known-chain", payload: "westend" })
-    port.triggerMessage({ type: "rpc", payload: '{ "id": 1 }' })
-    expect(app.state).toBe("connected")
-  })
+    expect(onStateChanged).toHaveBeenCalledWith([expectedConnection])
+    onStateChanged.mockReset()
 
-  test("Smoldot throws error when it does not exist", async () => {
-    try {
-      await manager.addChain(JSON.stringify(kusama), doNothing)
-    } catch (err: any) {
-      expect(err.message).toBe("Smoldot client does not exist.")
+    const healthStatus = {
+      isSyncing: false,
+      peers: 1,
+      shouldHavePeers: true,
     }
+
+    chain!._sendResponse(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "health-checker:0",
+        result: healthStatus,
+      }),
+    )
+
+    await wait(0)
+
+    expect(onStateChanged).toHaveBeenCalledWith([
+      { ...expectedConnection, healthStatus },
+    ])
   })
 
-  test("Spec message adds a chain", async () => {
-    port.triggerMessage({ type: "add-well-known-chain", payload: "westend" })
-    await waitForMessageToBePosted()
-    expect(app.healthChecker).toBeDefined()
+  it("disconnecting a tab disconnects the ports of the tab and emits the new state", async () => {
+    const { connectPort, manager } = helper
+    const onStateChanged = jest.fn()
+    manager.on("stateChanged", onStateChanged)
+
+    // This emulates 3 active tabs, with 3 connections each
+    const connections = Array(9)
+      .fill(null)
+      .map((_, idx) => idx)
+      .map((idx) => {
+        const tabId = Math.floor(idx / 3)
+        return connectPort(idx.toString(), tabId, {
+          type: "add-well-known-chain",
+          payload: "polkadot",
+        })
+      })
+    await wait(0)
+
+    const expectedChainConnections: ExposedChainConnection[] = connections.map(
+      (data) => ({
+        chainId: data.chainId,
+        tabId: data.tabId,
+        url: data.url,
+        chainName: "polkadot",
+        healthStatus: undefined,
+      }),
+    )
+
+    expect(onStateChanged).toHaveBeenCalledTimes(1)
+    expect(onStateChanged).toHaveBeenCalledWith(expectedChainConnections)
+    expect(connections.every((data) => data.port.connected === true)).toBe(true)
+
+    onStateChanged.mockReset()
+    manager.disconnectTab(0)
+    await wait(0)
+
+    expect(onStateChanged).toHaveBeenCalledTimes(1)
+    expect(onStateChanged).toHaveBeenCalledWith(
+      expectedChainConnections.filter((c) => c.tabId !== 0),
+    )
+    expect(
+      connections.every((data) => data.port.connected === data.tabId > 0),
+    ).toBe(true)
   })
 
-  test("Buffers RPC messages before spec message", async () => {
-    const message1 = JSON.stringify({ id: 1, jsonrpc: "2.0", result: {} })
-    port.triggerMessage({ type: "rpc", payload: message1 })
-    const message2 = JSON.stringify({ id: 2, jsonrpc: "2.0", result: {} })
-    port.triggerMessage({ type: "rpc", payload: message2 })
-    port.triggerMessage({ type: "add-well-known-chain", payload: "westend" })
-    await waitForMessageToBePosted()
-    expect(app.healthChecker).toBeDefined()
+  it("passes the relay-chains of its tab as the potentialRelayChains when instantiating a new chain", async () => {
+    const { connectPort } = helper
+
+    // This emulates 3 active tabs, where the 2 first chains of each tab
+    // are relayChains anre the 3rd one of that tab is a para-chain
+    const activeChains = Array(9)
+      .fill(null)
+      .map((_, idx) => idx)
+      .map((idx) => {
+        const tabId = Math.floor(idx / 3)
+        const { chain } = connectPort(idx.toString(), tabId, {
+          type: "add-well-known-chain",
+          payload: "polkadot",
+          parachainPayload:
+            idx % 3 === 2
+              ? JSON.stringify({ name: `parachain${idx}` })
+              : undefined,
+        })
+        return chain
+      })
+
+    await wait(0)
+
+    const { chain: newChain } = connectPort("lastOne", 0, {
+      type: "add-well-known-chain",
+      payload: "polkadot",
+    })
+
+    await wait(0)
+
+    expect(newChain!.options.potentialRelayChains).toEqual([
+      activeChains[0],
+      activeChains[1],
+    ])
   })
 
-  test("RPC port message sends the message to the chain", async () => {
-    port.triggerMessage({ type: "add-well-known-chain", payload: "westend" })
-    await waitForMessageToBePosted()
-    const message = JSON.stringify({ id: 1, jsonrpc: "2.0", result: {} })
-    port.triggerMessage({ type: "rpc", payload: message })
-    await waitForMessageToBePosted()
-  })
+  it("disconnects and removes the smoldot instance on shutdown", async () => {
+    const { manager, connectPort } = helper
+    await manager.shutdown()
 
-  test("App already disconnected", async () => {
-    app = manager.createApp(port)
-    port.triggerMessage({ type: "add-well-known-chain", payload: "westend" })
-    await waitForMessageToBePosted()
-    manager.disconnect(app)
-    await waitForMessageToBePosted()
-    expect(() => {
-      manager.disconnect(app)
-    }).toThrowError("Cannot disconnect - already disconnected")
+    expect(() => connectPort("boom", 0)).toThrow(
+      "Smoldot client does not exist.",
+    )
+    expect(() => manager.addChain("")).toThrow("Smoldot client does not exist.")
   })
 })

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -3,16 +3,16 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import {
   Client,
-  start,
   healthChecker as smHealthChecker,
+  Chain,
 } from "@substrate/smoldot-light"
 import { JsonRpcCallback, SmoldotHealth } from "@substrate/smoldot-light"
-import { ExposedAppInfo, App, ConnectionManagerInterface } from "./types"
+import { ExposedChainConnection, ChainConnection } from "./types"
 import EventEmitter from "eventemitter3"
-import { StateEmitter, State } from "./types"
-import { NetworkMainInfo, Network } from "../types"
+import { StateEmitter } from "./types"
 import { logger } from "@polkadot/util"
 import { ToExtension } from "@substrate/connect-extension-protocol"
 import westend from "../../public/assets/westend.json"
@@ -31,208 +31,127 @@ const l = logger("Extension Connection Manager")
 
 /**
  * ConnectionManager is the main class involved in managing connections from
- * apps.  It keeps track of apps and it is also responsible for triggering
- * events when the state changes for the UI to update accordingly.
+ * content-script.  It keeps track of active chain connections and it is also
+ * responsible for triggering events when the state changes for the UI to update
+ * accordingly.
  */
-export class ConnectionManager
-  extends (EventEmitter as { new (): StateEmitter })
-  implements ConnectionManagerInterface
-{
-  readonly #apps: App[] = []
-  #client: Client | undefined = undefined
-  #networks: Network[] = []
-  smoldotLogLevel = 3
+export class ConnectionManager extends (EventEmitter as {
+  new (): StateEmitter
+}) {
+  #client: Client | null
+  #emitScheduled = false
+  readonly #chainConnections: Map<string, ChainConnection> = new Map()
 
-  /** registeredApps
-   *
-   * @returns a list of the names of apps that are currently connected
-   */
-  get registeredApps(): string[] {
-    return this.#apps.map((a) => a.name)
-  }
-
-  /** registeredClients
-   *
-   * @returns a list of the networks that are currently connected
-   */
-  get registeredNetworks(): NetworkMainInfo[] {
-    return this.#networks.map((s: Network) => ({
-      name: s.name,
-      id: s.id,
-      status: s.status,
-    }))
+  constructor(client: Client) {
+    super()
+    this.#client = client
   }
 
   /**
-   * apps
    *
-   * @returns all the connected apps.
+   *
+   * @returns all the connected chains.
    */
-  get apps(): ExposedAppInfo[] {
-    return this.#apps.map((a: App) => ({
-      appName: a.appName,
-      chainName: a.chainName,
-      healthStatus: a.healthStatus,
-      pendingRequests: a.pendingRequests,
-      state: a.state,
-      url: a.url,
-      tabId: a.tabId,
-    }))
+  get connections(): ExposedChainConnection[] {
+    return [...this.#chainConnections.values()]
+      .filter((a) => a.chainName)
+      .map((a: ChainConnection) => ({
+        chainId: a.chainId,
+        url: a.url,
+        tabId: a.tabId,
+        chainName: a.chainName,
+        healthStatus: a.healthStatus,
+      }))
+  }
+
+  #emitStateChanged() {
+    // let's make sure that we don't unnecessary spam the UI with notifications
+    if (this.#emitScheduled) return
+
+    this.#emitScheduled = true
+    setTimeout(() => {
+      this.emit("stateChanged", this.connections)
+      this.#emitScheduled = false
+    }, 0)
   }
 
   /**
-   * getState
-   *
-   * @returns a view of the current state of the connection manager
-   */
-  getState(): State {
-    const state: State = { apps: [] }
-    return this.#apps.reduce((result, app) => {
-      let a = result.apps.find(
-        (a) => a.name === app.appName && a.tabId === app.tabId,
-      )
-      if (a === undefined) {
-        a = {
-          name: app.appName,
-          tabId: app.tabId,
-          networks: [],
-        }
-        result.apps.push(a)
-      }
-      a.networks.push({ name: app.chainName })
-      return result
-    }, state)
-  }
-
-  /**
-   * disconnectTab disconnects all apps connected
+   * disconnectTab disconnects all chains connected
    * from the supplied tabId
    *
    * @param tabId - the id of the tab to disconnect
    */
   disconnectTab(tabId: number): void {
-    this.#apps
-      .filter((a) => a.tabId && a.tabId === tabId)
-      .forEach((a) => {
-        this.disconnect(a)
-      })
-  }
-
-  /**
-   * disconnectAll disconnects all apps connected for all tabs
-   */
-  disconnectAll(): void {
-    this.#apps.filter((a) => a).forEach((a) => this.disconnect(a))
-  }
-
-  createApp(incPort: chrome.runtime.Port): App {
-    const splitIdx = incPort.name.indexOf("::")
-    if (splitIdx === -1) {
-      const payload = `Invalid port name ${incPort.name} expected <app_name>::<chain_name>`
-      incPort.postMessage({ type: "error", payload })
-      incPort.disconnect()
-      throw new Error(payload)
-    }
-    const { name, sender } = incPort
-    const appName: string = name.substr(0, splitIdx)
-    const chainName: string = name.substr(splitIdx + 2, name.length)
-    const tabId: number = sender?.tab?.id || -1
-    const url: string | undefined = sender?.url
-    const port: chrome.runtime.Port = incPort
-    const state = "connected"
-    const pendingRequests: string[] = []
-
-    const healthChecker = smHealthChecker()
-    const app: App = {
-      appName,
-      chainName,
-      name,
-      tabId,
-      url,
-      port,
-      state,
-      healthChecker,
-      pendingRequests,
-    }
-    port.onMessage.addListener(this.#handleMessage)
-    port.onDisconnect.addListener(() => {
-      this.#handleDisconnect(app)
+    this.#chainConnections.forEach((a) => {
+      if (a.tabId === tabId) a.port.disconnect()
     })
-    return app
   }
 
   /**
-   * addApp registers a new app to be tracked by the background.
+   * addChainConnection registers a new chain-connection to be tracked by the background.
    *
    * @param port - a port for a fresh connection that was made to the background
    * by a content script.
    */
-  addApp(port: chrome.runtime.Port): void {
+  addChainConnection(port: chrome.runtime.Port): void {
     if (!this.#client) {
       throw new Error("Smoldot client does not exist.")
-    }
-
-    if (this.#findApp(port)) {
-      port.postMessage({
-        type: "error",
-        payload: `App ${port.name} already exists.`,
-      })
-      port.disconnect()
-      return
     }
 
     // if create an `AppMediator` throws, it has sent an error down the
     // port and disconnected it, so we should just ignore
     try {
-      const app = this.createApp(port)
-      this.registerApp(app)
-    } catch (error) {
-      l.error(`Error while adding chain: ${error}`)
+      const { name: chainId, sender } = port
+      const tabId: number = sender!.tab!.id!
+      const url: string = sender!.url!
+      const pendingRequests: string[] = []
+
+      const healthChecker = smHealthChecker()
+      const connection: ChainConnection = {
+        chainName: "",
+        chainId,
+        tabId,
+        url,
+        port,
+        healthChecker,
+        pendingRequests,
+      }
+
+      const onMessageHandler = (msg: ToExtension) => {
+        this.#handleMessage(msg, connection)
+      }
+      port.onMessage.addListener(onMessageHandler)
+
+      const onDisconnect = () => {
+        connection.chain && connection.chain.remove()
+        connection.parachain && connection.parachain.remove()
+
+        port.onMessage.removeListener(onMessageHandler)
+        port.onDisconnect.removeListener(onDisconnect)
+
+        if (this.#chainConnections.get(chainId)?.chainName)
+          this.#emitStateChanged()
+
+        this.#chainConnections.delete(chainId)
+      }
+      port.onDisconnect.addListener(onDisconnect)
+
+      this.#chainConnections.set(chainId, connection)
+    } catch (e) {
+      const msg = `Error while connecting to the port ${e}`
+      l.error(msg)
+      this.#handleError(port, e instanceof Error ? e : new Error(msg))
     }
-  }
-
-  /**
-   * registerApp is used to associate an app with a network
-   *
-   * @param app - The app
-   */
-  registerApp(app: App): void {
-    this.#apps.push(app)
-    this.emit("stateChanged", this.getState())
-    this.emit("appsChanged", this.apps)
-  }
-
-  /**
-   * unregisterApp is used after an app has finished processing any unsubscribe
-   * messages and disconnected to fully unregister itself.
-   * It also retrieves the chain that app was connected to and calls smoldot for removal
-   *
-   * @param app - The app
-   */
-  unregisterApp(app: App): void {
-    const idx = this.#apps.findIndex((a) => a.name === app.name)
-    this.#apps.splice(idx, 1)
-    this.emit("stateChanged", this.getState())
-    this.emit("appsChanged", this.apps)
   }
 
   /** shutdown shuts down the connected smoldot client. */
-  async shutdown(): Promise<void> {
-    await this.#client?.terminate()
-    this.#client = undefined
-  }
+  shutdown(): Promise<void> {
+    if (!this.#client) return Promise.resolve()
 
-  /**
-   * initSmoldot initializes the smoldot client.
-   */
-  initSmoldot(): void {
-    try {
-      this.#client = start({
-        maxLogLevel: this.smoldotLogLevel,
-      })
-    } catch (err) {
-      l.error(`Error while initializing smoldot: ${err}`)
-    }
+    this.#chainConnections.forEach((a) => a.port.disconnect())
+    const client = this.#client
+    this.#client = null
+    return client.terminate()
   }
 
   /**
@@ -244,166 +163,134 @@ export class ConnectionManager
    *
    * @returns addedChain - An the newly added chain info
    */
-  async addChain(
+  addChain(
     chainSpec: string,
     jsonRpcCallback?: JsonRpcCallback,
     tabId?: number,
-  ): Promise<Network> {
+  ): Promise<Chain> {
     if (!this.#client) {
       throw new Error("Smoldot client does not exist.")
     }
-    const { name, id, relay_chain } = JSON.parse(chainSpec)
 
-    // identify all relay_chains init'ed from same app with tabId identifier
-    const potentialNetworks: Network[] = relay_chain
-      ? this.#networks.filter((n) => n.tabId === tabId)
-      : this.#networks
+    const potentialRelayChains = [...this.#chainConnections.values()]
+      .filter((c) => c.tabId === tabId && !c.parachain && c.chain)
+      .map((c) => c.chain!)
 
-    const addedChain = await this.#client.addChain({
+    return this.#client.addChain({
       chainSpec,
       jsonRpcCallback,
-      potentialRelayChains: potentialNetworks.map((r) => r.chain),
+      potentialRelayChains,
     })
-
-    // This covers cases of refreshing browser in order to avoid
-    // pilling up on this.#networks, the ones that were created from same tab
-    const existingNetwork = this.#networks.find(
-      (n) => n.name.toLowerCase() === name.toLowerCase() && n.tabId === tabId,
-    )
-    const network: Network = {
-      tabId: tabId || 0,
-      id,
-      name: name.toLowerCase(),
-      chain: addedChain,
-      status: "connected",
-    }
-    !existingNetwork && this.#networks.push(network)
-    return existingNetwork || network
   }
 
-  #initHealthChecker = (app: App, isParachain?: boolean): void => {
-    if (isParachain) {
-      app.parachain &&
-        app.healthChecker?.setSendJsonRpc(app.parachain.sendJsonRpc)
-    } else {
-      app.chain && app.healthChecker?.setSendJsonRpc(app.chain.sendJsonRpc)
-    }
-    void app.healthChecker?.start((health: SmoldotHealth) => {
-      if (
-        health &&
-        (app.healthStatus?.peers !== health.peers ||
-          app.healthStatus.isSyncing !== health.isSyncing)
-      ) {
-        this.emit("appsChanged", this.apps)
-      }
-      app.healthStatus = health
-    })
-    // process any RPC requests that came in while waiting for `addChain` to complete
-    if (app.pendingRequests.length > 0) {
-      app.pendingRequests.forEach((req) => app.healthChecker?.sendJsonRpc(req))
-      app.pendingRequests = []
-    }
-  }
-
-  #handleError = (app: App, e: Error): void => {
-    app.port.postMessage({ type: "error", payload: e.message })
-    app.port.disconnect()
-    this.unregisterApp(app)
+  #handleError(port: chrome.runtime.Port, e: Error) {
+    port.postMessage({ type: "error", payload: e.message })
+    port.disconnect()
   }
 
   /** Handles the incoming message that contains Spec. */
-  #handleSpecMessage = (
-    app: App,
+  async #handleSpecMessage(
+    chainConnection: ChainConnection,
     relayChainSpec: string,
     parachainSpec?: string,
-  ): void => {
+  ) {
     if (!relayChainSpec) {
-      const error: Error = new Error("Relay chain spec was not found")
-      this.#handleError(app, error)
-      return
+      throw new Error("Relay chain spec was not found")
     }
 
     const rpcCallback = (rpc: string) => {
-      const rpcResp: string | null | undefined =
-        app.healthChecker?.responsePassThrough(rpc)
-      if (rpcResp) app.port.postMessage({ type: "rpc", payload: rpcResp })
+      const rpcResp = chainConnection.healthChecker.responsePassThrough(rpc)
+      if (rpcResp)
+        chainConnection.port.postMessage({ type: "rpc", payload: rpcResp })
     }
 
-    let chainPromise: Promise<void>
+    let chainPromise: Promise<{ chain: Chain; parachain?: Chain }>
     // Means this is a parachain trying to connect
     if (parachainSpec) {
+      chainConnection.chainName = JSON.parse(parachainSpec).name || "unknown"
       // Connect the main Chain first and on success the parachain with the chain
       // that just got connected as the relayChain
-
-      chainPromise = this.addChain(relayChainSpec, undefined, app.tabId)
-        .then((network) => {
-          app.chain = network.chain
-          return this.addChain(parachainSpec, rpcCallback, app.tabId)
-        })
-        .then((network) => {
-          app.parachain = network.chain
-          app.chainName = JSON.parse(parachainSpec).name
-          return
-        })
-    } else {
-      // Connect the main Chain only
-      chainPromise = this.addChain(relayChainSpec, rpcCallback, app.tabId).then(
-        (network) => {
-          app.chain = network.chain
-          return
-        },
+      chainPromise = this.addChain(
+        relayChainSpec,
+        undefined,
+        chainConnection.tabId,
+      ).then((chain) =>
+        this.addChain(parachainSpec, rpcCallback, chainConnection.tabId).then(
+          (parachain) => ({ chain, parachain }),
+        ),
       )
+    } else {
+      chainConnection.chainName = JSON.parse(relayChainSpec).name || "unknown"
+      // Connect the main Chain only
+      chainPromise = this.addChain(
+        relayChainSpec,
+        rpcCallback,
+        chainConnection.tabId,
+      ).then((chain) => ({ chain }))
     }
+
+    chainConnection.chainName = chainConnection.chainName.toLowerCase()
+
+    this.#emitStateChanged()
 
     chrome.storage.sync.get("notifications", (s) => {
       s.notifications &&
-        chrome.notifications.create(app.port.name, {
+        chrome.notifications.create(chainConnection.port.name, {
           title: "Substrate Connect",
-          message: `App ${app.appName} connected to ${app.chainName}.`,
+          message: `Chain ${chainConnection.chainId} connected to ${chainConnection.chainName}.`,
           iconUrl: "./icons/icon-32.png",
           type: "basic",
         })
     })
 
-    chainPromise
-      .then(() => {
-        this.#initHealthChecker(app, !!app.parachain)
-      })
-      .catch((e: Error) => {
-        this.#handleError(app, e)
-      })
-  }
+    const { chain, parachain } = await chainPromise
+    chainConnection.chain = chain
+    chainConnection.parachain = parachain
 
-  #findApp(port: chrome.runtime.Port): App | undefined {
-    return this.#apps.find(
-      (a) => a.name === port.name && a.tabId === port.sender?.tab?.id,
+    // Initialize healthChecker
+    const sender = chainConnection.parachain
+      ? chainConnection.parachain
+      : chainConnection.chain
+
+    chainConnection.healthChecker.setSendJsonRpc(
+      sender.sendJsonRpc.bind(sender),
     )
+    chainConnection.healthChecker.start((health: SmoldotHealth) => {
+      const hasChanged =
+        chainConnection.healthStatus?.peers !== health.peers ||
+        chainConnection.healthStatus.isSyncing !== health.isSyncing ||
+        chainConnection.healthStatus.shouldHavePeers !== health.shouldHavePeers
+
+      chainConnection.healthStatus = health
+      if (hasChanged) this.emit("stateChanged", this.connections)
+    })
+
+    // process any RPC requests that came in while waiting for `addChain` to complete
+    chainConnection.pendingRequests.forEach((req) =>
+      chainConnection.healthChecker.sendJsonRpc(req),
+    )
+    chainConnection.pendingRequests = []
   }
 
-  #handleMessage = (msg: ToExtension, port: chrome.runtime.Port): void => {
+  #handleMessage(msg: ToExtension, chainConnection: ChainConnection): void {
     if (
       (msg.type !== "rpc" &&
         msg.type !== "add-chain" &&
         msg.type !== "add-well-known-chain") ||
       !msg.payload
     ) {
-      console.warn(
-        `Unrecognised message type '${msg.type}' or payload '${msg.payload}' received from content script`,
-      )
-      return
+      const errorMsg = `Unrecognised message type '${msg.type}' or payload '${msg.payload}' received from content script`
+      l.error(errorMsg)
+      return this.#handleError(chainConnection.port, new Error(errorMsg))
     }
-    const app = this.#findApp(port)
-    if (!app) return
 
     if (msg.type === "rpc") {
-      if (app.chain === undefined) {
-        // `addChain` hasn't resolved yet after the spec message so buffer the
-        // messages to be sent when it does resolve
-        app.pendingRequests.push(msg.payload)
-        return
-      }
-
-      return app.healthChecker?.sendJsonRpc(msg.payload)
+      chainConnection.chain
+        ? chainConnection.healthChecker.sendJsonRpc(msg.payload)
+        : // `addChain` hasn't resolved yet after the spec message so buffer the
+          // messages to be sent when it does resolve
+          chainConnection.pendingRequests.push(msg.payload)
+      return
     }
 
     const chainSpec =
@@ -411,28 +298,17 @@ export class ConnectionManager
         ? msg.payload
         : wellKnownChains.get(msg.payload) ?? ""
 
-    return this.#handleSpecMessage(app, chainSpec, msg.parachainPayload)
-  }
-
-  /**
-   * disconnect tells the app to clean up its state and unsubscribe from any
-   * active subscriptions and ultimately disconnects the communication port.
-   */
-  disconnect(app: App): void {
-    this.#handleDisconnect(app)
-  }
-
-  #handleDisconnect = (app: App): void => {
-    if (app.state === "disconnected") {
-      throw new Error("Cannot disconnect - already disconnected")
-    }
-    // call remove() for both relaychain and parachain
-    app.chain && app.chain.remove()
-    app.parachain && app.parachain.remove()
-    this.#networks = this.#networks.filter((n) => n.tabId !== app.tabId)
-
-    this.unregisterApp(app)
-
-    app.state = "disconnected"
+    this.#handleSpecMessage(
+      chainConnection,
+      chainSpec,
+      msg.parachainPayload,
+    ).catch((e) => {
+      const errorMsg = `An error happened while adding the chain ${e}`
+      l.error(errorMsg)
+      this.#handleError(
+        chainConnection.port,
+        e instanceof Error ? e : new Error(errorMsg),
+      )
+    })
   }
 }

--- a/projects/extension/src/background/types.ts
+++ b/projects/extension/src/background/types.ts
@@ -1,56 +1,25 @@
-import type { JsonRpcCallback } from "@substrate/smoldot-light"
 import EventEmitter from "eventemitter3"
 import StrictEventEmitter from "strict-event-emitter-types"
 import { HealthChecker, Chain, SmoldotHealth } from "@substrate/smoldot-light"
-import { Network } from "../types"
 
-export interface ExposedAppInfo {
-  appName: string
+export interface ExposedChainConnection {
+  chainId: string
   chainName: string
   tabId: number
-  url?: string
+  url: string
   healthStatus?: SmoldotHealth
-  pendingRequests: string[]
-  state: AppState
 }
 
-export interface App extends ExposedAppInfo {
+export interface ChainConnection extends ExposedChainConnection {
+  pendingRequests: string[]
   chain?: Chain
   parachain?: Chain
-  name: string
   port: chrome.runtime.Port
-  healthChecker?: HealthChecker
-}
-
-export type AppState = "connected" | "disconnected"
-
-export interface PopupAppInfo {
-  name: string
-  tabId: number
-  networks: NetworkState[]
-}
-
-export interface State {
-  apps: PopupAppInfo[]
-}
-
-export interface NetworkState {
-  name: string
+  healthChecker: HealthChecker
 }
 
 export interface StateEvents {
-  stateChanged: State
-  appsChanged: ExposedAppInfo[]
+  stateChanged: ExposedChainConnection[]
 }
 
 export type StateEmitter = StrictEventEmitter<EventEmitter, StateEvents>
-
-export interface ConnectionManagerInterface {
-  registerApp: (app: App) => void
-  unregisterApp: (app: App) => void
-  addChain: (
-    spec: string,
-    jsonRpcCallback?: JsonRpcCallback,
-    tabId?: number,
-  ) => Promise<Network>
-}

--- a/projects/extension/src/components/Tab.tsx
+++ b/projects/extension/src/components/Tab.tsx
@@ -13,10 +13,9 @@ import Tooltip, { TooltipProps } from "@material-ui/core/Tooltip"
 import { grey } from "@material-ui/core/colors"
 import { IconWeb3 } from "."
 import { TabInterface } from "../types"
-import { ConnectionManager } from "../background/ConnectionManager"
 
 interface TabProps {
-  manager?: ConnectionManager
+  disconnectTab: (tabId: number) => void
   current?: boolean
   tab?: TabInterface
   setActiveTab?: Dispatch<SetStateAction<TabInterface | undefined>>
@@ -53,7 +52,7 @@ const BootstrapTooltip = (props: TooltipProps) => {
 }
 
 const Tab: FunctionComponent<TabProps> = ({
-  manager,
+  disconnectTab,
   tab,
   current = false,
   setActiveTab,
@@ -70,7 +69,7 @@ const Tab: FunctionComponent<TabProps> = ({
       /* TODO(nik): Fix smoldot definition (see: https://github.com/paritytech/substrate-connect/blob/3350cdff9c4c294393160189816168a93c983f79/projects/extension/src/background/ConnectionManager.ts#L202)
        ** eslint disable below seems to be due to smoldot definition */
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      manager?.disconnectTab(tab.tabId)
+      disconnectTab(tab.tabId)
       if (setActiveTab && current) {
         setActiveTab(undefined)
       }
@@ -92,12 +91,8 @@ const Tab: FunctionComponent<TabProps> = ({
               {tab.url}
             </Typography>
             <Box display="flex" alignItems="center">
-              {tab?.uApp.networks.map((n) => (
-                <IconWeb3
-                  key={n}
-                  size="14px"
-                  color={tab?.uApp.enabled ? grey[800] : grey[400]}
-                >
+              {tab?.networks.map((n) => (
+                <IconWeb3 key={n} size="14px" color={grey[800]}>
                   {n}
                 </IconWeb3>
               ))}

--- a/projects/extension/src/mocks.ts
+++ b/projects/extension/src/mocks.ts
@@ -2,74 +2,122 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { jest } from "@jest/globals"
-import { App, ConnectionManagerInterface } from "./background/types"
-import { Chain } from "@substrate/smoldot-light"
-import { Network } from "./types"
+/* eslint-disable @typescript-eslint/no-empty-function */
+
+import {
+  ToApplication,
+  ToExtension,
+} from "@substrate/connect-extension-protocol"
+import { AddChainOptions, Chain, Client } from "@substrate/smoldot-light"
+
+const noop: any = Function.prototype
+
+export const TEST_URL = "https://test.com"
 
 export class MockPort implements chrome.runtime.Port {
   sender: any
-  #messageListeners = []
-  #disconnectListeners = []
+  connected = true
+  postedMessages: Array<any> = []
   readonly name: string
-
-  constructor(name: string) {
-    this.name = name
-    this.sender = { url: "http://test.com/", tab: { id: 1234 } }
+  #callbacks = {
+    onDisconnect: noop,
+    onMessageCb: noop,
   }
 
-  postMessage: (message: any) => void = jest.fn()
-  disconnect: () => void = jest.fn()
+  constructor(name: string, tabId: number, url = TEST_URL) {
+    this.name = name
+    this.sender = { url, tab: { id: tabId } }
+  }
+
+  postMessage(message: any) {
+    this.postedMessages.push(message)
+  }
+
+  disconnect() {
+    this.connected = false
+    this.#callbacks.onDisconnect()
+  }
 
   setTabId(id: number): void {
     this.sender.tab.id = id
   }
 
-  triggerMessage(message: any): void {
-    this.#messageListeners.forEach((l: any) => {
-      l(message, this)
+  _sendExtensionMessage(
+    message: Omit<ToExtension, "origin" | "chainId">,
+  ): void {
+    this.#callbacks.onMessageCb({
+      ...message,
+      chainId: this.name,
+      origin: "extension-provider",
     })
   }
 
-  triggerDisconnect(): void {
-    this.#disconnectListeners.forEach((l: any) => {
-      l()
-    })
+  _sendAppMessage({
+    type,
+    payload,
+  }: Pick<ToApplication, "type" | "payload">): void {
+    this.#callbacks.onMessageCb({ type, payload })
   }
 
   onMessage = {
     addListener: (listener: never) => {
-      this.#messageListeners.push(listener)
+      this.#callbacks.onMessageCb = listener
+    },
+    removeListener: () => {
+      this.#callbacks.onMessageCb = noop
     },
   } as any
+
   onDisconnect = {
     addListener: (listener: never) => {
-      this.#disconnectListeners.push(listener)
+      this.#callbacks.onDisconnect = listener
+    },
+    removeListener: () => {
+      this.#callbacks.onDisconnect = noop
     },
   } as any
 }
 
-export class MockConnectionManager implements ConnectionManagerInterface {
-  addChain(): Promise<Network> {
-    return Promise.resolve({
-      chain: {} as Chain,
-      tabId: 0,
-    } as Network)
+export class MockedChain implements Chain {
+  options: AddChainOptions
+  isActive = true
+  receivedMessages: string[] = []
+  #onRemove: () => void
+
+  constructor(options: AddChainOptions, onRemove: () => void) {
+    this.#onRemove = onRemove
+    this.options = options
   }
-  createApp: (port: chrome.runtime.Port) => App = jest.fn()
-  disconnect: (app: App) => void = jest.fn()
-  registerApp: () => void = jest.fn()
-  unregisterApp: () => void = jest.fn()
+
+  sendJsonRpc(rpc: string) {
+    this.receivedMessages.push(rpc)
+  }
+
+  _sendResponse(message: string) {
+    this.options.jsonRpcCallback?.(message)
+  }
+
+  databaseContent() {
+    return Promise.resolve("")
+  }
+  remove() {
+    this.#onRemove()
+    this.isActive = false
+  }
 }
 
-export class ErroringMockConnectionManager
-  implements ConnectionManagerInterface
-{
-  addChain(): Promise<Network> {
-    return Promise.reject(new Error("Invalid chain spec"))
+export class MockSmoldotClient implements Client {
+  constructor() {}
+  chains = new Set<MockedChain>()
+  addChain(options: AddChainOptions): Promise<MockedChain> {
+    const chain = new MockedChain(options, () => {
+      this.chains.delete(chain)
+    })
+    this.chains.add(chain)
+    return Promise.resolve(chain)
   }
-  createApp: (port: chrome.runtime.Port) => App = jest.fn()
-  disconnect: (app: App) => void = jest.fn()
-  registerApp: () => void = jest.fn()
-  unregisterApp: () => void = jest.fn()
+  terminate() {
+    this.chains.clear()
+    return Promise.resolve()
+  }
 }

--- a/projects/extension/src/types/index.ts
+++ b/projects/extension/src/types/index.ts
@@ -7,14 +7,8 @@ export type NetworkStatus = "connected" | "disconnecting" | "disconnected"
 export interface TabInterface {
   tabId: number | undefined
   url: string | undefined
-  uApp: uApp
-  isActive?: boolean
-}
-export type uApp = {
   networks: string[] // TODO: for now pass strings in order to make the v0 prototype
-  // networks: Network[]; // This should be activated for parachains and v1
-  name: string
-  enabled: boolean
+  isActive?: boolean
 }
 
 export interface NetworkMainInfo {


### PR DESCRIPTION
I feel bad for opening such a large PR. So, I would like to explain how and why it came to this.

When I started working on #571, the very first thing that I did was to define a new public interface that looked like this:

```ts
export interface ExposedChainConnection {
  chainId: string;
  chainName: string;
  tabId: number;
  url: string;
  healthStatus?: SmoldotHealth;
}

export interface Background extends Window {
  manager: {
    onManagerStateChanged: (
      listener: (state: ExposedChainConnection[]) => void
    ) => () => void;
    disconnectTab: (tabId: number) => void;
  };
}
```

Which is all what needs to be exposed so that the UI can display the state of the different connections.

Next, I updated the code in the React components to leverage this new API. So far, so good.

Up until this point, I hadn't even looked at the actual implementation of `ConnectionManager.ts`. However, when I went to make the implementation compliant with the new API, then I noticed that there were lots of types (`PopupAppInfo`, `AppState`, `App`, `NetworkState`, etc) that were no longer needed. Probably the only reason why they existed is b/c `ConnectionManager` was tightly coupled to the UI.

Also, given the way that the `ConnectionManager` was keeping track of all that bogus state, combined with the fact that the public API was exposing too much, that ended up being the perfect recipe for producing some annoying bugs (`disconnectTab` would leave the ports connected, the UI was not always displaying all the active networks in a tab, there were cases when not all `potentialRelayChains` were being passed, etc). Also, the tests mainly consisted in testing a public interface that was too loose and that basically made assertions about the UI state. So, with the new API those tests were no longer relevant (or useful).

So, I started fixing the public API but I ended up falling into a slippery slope that led me to a complete refactor of the `ConnectionManager`. I got rid of all those things that were no longer needed, and I think that the code is now a lot more straight forward. Then I replaced the previous `ConnectionManager` tests with a new set of tests.

About the approach that I took for testing: the `ConnectionManager` is responsible for managing the different connections that come from the content-script ports and ensuring that the communication between smoldot and these ports works correctly, while also being responsible for letting other entities know about the relevant parts of its state (`ExposedChainConnection[]`) whenever it changes.

Therefore, these are the things that the tests should be testing. In order to do that, these new tests mock the smoldot client and the chrome ports in order to make sure that the interactions between them work correctly, and they also make sure that `ConnectionManager` emits an event with the correct `ExposedChainConnection[]` when the chains are being added/removed or when the health of one of them changes.

It's worth pointing out that currently the test-coverage stats on the `master` branch for the `extension` workspace look like this:

```bash
Statements   : 76.52% ( 176/230 )
Branches     : 49.61% ( 64/129 )
Functions    : 81.69% ( 58/71 )
Lines        : 76.36% ( 168/220 )
```

while the same stats on this branch look like this:

```bash
Statements   : 94.62% ( 176/186 )
Branches     : 80.51% ( 62/77 )  
Functions    : 94.82% ( 55/58 )  
Lines        : 94.47% ( 171/181 )
```

So, in the end this PR does a lot more than what #571 was strictly about. However, I think that these tests justify that these changes are solid and worthy of being merged into `master`.