### PR TITLE
Update databaseContent from smoldot to local storage

### DIFF
--- a/projects/extension/public/manifest.json
+++ b/projects/extension/public/manifest.json
@@ -6,7 +6,7 @@
   "short_name": "substrate-connect",
   "version": "0.0.4",
   "manifest_version": 2,
-  "permissions": ["notifications", "storage", "tabs"],
+  "permissions": ["notifications", "storage", "tabs", "alarms"],
   "background": {
     "scripts": ["background.js"]
   },

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -1,9 +1,12 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-misused-promises */
+/* eslint-disable @typescript-eslint/no-floating-promises */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import {
   Client,
   healthChecker as smHealthChecker,
@@ -166,6 +169,7 @@ export class ConnectionManager extends (EventEmitter as {
     chainSpec: string,
     jsonRpcCallback?: JsonRpcCallback,
     tabId?: number,
+    databaseContent?: string,
   ): Promise<Chain> {
     if (!this.#client) {
       throw new Error("Smoldot client does not exist.")
@@ -177,6 +181,7 @@ export class ConnectionManager extends (EventEmitter as {
 
     return this.#client.addChain({
       chainSpec,
+      databaseContent,
       jsonRpcCallback,
       potentialRelayChains,
     })

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -1,12 +1,9 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-misused-promises */
-/* eslint-disable @typescript-eslint/no-floating-promises */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import {
   Client,
   healthChecker as smHealthChecker,

--- a/projects/extension/src/background/index.ts
+++ b/projects/extension/src/background/index.ts
@@ -76,7 +76,7 @@ const init = async () => {
         dbContent,
       )
       wellKnownConnections.set(key, chain)
-      !dbContent && saveChainDbContent(key, chain)
+      if (!dbContent) saveChainDbContent(key, chain)
     }
 
     chrome.alarms.create("DatabaseContentAlarm", {


### PR DESCRIPTION
- Add functionality to extension in order to periodically call `client.databaseContent()` for the well-known-chains (`Polkadot`, `Kusama`, `Rococo`, `Westend`) and save the result in local storage, using the chrome feature `alarms`.
- The alarm will repeat every 5 (`periodInMinutes`) minutes after the initial event for DatabaseContentAlarm
- `databaseContent()` is called with `QUOTA_BYTES: 5000000` divided by the amount of known chains (as of now 4). The maximum amount (in bytes) of data that can be stored in local storage, as measured by the JSON stringification of every value plus every key's length.
- Upon init of extension for each chain the `databaseContent` will be retrieved from localStorage and sent to `addChain`


Fixes #568 