### PR TITLE
Use smoldot's database system in the extension

### DIFF
--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -20,26 +20,61 @@
  * The {@link ConnectionManager} is the class in the extension background.
  */
 
-export interface ToApplication {
-  /** origin is used to determine which side sent the message **/
+interface ToApplicationHeader {
   origin: "content-script"
-  /** Which chain this message applies to **/
+}
+
+interface ToApplicationError {
+  type: "error"
   chainId: string
-  /** Type of the message. Defines how to interpret the {@link payload} */
-  type: "error" | "rpc" | "chain-ready"
-  /** Payload of the message. Either a JSON encoded RPC response or an error message **/
   payload: string
 }
 
-export interface ToExtension {
-  /** origin is used to determine which side sent the message **/
-  origin: "extension-provider"
-  /** The uniqueId for extension multiplexing **/
+interface ToApplicationChainReady {
+  type: "chain-ready"
   chainId: string
-  /** The message the `ExtensionMessageRouter` should forward to the background **/
-  /** Type of the message. Defines how to interpret the {@link payload} */
-  type: "rpc" | "add-chain" | "add-well-known-chain" | "remove-chain"
-  /** Payload of the message -  a JSON encoded RPC request **/
-  payload: string
-  parachainPayload?: string
 }
+
+interface ToApplicationRpc {
+  type: "rpc"
+  chainId: string
+  payload: string
+}
+
+export type ToApplication = ToApplicationHeader &
+  (ToApplicationError | ToApplicationChainReady | ToApplicationRpc)
+
+interface ToExtensionHeader {
+  origin: "extension-provider"
+}
+
+interface ToExtensionAddChain {
+  type: "add-chain"
+  chainId: string
+  payload: { chainSpec: string; parachainSpec?: string }
+}
+
+interface ToExtensionAddWellKnownChain {
+  type: "add-well-known-chain"
+  chainId: string
+  payload: { name: string; parachainSpec?: string }
+}
+
+interface ToExtensionRpc {
+  type: "rpc"
+  chainId: string
+  payload: string
+}
+
+interface ToExtensionRemoveChain {
+  type: "remove-chain"
+  chainId: string
+}
+
+export type ToExtension = ToExtensionHeader &
+  (
+    | ToExtensionAddChain
+    | ToExtensionAddWellKnownChain
+    | ToExtensionRpc
+    | ToExtensionRemoveChain
+  )

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -55,7 +55,6 @@ const emulateConnect = (
     origin: "content-script",
     chainId,
     type: "chain-ready",
-    payload: "",
   })
   return p
 }
@@ -79,8 +78,8 @@ test("connected and sends correct spec message", async () => {
 
   const expectedMessage: Partial<ToExtension> = {
     origin: "extension-provider",
-    payload: '{"name":"Westend","id":"westend2"}',
     type: "add-chain",
+    payload: { chainSpec: '{"name":"Westend","id":"westend2"}' },
   }
   expect(handler).toHaveBeenCalledTimes(2)
   const { data } = handler.mock.calls[0][0] as MessageEvent
@@ -101,13 +100,13 @@ test("connected multiple chains and sends correct spec message", async () => {
 
   const expectedMessage1: Partial<ToExtension> = {
     origin: "extension-provider",
-    payload: '{"name":"Westend","id":"westend2"}',
     type: "add-chain",
+    payload: { chainSpec: '{"name":"Westend","id":"westend2"}' },
   }
   const expectedMessage2: Partial<ToExtension> = {
     origin: "extension-provider",
-    payload: '{"name":"Rococo","id":"rococo"}',
     type: "add-chain",
+    payload: { chainSpec: '{"name":"Rococo","id":"rococo"}' },
   }
 
   expect(handler).toHaveBeenCalledTimes(4)
@@ -126,8 +125,8 @@ test("connected parachain sends correct spec message", async () => {
 
   const expectedMessage: Partial<ToExtension> = {
     origin: "extension-provider",
-    payload: '{"name":"Westend","id":"westend2"}',
     type: "add-chain",
+    payload: { chainSpec: '{"name":"Westend","id":"westend2"}' },
   }
   expect(handler).toHaveBeenCalledTimes(2)
   const { data } = handler.mock.calls[0][0] as MessageEvent

--- a/projects/extension/public/manifest.json
+++ b/projects/extension/public/manifest.json
@@ -6,7 +6,7 @@
   "short_name": "substrate-connect",
   "version": "0.0.4",
   "manifest_version": 2,
-  "permissions": ["notifications", "storage", "tabs"],
+  "permissions": ["notifications", "storage", "tabs", "alarms"],
   "background": {
     "scripts": ["background.js"]
   },

--- a/projects/extension/src/background/ConnectionManager.test.ts
+++ b/projects/extension/src/background/ConnectionManager.test.ts
@@ -8,7 +8,13 @@
 import { jest } from "@jest/globals"
 import { ConnectionManager } from "./ConnectionManager"
 import { ExposedChainConnection } from "./types"
-import { MockedChain, MockPort, MockSmoldotClient, TEST_URL } from "../mocks"
+import {
+  MockedChain,
+  MockPort,
+  MockSmoldotClient,
+  TEST_URL,
+  HeaderlessToExtension,
+} from "../mocks"
 import { ToExtension } from "@substrate/connect-extension-protocol"
 
 const wait = (ms: number) => new Promise((res) => setTimeout(res, ms))
@@ -23,7 +29,7 @@ const createHelper = () => {
     connectPort: (
       chainId: string,
       tabId: number,
-      addChainMsg: Omit<ToExtension, "origin" | "chainId"> | null = null,
+      addChainMsg?: HeaderlessToExtension<ToExtension>,
       url = TEST_URL,
     ) => {
       const port = new MockPort(chainId, tabId)
@@ -72,7 +78,7 @@ describe("ConnectionManager", () => {
 
     port._sendExtensionMessage({
       type: "add-well-known-chain",
-      payload: "polkadot",
+      payload: { name: "polkadot" },
     })
 
     await wait(0)
@@ -121,7 +127,7 @@ describe("ConnectionManager", () => {
 
     port._sendExtensionMessage({
       type: "add-well-known-chain",
-      payload: "polkadot",
+      payload: { name: "polkadot" },
     })
     await wait(0)
 
@@ -143,7 +149,7 @@ describe("ConnectionManager", () => {
 
     port._sendExtensionMessage({
       type: "add-well-known-chain",
-      payload: "polkadot",
+      payload: { name: "polkadot" },
     })
 
     port._sendExtensionMessage({
@@ -166,7 +172,7 @@ describe("ConnectionManager", () => {
 
     const { port, chain } = connectPort("chainId", 1, {
       type: "add-well-known-chain",
-      payload: "polkadot",
+      payload: { name: "polkadot" },
     })
 
     await wait(0)
@@ -234,7 +240,7 @@ describe("ConnectionManager", () => {
     const { connectPort } = helper
     const { port } = connectPort("chainId", 1, {
       type: "add-well-known-chain",
-      payload: "nonexisting",
+      payload: { name: "nonexisting" },
     })
 
     await wait(0)
@@ -254,7 +260,7 @@ describe("ConnectionManager", () => {
 
     const { chain, chainId, tabId, url } = connectPort("chainId", 1, {
       type: "add-well-known-chain",
-      payload: "polkadot",
+      payload: { name: "polkadot" },
     })
 
     await wait(0)
@@ -304,7 +310,7 @@ describe("ConnectionManager", () => {
         const tabId = Math.floor(idx / 3)
         return connectPort(idx.toString(), tabId, {
           type: "add-well-known-chain",
-          payload: "polkadot",
+          payload: { name: "polkadot" },
         })
       })
     await wait(0)
@@ -348,11 +354,13 @@ describe("ConnectionManager", () => {
         const tabId = Math.floor(idx / 3)
         const { chain } = connectPort(idx.toString(), tabId, {
           type: "add-well-known-chain",
-          payload: "polkadot",
-          parachainPayload:
-            idx % 3 === 2
-              ? JSON.stringify({ name: `parachain${idx}` })
-              : undefined,
+          payload: {
+            name: "polkadot",
+            parachainSpec:
+              idx % 3 === 2
+                ? JSON.stringify({ name: `parachain${idx}` })
+                : undefined,
+          },
         })
         return chain
       })
@@ -361,7 +369,7 @@ describe("ConnectionManager", () => {
 
     const { chain: newChain } = connectPort("lastOne", 0, {
       type: "add-well-known-chain",
-      payload: "polkadot",
+      payload: { name: "polkadot" },
     })
 
     await wait(0)
@@ -388,12 +396,12 @@ describe("ConnectionManager", () => {
 
     const { chain: tab1Chain, port: tab1Port } = connectPort(chainId, 1, {
       type: "add-well-known-chain",
-      payload: "polkadot",
+      payload: { name: "polkadot" },
     })
 
     const { chain: tab2Chain, port: tab2Port } = connectPort(chainId, 2, {
       type: "add-well-known-chain",
-      payload: "polkadot",
+      payload: { name: "polkadot" },
     })
 
     await wait(0)
@@ -476,7 +484,7 @@ describe("ConnectionManager", () => {
 
     const { port } = connectPort("chainId", 1, {
       type: "add-well-known-chain",
-      payload: "polkadot",
+      payload: { name: "polkadot" },
     })
 
     expect(client.chains.size).toBe(1)
@@ -497,7 +505,7 @@ describe("ConnectionManager", () => {
 
     const { port } = connectPort("chainId", 1, {
       type: "add-well-known-chain",
-      payload: "polkadot",
+      payload: { name: "polkadot" },
     })
 
     await wait(0)
@@ -506,7 +514,6 @@ describe("ConnectionManager", () => {
 
     port._sendExtensionMessage({
       type: "remove-chain",
-      payload: "",
     })
 
     expect(port.postedMessages).toEqual([

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -6,6 +6,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import {
   Client,
   healthChecker as smHealthChecker,
@@ -198,12 +199,15 @@ export class ConnectionManager extends (EventEmitter as {
     const chainName = knownChainName?.toLowerCase()
     const databaseContent =
       chainName &&
-      (await new Promise<string>((res) =>
-        chrome.storage.local.get([chainName], (val) => {
-          return res(val[chainName])
-        }),
-      ))
-    console.log("databaseContent", databaseContent)
+      (await new Promise<string>((resolve, reject) => {
+        chrome.storage.local.get([chainName], (result) => {
+          if (result[chainName] === undefined) {
+            reject()
+          }
+          resolve(result[chainName])
+        })
+      }))
+
     return this.#client.addChain({
       chainSpec,
       databaseContent,

--- a/projects/extension/src/background/index.ts
+++ b/projects/extension/src/background/index.ts
@@ -59,7 +59,7 @@ const init = async () => {
           chrome.storage.local.QUOTA_BYTES / wellKnownChains.size,
         )
         const keyLow: string = key.toLowerCase()
-        chrome.storage.local.set({ keyLow: db })
+        chrome.storage.local.set({ [keyLow]: db })
       }
     }
     /**

--- a/projects/extension/src/content/ExtensionMessageRouter.test.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.test.ts
@@ -39,7 +39,7 @@ describe("Disconnect and incorrect cases", () => {
     sendMessage({
       chainId: "test",
       type: "add-well-known-chain",
-      payload: "westend",
+      payload: { name: "westend" },
       origin: "extension-provider",
     })
     await waitForMessageToBePosted()
@@ -88,7 +88,7 @@ describe("Connection and forward cases", () => {
     sendMessage({
       chainId,
       type: "add-well-known-chain",
-      payload: "westend",
+      payload: { name: "westend" },
       origin: "extension-provider",
     })
 
@@ -105,7 +105,7 @@ describe("Connection and forward cases", () => {
     sendMessage({
       chainId: "test",
       type: "add-well-known-chain",
-      payload: "westend",
+      payload: { name: "westend" },
       origin: "extension-provider",
     })
     await waitForMessageToBePosted()
@@ -113,10 +113,10 @@ describe("Connection and forward cases", () => {
     // rpc
     const rpcMessage: ToExtension = {
       chainId: "test",
+      origin: "extension-provider",
       type: "rpc",
       payload:
         '{"id":1,"jsonrpc":"2.0","method":"state_getStorage","params":["<hash>"]}',
-      origin: "extension-provider",
     }
     sendMessage(rpcMessage)
     await waitForMessageToBePosted()
@@ -136,7 +136,7 @@ describe("Connection and forward cases", () => {
     sendMessage({
       chainId: "test",
       type: "add-well-known-chain",
-      payload: "westend",
+      payload: { name: "westend" },
       origin: "extension-provider",
     })
     await waitForMessageToBePosted()
@@ -168,7 +168,7 @@ describe("Connection and forward cases", () => {
     sendMessage({
       chainId: "test",
       type: "add-well-known-chain",
-      payload: "westend",
+      payload: { name: "westend" },
       origin: "extension-provider",
     })
     await waitForMessageToBePosted()

--- a/yarn.lock
+++ b/yarn.lock
@@ -7980,9 +7980,9 @@ nan@^2.14.2:
   integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
 
 nanoid@^3.1.30:
-  version "3.1.30"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.30.tgz#63f93cc548d2a113dc5dfbc63bfa09e2b9b64362"
-  integrity sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.2.0.tgz#62667522da6673971cca916a6d3eff3f415ff80c"
+  integrity sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
- Add functionality to extension in order to periodically call `smoldotClient.databaseContent()` for the hardcoded chains (`Polkadot`, `Kusama`, `Rococo`, `Westend`) and save the result in local storage, using the chrome feature `alarms`.
- The alarm will repeat every 5 (`periodInMinutes`) minutes after the initial event for DatabaseContentAlarm
- `databaseContent()` is called with `QUOTA_BYTES: 5000000` divided by the amount of known chains (as of now 4). The maximum amount (in bytes) of data that can be stored in local storage, as measured by the JSON stringification of every value plus every key's length.

Fixes #568 