### PR TITLE
improve typings of `ToExtension` & `ToApplication`

### DIFF
--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -22,6 +22,9 @@
 
 interface ToApplicationHeader {
   origin: "content-script"
+}
+
+type ToApplicationChainHeader = ToApplicationHeader & {
   chainId: string
 }
 
@@ -39,11 +42,14 @@ interface ToApplicationRpc {
   payload: string
 }
 
-export type ToApplication = ToApplicationHeader &
+export type ToApplication = ToApplicationChainHeader &
   (ToApplicationError | ToApplicationChainReady | ToApplicationRpc)
 
 interface ToExtensionHeader {
   origin: "extension-provider"
+}
+
+type ToExtensionChainHeader = ToExtensionHeader & {
   chainId: string
 }
 
@@ -66,7 +72,7 @@ interface ToExtensionRemoveChain {
   type: "remove-chain"
 }
 
-export type ToExtension = ToExtensionHeader &
+export type ToExtension = ToExtensionChainHeader &
   (
     | ToExtensionAddChain
     | ToExtensionAddWellKnownChain

--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -20,26 +20,56 @@
  * The {@link ConnectionManager} is the class in the extension background.
  */
 
-export interface ToApplication {
-  /** origin is used to determine which side sent the message **/
+interface ToApplicationHeader {
   origin: "content-script"
-  /** Which chain this message applies to **/
   chainId: string
-  /** Type of the message. Defines how to interpret the {@link payload} */
-  type: "error" | "rpc" | "chain-ready"
-  /** Payload of the message. Either a JSON encoded RPC response or an error message **/
+}
+
+interface ToApplicationError {
+  type: "error"
   payload: string
 }
 
-export interface ToExtension {
-  /** origin is used to determine which side sent the message **/
-  origin: "extension-provider"
-  /** The uniqueId for extension multiplexing **/
-  chainId: string
-  /** The message the `ExtensionMessageRouter` should forward to the background **/
-  /** Type of the message. Defines how to interpret the {@link payload} */
-  type: "rpc" | "add-chain" | "add-well-known-chain" | "remove-chain"
-  /** Payload of the message -  a JSON encoded RPC request **/
-  payload: string
-  parachainPayload?: string
+interface ToApplicationChainReady {
+  type: "chain-ready"
 }
+
+interface ToApplicationRpc {
+  type: "rpc"
+  payload: string
+}
+
+export type ToApplication = ToApplicationHeader &
+  (ToApplicationError | ToApplicationChainReady | ToApplicationRpc)
+
+interface ToExtensionHeader {
+  origin: "extension-provider"
+  chainId: string
+}
+
+interface ToExtensionAddChain {
+  type: "add-chain"
+  payload: { chainSpec: string; parachainSpec?: string }
+}
+
+interface ToExtensionAddWellKnownChain {
+  type: "add-well-known-chain"
+  payload: { name: string; parachainSpec?: string }
+}
+
+interface ToExtensionRpc {
+  type: "rpc"
+  payload: string
+}
+
+interface ToExtensionRemoveChain {
+  type: "remove-chain"
+}
+
+export type ToExtension = ToExtensionHeader &
+  (
+    | ToExtensionAddChain
+    | ToExtensionAddWellKnownChain
+    | ToExtensionRpc
+    | ToExtensionRemoveChain
+  )

--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -24,55 +24,54 @@ interface ToApplicationHeader {
   origin: "content-script"
 }
 
-type ToApplicationChainHeader = ToApplicationHeader & {
-  chainId: string
-}
-
 interface ToApplicationError {
   type: "error"
+  chainId: string
   payload: string
 }
 
 interface ToApplicationChainReady {
   type: "chain-ready"
+  chainId: string
 }
 
 interface ToApplicationRpc {
   type: "rpc"
+  chainId: string
   payload: string
 }
 
-export type ToApplication = ToApplicationChainHeader &
+export type ToApplication = ToApplicationHeader &
   (ToApplicationError | ToApplicationChainReady | ToApplicationRpc)
 
 interface ToExtensionHeader {
   origin: "extension-provider"
 }
 
-type ToExtensionChainHeader = ToExtensionHeader & {
-  chainId: string
-}
-
 interface ToExtensionAddChain {
   type: "add-chain"
+  chainId: string
   payload: { chainSpec: string; parachainSpec?: string }
 }
 
 interface ToExtensionAddWellKnownChain {
   type: "add-well-known-chain"
+  chainId: string
   payload: { name: string; parachainSpec?: string }
 }
 
 interface ToExtensionRpc {
   type: "rpc"
+  chainId: string
   payload: string
 }
 
 interface ToExtensionRemoveChain {
   type: "remove-chain"
+  chainId: string
 }
 
-export type ToExtension = ToExtensionChainHeader &
+export type ToExtension = ToExtensionHeader &
   (
     | ToExtensionAddChain
     | ToExtensionAddWellKnownChain

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -55,7 +55,6 @@ const emulateConnect = (
     origin: "content-script",
     chainId,
     type: "chain-ready",
-    payload: "",
   })
   return p
 }
@@ -79,8 +78,8 @@ test("connected and sends correct spec message", async () => {
 
   const expectedMessage: Partial<ToExtension> = {
     origin: "extension-provider",
-    payload: '{"name":"Westend","id":"westend2"}',
     type: "add-chain",
+    payload: { chainSpec: '{"name":"Westend","id":"westend2"}' },
   }
   expect(handler).toHaveBeenCalledTimes(2)
   const { data } = handler.mock.calls[0][0] as MessageEvent
@@ -101,13 +100,13 @@ test("connected multiple chains and sends correct spec message", async () => {
 
   const expectedMessage1: Partial<ToExtension> = {
     origin: "extension-provider",
-    payload: '{"name":"Westend","id":"westend2"}',
     type: "add-chain",
+    payload: { chainSpec: '{"name":"Westend","id":"westend2"}' },
   }
   const expectedMessage2: Partial<ToExtension> = {
     origin: "extension-provider",
-    payload: '{"name":"Rococo","id":"rococo"}',
     type: "add-chain",
+    payload: { chainSpec: '{"name":"Rococo","id":"rococo"}' },
   }
 
   expect(handler).toHaveBeenCalledTimes(4)
@@ -126,8 +125,8 @@ test("connected parachain sends correct spec message", async () => {
 
   const expectedMessage: Partial<ToExtension> = {
     origin: "extension-provider",
-    payload: '{"name":"Westend","id":"westend2"}',
     type: "add-chain",
+    payload: { chainSpec: '{"name":"Westend","id":"westend2"}' },
   }
   expect(handler).toHaveBeenCalledTimes(2)
   const { data } = handler.mock.calls[0][0] as MessageEvent

--- a/projects/extension/src/background/ConnectionManager.test.ts
+++ b/projects/extension/src/background/ConnectionManager.test.ts
@@ -8,7 +8,13 @@
 import { jest } from "@jest/globals"
 import { ConnectionManager } from "./ConnectionManager"
 import { ExposedChainConnection } from "./types"
-import { MockedChain, MockPort, MockSmoldotClient, TEST_URL } from "../mocks"
+import {
+  MockedChain,
+  MockPort,
+  MockSmoldotClient,
+  TEST_URL,
+  HeaderlessToExtension,
+} from "../mocks"
 import { ToExtension } from "@substrate/connect-extension-protocol"
 
 const wait = (ms: number) => new Promise((res) => setTimeout(res, ms))
@@ -23,7 +29,7 @@ const createHelper = () => {
     connectPort: (
       chainId: string,
       tabId: number,
-      addChainMsg: Omit<ToExtension, "origin" | "chainId"> | null = null,
+      addChainMsg?: HeaderlessToExtension<ToExtension>,
       url = TEST_URL,
     ) => {
       const port = new MockPort(chainId, tabId)
@@ -72,7 +78,7 @@ describe("ConnectionManager", () => {
 
     port._sendExtensionMessage({
       type: "add-well-known-chain",
-      payload: "polkadot",
+      payload: { name: "polkadot" },
     })
 
     await wait(0)
@@ -121,7 +127,7 @@ describe("ConnectionManager", () => {
 
     port._sendExtensionMessage({
       type: "add-well-known-chain",
-      payload: "polkadot",
+      payload: { name: "polkadot" },
     })
     await wait(0)
 
@@ -143,7 +149,7 @@ describe("ConnectionManager", () => {
 
     port._sendExtensionMessage({
       type: "add-well-known-chain",
-      payload: "polkadot",
+      payload: { name: "polkadot" },
     })
 
     port._sendExtensionMessage({
@@ -166,7 +172,7 @@ describe("ConnectionManager", () => {
 
     const { port, chain } = connectPort("chainId", 1, {
       type: "add-well-known-chain",
-      payload: "polkadot",
+      payload: { name: "polkadot" },
     })
 
     await wait(0)
@@ -234,7 +240,7 @@ describe("ConnectionManager", () => {
     const { connectPort } = helper
     const { port } = connectPort("chainId", 1, {
       type: "add-well-known-chain",
-      payload: "nonexisting",
+      payload: { name: "nonexisting" },
     })
 
     await wait(0)
@@ -254,7 +260,7 @@ describe("ConnectionManager", () => {
 
     const { chain, chainId, tabId, url } = connectPort("chainId", 1, {
       type: "add-well-known-chain",
-      payload: "polkadot",
+      payload: { name: "polkadot" },
     })
 
     await wait(0)
@@ -304,7 +310,7 @@ describe("ConnectionManager", () => {
         const tabId = Math.floor(idx / 3)
         return connectPort(idx.toString(), tabId, {
           type: "add-well-known-chain",
-          payload: "polkadot",
+          payload: { name: "polkadot" },
         })
       })
     await wait(0)
@@ -348,11 +354,13 @@ describe("ConnectionManager", () => {
         const tabId = Math.floor(idx / 3)
         const { chain } = connectPort(idx.toString(), tabId, {
           type: "add-well-known-chain",
-          payload: "polkadot",
-          parachainPayload:
-            idx % 3 === 2
-              ? JSON.stringify({ name: `parachain${idx}` })
-              : undefined,
+          payload: {
+            name: "polkadot",
+            parachainSpec:
+              idx % 3 === 2
+                ? JSON.stringify({ name: `parachain${idx}` })
+                : undefined,
+          },
         })
         return chain
       })
@@ -361,7 +369,7 @@ describe("ConnectionManager", () => {
 
     const { chain: newChain } = connectPort("lastOne", 0, {
       type: "add-well-known-chain",
-      payload: "polkadot",
+      payload: { name: "polkadot" },
     })
 
     await wait(0)
@@ -388,12 +396,12 @@ describe("ConnectionManager", () => {
 
     const { chain: tab1Chain, port: tab1Port } = connectPort(chainId, 1, {
       type: "add-well-known-chain",
-      payload: "polkadot",
+      payload: { name: "polkadot" },
     })
 
     const { chain: tab2Chain, port: tab2Port } = connectPort(chainId, 2, {
       type: "add-well-known-chain",
-      payload: "polkadot",
+      payload: { name: "polkadot" },
     })
 
     await wait(0)
@@ -476,7 +484,7 @@ describe("ConnectionManager", () => {
 
     const { port } = connectPort("chainId", 1, {
       type: "add-well-known-chain",
-      payload: "polkadot",
+      payload: { name: "polkadot" },
     })
 
     expect(client.chains.size).toBe(1)
@@ -497,7 +505,7 @@ describe("ConnectionManager", () => {
 
     const { port } = connectPort("chainId", 1, {
       type: "add-well-known-chain",
-      payload: "polkadot",
+      payload: { name: "polkadot" },
     })
 
     await wait(0)
@@ -506,7 +514,6 @@ describe("ConnectionManager", () => {
 
     port._sendExtensionMessage({
       type: "remove-chain",
-      payload: "",
     })
 
     expect(port.postedMessages).toEqual([

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -303,13 +303,13 @@ export class ConnectionManager extends (EventEmitter as {
 
     const chainSpec =
       msg.type === "add-chain"
-        ? msg.payload
-        : wellKnownChains.get(msg.payload) ?? ""
+        ? msg.payload.chainSpec
+        : wellKnownChains.get(msg.payload.name)!
 
     this.#handleSpecMessage(
       chainConnection,
       chainSpec,
-      msg.parachainPayload,
+      msg.payload.parachainSpec,
     ).catch((e) => {
       const errorMsg = `An error happened while adding the chain ${e}`
       l.error(errorMsg)

--- a/projects/extension/src/content/ExtensionMessageRouter.test.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.test.ts
@@ -39,7 +39,7 @@ describe("Disconnect and incorrect cases", () => {
     sendMessage({
       chainId: "test",
       type: "add-well-known-chain",
-      payload: "westend",
+      payload: { name: "westend" },
       origin: "extension-provider",
     })
     await waitForMessageToBePosted()
@@ -88,7 +88,7 @@ describe("Connection and forward cases", () => {
     sendMessage({
       chainId,
       type: "add-well-known-chain",
-      payload: "westend",
+      payload: { name: "westend" },
       origin: "extension-provider",
     })
 
@@ -105,7 +105,7 @@ describe("Connection and forward cases", () => {
     sendMessage({
       chainId: "test",
       type: "add-well-known-chain",
-      payload: "westend",
+      payload: { name: "westend" },
       origin: "extension-provider",
     })
     await waitForMessageToBePosted()
@@ -113,10 +113,10 @@ describe("Connection and forward cases", () => {
     // rpc
     const rpcMessage: ToExtension = {
       chainId: "test",
+      origin: "extension-provider",
       type: "rpc",
       payload:
         '{"id":1,"jsonrpc":"2.0","method":"state_getStorage","params":["<hash>"]}',
-      origin: "extension-provider",
     }
     sendMessage(rpcMessage)
     await waitForMessageToBePosted()
@@ -136,7 +136,7 @@ describe("Connection and forward cases", () => {
     sendMessage({
       chainId: "test",
       type: "add-well-known-chain",
-      payload: "westend",
+      payload: { name: "westend" },
       origin: "extension-provider",
     })
     await waitForMessageToBePosted()
@@ -168,7 +168,7 @@ describe("Connection and forward cases", () => {
     sendMessage({
       chainId: "test",
       type: "add-well-known-chain",
-      payload: "westend",
+      payload: { name: "westend" },
       origin: "extension-provider",
     })
     await waitForMessageToBePosted()

--- a/projects/extension/src/mocks.ts
+++ b/projects/extension/src/mocks.ts
@@ -16,16 +16,14 @@ export const TEST_URL = "https://test.com"
 
 export type HeaderlessToExtension<T extends ToExtension> = T extends {
   origin: "extension-provider"
-  chainId: string
 } & infer V
-  ? V
+  ? Omit<V, "chainId">
   : unknown
 
 export type HeaderlessToApplication<T extends ToApplication> = T extends {
   origin: "content-script"
-  chainId: string
 } & infer V
-  ? V
+  ? Omit<V, "chainId">
   : unknown
 
 export class MockPort implements chrome.runtime.Port {


### PR DESCRIPTION
Following task #572 this PR is fixing the following:

- Split `ToApplication` and `ToExtension` in multiple messages based on their type, so that `add-chain`, `remove-chain`, etc. can be passed different fields. The `chainId` field shouldn't be directly in `ToApplication` and `ToExtension` but in each individual message.

I initially thought that it would make sense to also get rid of the `parachainSpec` property in this PR, but things started to get a bit out of hand. So, I decided to tackle that in the next PR, as it's very much related to the effort of adding the `potentialRelayChainIds` property into the `add-chain` message.