### PR TITLE
Revert regenerator runtime for burnr

### DIFF
--- a/projects/burnr/package.json
+++ b/projects/burnr/package.json
@@ -39,6 +39,7 @@
     "react-is": "^17.0.2",
     "react-router": "^6.2.1",
     "react-router-dom": "^6.2.1",
+    "regenerator-runtime": "^0.13.9",
     "unique-names-generator": "^4.6.0"
   }
 }

--- a/projects/burnr/src/index.tsx
+++ b/projects/burnr/src/index.tsx
@@ -1,3 +1,4 @@
+import "regenerator-runtime/runtime"
 import { render } from "react-dom"
 import App from "./App"
 


### PR DESCRIPTION
I have tried several alternatives concerning regenerator-runtime issue for burnr wallet (such as `plugins` for babel and `useBuiltIns`) but in vain. For now (and upcoming deploy in ipfs) I will revert the plugin `regenerator-runtime` 