### PR TITLE
add `chain-ready` message type

### DIFF
--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -26,7 +26,7 @@ export interface ToApplication {
   /** Which chain this message applies to **/
   chainId: string
   /** Type of the message. Defines how to interpret the {@link payload} */
-  type: "error" | "rpc"
+  type: "error" | "rpc" | "add-chain-ok"
   /** Payload of the message. Either a JSON encoded RPC response or an error message **/
   payload: string
 }

--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -26,7 +26,7 @@ export interface ToApplication {
   /** Which chain this message applies to **/
   chainId: string
   /** Type of the message. Defines how to interpret the {@link payload} */
-  type: "error" | "rpc" | "add-chain-ok"
+  type: "error" | "rpc" | "chain-ready"
   /** Payload of the message. Either a JSON encoded RPC response or an error message **/
   payload: string
 }

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -4,7 +4,10 @@
 
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { jest } from "@jest/globals"
-import type { ExtensionProviderClass } from "./ExtensionProvider"
+import type {
+  ExtensionProvider as IExtensionProvider,
+  ExtensionProviderClass,
+} from "./ExtensionProvider"
 
 jest.unstable_mockModule("./getRandomChainId.js", () => {
   let nextChainId = "test"
@@ -43,6 +46,20 @@ const sendMessage = (msg: ToApplication): void => {
 const westendSpec = JSON.stringify({ name: "Westend", id: "westend2" })
 const rococoSpec = JSON.stringify({ name: "Rococo", id: "rococo" })
 
+const emulateConnect = (
+  ep: IExtensionProvider,
+  chainId = "test",
+): Promise<void> => {
+  const p = ep.connect()
+  sendMessage({
+    origin: "content-script",
+    chainId,
+    type: "add-chain-ok",
+    payload: "",
+  })
+  return p
+}
+
 let handler = jest.fn()
 beforeEach(() => {
   handler = jest.fn()
@@ -57,7 +74,7 @@ test("connected and sends correct spec message", async () => {
   const ep = new ExtensionProvider(westendSpec)
   const emitted = jest.fn()
   ep.on("connected", emitted)
-  await ep.connect()
+  await emulateConnect(ep)
   await waitForMessageToBePosted()
 
   const expectedMessage: Partial<ToExtension> = {
@@ -65,7 +82,7 @@ test("connected and sends correct spec message", async () => {
     payload: '{"name":"Westend","id":"westend2"}',
     type: "add-chain",
   }
-  expect(handler).toHaveBeenCalledTimes(1)
+  expect(handler).toHaveBeenCalledTimes(2)
   const { data } = handler.mock.calls[0][0] as MessageEvent
   expect(data).toMatchObject(expectedMessage)
 })
@@ -77,9 +94,9 @@ test("connected multiple chains and sends correct spec message", async () => {
   const emitted2 = jest.fn()
   ep1.on("connected", emitted1)
   ep2.on("connected", emitted2)
-  await ep1.connect()
+  await emulateConnect(ep1)
   await waitForMessageToBePosted()
-  await ep2.connect()
+  await emulateConnect(ep2)
   await waitForMessageToBePosted()
 
   const expectedMessage1: Partial<ToExtension> = {
@@ -93,9 +110,9 @@ test("connected multiple chains and sends correct spec message", async () => {
     type: "add-chain",
   }
 
-  expect(handler).toHaveBeenCalledTimes(2)
+  expect(handler).toHaveBeenCalledTimes(4)
   const data1 = handler.mock.calls[0][0] as MessageEvent
-  const data2 = handler.mock.calls[1][0] as MessageEvent
+  const data2 = handler.mock.calls[2][0] as MessageEvent
   expect(data1.data).toMatchObject(expectedMessage1)
   expect(data2.data).toMatchObject(expectedMessage2)
 })
@@ -104,7 +121,7 @@ test("connected parachain sends correct spec message", async () => {
   const ep = new ExtensionProvider(westendSpec)
   const emitted = jest.fn()
   ep.on("connected", emitted)
-  await ep.connect()
+  await emulateConnect(ep)
   await waitForMessageToBePosted()
 
   const expectedMessage: Partial<ToExtension> = {
@@ -112,7 +129,7 @@ test("connected parachain sends correct spec message", async () => {
     payload: '{"name":"Westend","id":"westend2"}',
     type: "add-chain",
   }
-  expect(handler).toHaveBeenCalledTimes(1)
+  expect(handler).toHaveBeenCalledTimes(2)
   const { data } = handler.mock.calls[0][0] as MessageEvent
   expect(data).toMatchObject(expectedMessage)
 })
@@ -120,7 +137,7 @@ test("connected parachain sends correct spec message", async () => {
 test("disconnect sends disconnect message and emits disconnected", async () => {
   const ep = new ExtensionProvider(westendSpec)
   const emitted = jest.fn()
-  await ep.connect()
+  await emulateConnect(ep)
 
   ep.on("disconnected", emitted)
   void ep.disconnect()
@@ -134,7 +151,7 @@ test("disconnects and emits an error when it receives an error message", async (
   mockedGetRandomChainId._setNextChainId("foo")
   const ep = new ExtensionProvider(westendSpec)
   const emitted = jest.fn()
-  await ep.connect()
+  await emulateConnect(ep, "foo")
 
   ep.on("error", emitted)
   await waitForMessageToBePosted()
@@ -152,7 +169,7 @@ test("disconnects and emits an error when it receives an error message", async (
 test("emits error when it receives an error message", async () => {
   mockedGetRandomChainId._setNextChainId("foo")
   const ep = new ExtensionProvider(westendSpec)
-  await ep.connect()
+  await emulateConnect(ep, "foo")
   await waitForMessageToBePosted()
   const errorMessage: ToApplication = {
     origin: "content-script",
@@ -173,10 +190,10 @@ test("emits error when it receives an error message", async () => {
 test("it routes incoming messages to the correct Provider", async () => {
   mockedGetRandomChainId._setNextChainId("foo1")
   const ep1 = new ExtensionProvider("ExtensionProvider1", westendSpec)
-  await ep1.connect()
+  await emulateConnect(ep1, "foo1")
   mockedGetRandomChainId._setNextChainId("foo2")
   const ep2 = new ExtensionProvider("ExtensionProvider2", westendSpec)
-  await ep2.connect()
+  await emulateConnect(ep2, "foo2")
   await waitForMessageToBePosted()
 
   let extensionProvider1Response: string | undefined = undefined

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -54,7 +54,7 @@ const emulateConnect = (
   sendMessage({
     origin: "content-script",
     chainId,
-    type: "add-chain-ok",
+    type: "chain-ready",
     payload: "",
   })
   return p

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
@@ -273,12 +273,12 @@ export class ExtensionProvider implements ProviderInterface {
 
         window.removeEventListener("message", waitForChainCb)
 
-        if (data.type === "add-chain-ok") return res()
+        if (data.type === "chain-ready") return res()
 
         const error = new Error(
           data.type === "error"
             ? data.payload
-            : "Unexpected message received from the extension while waiting for 'add-chain-ok' message",
+            : "Unexpected message received from the extension while waiting for 'chain-ready' message",
         )
         rej(error)
         this.emit("error", error)

--- a/projects/extension/src/background/ConnectionManager.test.ts
+++ b/projects/extension/src/background/ConnectionManager.test.ts
@@ -184,7 +184,7 @@ describe("ConnectionManager", () => {
     ])
     expect(port.postedMessages).toEqual([
       {
-        type: "add-chain-ok",
+        type: "chain-ready",
       },
     ])
 
@@ -200,7 +200,7 @@ describe("ConnectionManager", () => {
 
     expect(port.postedMessages).toEqual([
       {
-        type: "add-chain-ok",
+        type: "chain-ready",
       },
       {
         type: "rpc",
@@ -445,7 +445,7 @@ describe("ConnectionManager", () => {
 
     expect(tab1Port.postedMessages).toEqual([
       {
-        type: "add-chain-ok",
+        type: "chain-ready",
       },
       {
         type: "rpc",
@@ -458,7 +458,7 @@ describe("ConnectionManager", () => {
     ])
     expect(tab2Port.postedMessages).toEqual([
       {
-        type: "add-chain-ok",
+        type: "chain-ready",
       },
       {
         type: "rpc",

--- a/projects/extension/src/background/ConnectionManager.test.ts
+++ b/projects/extension/src/background/ConnectionManager.test.ts
@@ -88,7 +88,7 @@ describe("ConnectionManager", () => {
     expect(onStateChanged).toHaveBeenCalledWith([expectedConnection])
     expect(manager.connections).toEqual([expectedConnection])
     expect(client.chains.size).toBe(1)
-    expect(port.postedMessages.length).toBe(0)
+    expect(port.postedMessages.length).toBe(1)
   })
 
   it("does not emit if the port gets disconnected before the chain has been instantiated", async () => {
@@ -134,7 +134,7 @@ describe("ConnectionManager", () => {
     ])
   })
 
-  it("the 'rpc' messages received before 'add-chain' get processed as soon as the chain is instantiated", async () => {
+  it("sending an 'rpc' message before the chain is added triggers an error", async () => {
     const { connectPort, client } = helper
 
     const { port } = connectPort("chainId", 1)
@@ -142,26 +142,22 @@ describe("ConnectionManager", () => {
     expect(client.chains.size).toBe(0)
 
     port._sendExtensionMessage({
+      type: "add-well-known-chain",
+      payload: "polkadot",
+    })
+
+    port._sendExtensionMessage({
       type: "rpc",
       payload: JSON.stringify({ jsonrpc: "2.0", id: "1" }),
     })
 
-    port._sendExtensionMessage({
-      type: "rpc",
-      payload: JSON.stringify({ jsonrpc: "2.0", id: "2" }),
-    })
-
-    port._sendExtensionMessage({
-      type: "add-well-known-chain",
-      payload: "polkadot",
-    })
     await wait(0)
 
-    const [chain] = [...client.chains]
-    expect(chain.receivedMessages).toEqual([
-      '{"jsonrpc":"2.0","id":"health-checker:0","method":"system_health","params":[]}',
-      '{"jsonrpc":"2.0","id":"extern:\\"1\\""}',
-      '{"jsonrpc":"2.0","id":"extern:\\"2\\""}',
+    expect(port.postedMessages).toEqual([
+      {
+        type: "error",
+        payload: "RPC request received befor the chain was successfully added",
+      },
     ])
   })
 
@@ -186,7 +182,11 @@ describe("ConnectionManager", () => {
       '{"jsonrpc":"2.0","id":"health-checker:0","method":"system_health","params":[]}',
       '{"jsonrpc":"2.0","id":"extern:\\"1\\""}',
     ])
-    expect(port.postedMessages).toEqual([])
+    expect(port.postedMessages).toEqual([
+      {
+        type: "add-chain-ok",
+      },
+    ])
 
     chain!._sendResponse(
       JSON.stringify({
@@ -199,6 +199,9 @@ describe("ConnectionManager", () => {
     await wait(0)
 
     expect(port.postedMessages).toEqual([
+      {
+        type: "add-chain-ok",
+      },
       {
         type: "rpc",
         payload: JSON.stringify({
@@ -420,8 +423,8 @@ describe("ConnectionManager", () => {
     expect(lastMessage).toBe('{"jsonrpc":"2.0","id":"extern:\\"ping2\\""}')
 
     // let's make sure that each port receives *only* their own messages
-    expect(tab1Port.postedMessages.length).toBe(0)
-    expect(tab2Port.postedMessages.length).toBe(0)
+    expect(tab1Port.postedMessages.length).toBe(1)
+    expect(tab2Port.postedMessages.length).toBe(1)
 
     tab1Chain!._sendResponse(
       JSON.stringify({
@@ -442,6 +445,9 @@ describe("ConnectionManager", () => {
 
     expect(tab1Port.postedMessages).toEqual([
       {
+        type: "add-chain-ok",
+      },
+      {
         type: "rpc",
         payload: JSON.stringify({
           jsonrpc: "2.0",
@@ -451,6 +457,9 @@ describe("ConnectionManager", () => {
       },
     ])
     expect(tab2Port.postedMessages).toEqual([
+      {
+        type: "add-chain-ok",
+      },
       {
         type: "rpc",
         payload: JSON.stringify({

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -255,7 +255,7 @@ export class ConnectionManager extends (EventEmitter as {
       return
     }
 
-    chainConnection.port.postMessage({ type: "add-chain-ok" })
+    chainConnection.port.postMessage({ type: "chain-ready" })
 
     // Initialize healthChecker
     const sender = chainConnection.parachain

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -104,7 +104,6 @@ export class ConnectionManager extends (EventEmitter as {
       const { name: chainId, sender } = port
       const tabId: number = sender!.tab!.id!
       const url: string = sender!.url!
-      const pendingRequests: string[] = []
 
       const healthChecker = smHealthChecker()
       const id = `${chainId}::${tabId}`
@@ -116,7 +115,6 @@ export class ConnectionManager extends (EventEmitter as {
         url,
         port,
         healthChecker,
-        pendingRequests,
       }
 
       const onMessageHandler = (msg: ToExtension) => {
@@ -248,6 +246,17 @@ export class ConnectionManager extends (EventEmitter as {
     chainConnection.chain = chain
     chainConnection.parachain = parachain
 
+    // it has to be taken into account the fact that it's technically possible
+    // -although, quite unlikey- that the port gets closed while we are waiting
+    // for smoldot to return the chain. The way to know this is by checking
+    // whether this `chainConnection` is still present insinde `#chainConnections`.
+    // If it isn't, that means that the port got disconnected, so we should stop.
+    if (!this.#chainConnections.has(chainConnection.id)) {
+      return
+    }
+
+    chainConnection.port.postMessage({ type: "add-chain-ok" })
+
     // Initialize healthChecker
     const sender = chainConnection.parachain
       ? chainConnection.parachain
@@ -265,12 +274,6 @@ export class ConnectionManager extends (EventEmitter as {
       chainConnection.healthStatus = health
       if (hasChanged) this.emit("stateChanged", this.connections)
     })
-
-    // process any RPC requests that came in while waiting for `addChain` to complete
-    chainConnection.pendingRequests.forEach((req) =>
-      chainConnection.healthChecker.sendJsonRpc(req),
-    )
-    chainConnection.pendingRequests = []
   }
 
   #handleMessage(msg: ToExtension, chainConnection: ChainConnection): void {
@@ -286,11 +289,13 @@ export class ConnectionManager extends (EventEmitter as {
     }
 
     if (msg.type === "rpc") {
-      chainConnection.chain
-        ? chainConnection.healthChecker.sendJsonRpc(msg.payload)
-        : // `addChain` hasn't resolved yet after the spec message so buffer the
-          // messages to be sent when it does resolve
-          chainConnection.pendingRequests.push(msg.payload)
+      if (chainConnection.chain)
+        return chainConnection.healthChecker.sendJsonRpc(msg.payload)
+
+      const errorMsg =
+        "RPC request received befor the chain was successfully added"
+      l.error(errorMsg)
+      this.#handleError(chainConnection.port, new Error(errorMsg))
       return
     }
 

--- a/projects/extension/src/background/types.ts
+++ b/projects/extension/src/background/types.ts
@@ -12,7 +12,6 @@ export interface ExposedChainConnection {
 
 export interface ChainConnection extends ExposedChainConnection {
   id: string
-  pendingRequests: string[]
   chain?: Chain
   parachain?: Chain
   port: chrome.runtime.Port


### PR DESCRIPTION
Following task #572 this PR is fixing the following:

- When you send a message to add a chain, the extension should return ~~two~~ one message~~s~~ that ~~don't~~ doesn't exist yet: ~~one "add-chain-started" message immediately returned, and that is used to know whether the extension exists, and~~ one "add-chain-ok" or "add-chain-error" message. All ~~three~~ two messages indicate which `chainId` they refer to, and "add-chain-error" also provides an `error` string.

Now that we have the `add-chain-ok` message, there is no reason for the `ConnectionManager` to try to handle `RPC` messages that came too early. Instead, now it should send an error to the content-script if an RPC message comes before the `add-chain-ok` message has been sent. Therefore, this logic and the related tests have been updated accordingly.

Regarding the code of the `ExtensionProvider`: I've tried to make as little changes as possible while still ensuring that the `Promise` returned by `connect` now doesn't resolve until it receives the `add-chain-ok` response from the Extension. I've also tried to make as little changes as possible to the tests of the `ExtensionProvider` b/c well... it's out of the scope of this PR to improve those tests, but IMO they should be improved at some point.