### PR TITLE
add  `remove-chain` type into `ToExtension`

### DIFF
--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -38,7 +38,7 @@ export interface ToExtension {
   chainId: string
   /** The message the `ExtensionMessageRouter` should forward to the background **/
   /** Type of the message. Defines how to interpret the {@link payload} */
-  type: "rpc" | "add-chain" | "add-well-known-chain"
+  type: "rpc" | "add-chain" | "add-well-known-chain" | "remove-chain"
   /** Payload of the message -  a JSON encoded RPC request **/
   payload: string
   parachainPayload?: string

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.ts
@@ -337,6 +337,12 @@ export class ExtensionProvider implements ProviderInterface {
     if (this.#connectionStatePingerId !== null) {
       clearInterval(this.#connectionStatePingerId)
     }
+    sendMessage({
+      origin: EXTENSION_PROVIDER_ORIGIN,
+      chainId: this.#chainId,
+      type: "remove-chain",
+      payload: "",
+    })
     this.#isConnected = false
     this.emit("disconnected")
     return Promise.resolve()

--- a/projects/extension/src/background/ConnectionManager.test.ts
+++ b/projects/extension/src/background/ConnectionManager.test.ts
@@ -491,4 +491,30 @@ describe("ConnectionManager", () => {
 
     expect(client.chains.size).toBe(0)
   })
+
+  it("disconnects and cleans up upon receiving a `remove-chain` message", async () => {
+    const { connectPort, client } = helper
+
+    const { port } = connectPort("chainId", 1, {
+      type: "add-well-known-chain",
+      payload: "polkadot",
+    })
+
+    await wait(0)
+
+    expect(client.chains.size).toBe(1)
+
+    port._sendExtensionMessage({
+      type: "remove-chain",
+      payload: "",
+    })
+
+    expect(port.postedMessages).toEqual([
+      {
+        type: "chain-ready",
+      },
+    ])
+    expect(client.chains.size).toBe(0)
+    expect(port.connected).toBe(false)
+  })
 })

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -279,18 +279,9 @@ export class ConnectionManager extends (EventEmitter as {
   }
 
   #handleMessage(msg: ToExtension, chainConnection: ChainConnection): void {
-    if (
-      (msg.type !== "rpc" &&
-        msg.type !== "add-chain" &&
-        msg.type !== "add-well-known-chain") ||
-      !msg.payload
-    ) {
-      const errorMsg = `Unrecognised message type '${msg.type}' or payload '${msg.payload}' received from content script`
-      l.error(errorMsg)
-      return this.#handleError(chainConnection.port, new Error(errorMsg))
-    }
+    if (msg.type === "remove-chain") return chainConnection.port.disconnect()
 
-    if (msg.type === "rpc") {
+    if (msg.type === "rpc" && msg.payload) {
       if (chainConnection.chain)
         return chainConnection.healthChecker.sendJsonRpc(msg.payload)
 
@@ -299,6 +290,15 @@ export class ConnectionManager extends (EventEmitter as {
       l.error(errorMsg)
       this.#handleError(chainConnection.port, new Error(errorMsg))
       return
+    }
+
+    if (
+      !msg.payload ||
+      (msg.type !== "add-chain" && msg.type !== "add-well-known-chain")
+    ) {
+      const errorMsg = `Unrecognised message type '${msg.type}' or payload '${msg.payload}' received from content script`
+      l.error(errorMsg)
+      return this.#handleError(chainConnection.port, new Error(errorMsg))
     }
 
     const chainSpec =


### PR DESCRIPTION
Following task #572 this PR is fixing the following:

 - Add a new message "remove-chain" that tells the extension that we no longer want a chain. This is equivalent to the legacy `action: "disconnect"`.