### PR TITLE
Replace `payload` fields with more accurate names

### DIFF
--- a/packages/connect-extension-protocol/src/index.ts
+++ b/packages/connect-extension-protocol/src/index.ts
@@ -102,7 +102,7 @@ interface ToApplicationHeader {
 interface ToApplicationError {
   type: "error"
   chainId: string
-  payload: string
+  errorMessage: string
 }
 
 interface ToApplicationChainReady {
@@ -113,7 +113,7 @@ interface ToApplicationChainReady {
 interface ToApplicationRpc {
   type: "rpc"
   chainId: string
-  payload: string
+  jsonRpcMessage: string
 }
 
 export type ToApplication = ToApplicationHeader &
@@ -126,19 +126,20 @@ interface ToExtensionHeader {
 interface ToExtensionAddChain {
   type: "add-chain"
   chainId: string
-  payload: { chainSpec: string; potentialRelayChainIds: Array<string> }
+  chainSpec: string
+  potentialRelayChainIds: string[]
 }
 
 interface ToExtensionAddWellKnownChain {
   type: "add-well-known-chain"
   chainId: string
-  payload: string
+  chainName: string
 }
 
 interface ToExtensionRpc {
   type: "rpc"
   chainId: string
-  payload: string
+  jsonRpcMessage: string
 }
 
 interface ToExtensionRemoveChain {

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -79,10 +79,8 @@ test("connected and sends correct spec message", async () => {
   const expectedMessage: Partial<ToExtension> = {
     origin: "substrate-connect-client",
     type: "add-chain",
-    payload: {
-      chainSpec: '{"name":"Westend","id":"westend2"}',
-      potentialRelayChainIds: [],
-    },
+    chainSpec: '{"name":"Westend","id":"westend2"}',
+    potentialRelayChainIds: [],
   }
   expect(handler).toHaveBeenCalledTimes(2)
   const { data } = handler.mock.calls[0][0] as MessageEvent
@@ -104,18 +102,14 @@ test("connected multiple chains and sends correct spec message", async () => {
   const expectedMessage1: Partial<ToExtension> = {
     origin: "substrate-connect-client",
     type: "add-chain",
-    payload: {
-      chainSpec: '{"name":"Westend","id":"westend2"}',
-      potentialRelayChainIds: [],
-    },
+    chainSpec: '{"name":"Westend","id":"westend2"}',
+    potentialRelayChainIds: [],
   }
   const expectedMessage2: Partial<ToExtension> = {
     origin: "substrate-connect-client",
     type: "add-chain",
-    payload: {
-      chainSpec: '{"name":"Rococo","id":"rococo"}',
-      potentialRelayChainIds: [],
-    },
+    chainSpec: '{"name":"Rococo","id":"rococo"}',
+    potentialRelayChainIds: [],
   }
 
   expect(handler).toHaveBeenCalledTimes(4)
@@ -135,10 +129,8 @@ test("connected parachain sends correct spec message", async () => {
   const expectedMessage: Partial<ToExtension> = {
     origin: "substrate-connect-client",
     type: "add-chain",
-    payload: {
-      chainSpec: '{"name":"Westend","id":"westend2"}',
-      potentialRelayChainIds: [],
-    },
+    chainSpec: '{"name":"Westend","id":"westend2"}',
+    potentialRelayChainIds: [],
   }
   expect(handler).toHaveBeenCalledTimes(2)
   const { data } = handler.mock.calls[0][0] as MessageEvent
@@ -170,7 +162,7 @@ test("disconnects and emits an error when it receives an error message", async (
     origin: "substrate-connect-extension",
     chainId: "foo",
     type: "error",
-    payload: "disconnected",
+    errorMessage: "disconnected",
   })
   await waitForMessageToBePosted()
   expect(emitted).toHaveBeenCalled()
@@ -186,7 +178,7 @@ test("emits error when it receives an error message", async () => {
     origin: "substrate-connect-extension",
     chainId: "foo",
     type: "error",
-    payload: "Boom!",
+    errorMessage: "Boom!",
   }
   const errorHandler = jest.fn()
   ep.on("error", errorHandler)
@@ -195,7 +187,7 @@ test("emits error when it receives an error message", async () => {
 
   expect(errorHandler).toHaveBeenCalled()
   const error = errorHandler.mock.calls[0][0] as Error
-  expect(error.message).toEqual(errorMessage.payload)
+  expect(error.message).toEqual(errorMessage.errorMessage)
 })
 
 test("it routes incoming messages to the correct Provider", async () => {
@@ -247,7 +239,7 @@ test("it routes incoming messages to the correct Provider", async () => {
     origin: "substrate-connect-extension",
     chainId: latestChainId,
     type: "rpc",
-    payload: JSON.stringify({
+    jsonRpcMessage: JSON.stringify({
       id: latestRequestRpcId,
       jsonrpc: "2.0",
       result: "hi ExtensionProvider2!",

--- a/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
+++ b/packages/connect/src/ExtensionProvider/ExtensionProvider.test.ts
@@ -226,10 +226,10 @@ test("it routes incoming messages to the correct Provider", async () => {
 
   const latestRequest = handler.mock.calls[
     handler.mock.calls.length - 1
-  ][0] as MessageEvent<{ payload: string; chainId: string }>
+  ][0] as MessageEvent<{ jsonRpcMessage: string; chainId: string }>
 
   const latestRequestRpcId = (
-    JSON.parse(latestRequest?.data.payload ?? "{}") as {
+    JSON.parse(latestRequest?.data.jsonRpcMessage ?? "{}") as {
       id: number
     }
   ).id

--- a/projects/extension/src/background/ConnectionManager.test.ts
+++ b/projects/extension/src/background/ConnectionManager.test.ts
@@ -78,7 +78,7 @@ describe("ConnectionManager", () => {
 
     port._sendExtensionMessage({
       type: "add-well-known-chain",
-      payload: "polkadot",
+      chainName: "polkadot",
     })
 
     await wait(0)
@@ -127,7 +127,7 @@ describe("ConnectionManager", () => {
 
     port._sendExtensionMessage({
       type: "add-well-known-chain",
-      payload: "polkadot",
+      chainName: "polkadot",
     })
     await wait(0)
 
@@ -149,12 +149,12 @@ describe("ConnectionManager", () => {
 
     port._sendExtensionMessage({
       type: "add-well-known-chain",
-      payload: "polkadot",
+      chainName: "polkadot",
     })
 
     port._sendExtensionMessage({
       type: "rpc",
-      payload: JSON.stringify({ jsonrpc: "2.0", id: "1" }),
+      jsonRpcMessage: JSON.stringify({ jsonrpc: "2.0", id: "1" }),
     })
 
     await wait(0)
@@ -172,14 +172,14 @@ describe("ConnectionManager", () => {
 
     const { port, chain } = connectPort("chainId", 1, {
       type: "add-well-known-chain",
-      payload: "polkadot",
+      chainName: "polkadot",
     })
 
     await wait(0)
 
     port._sendExtensionMessage({
       type: "rpc",
-      payload: JSON.stringify({ jsonrpc: "2.0", id: "1" }),
+      jsonRpcMessage: JSON.stringify({ jsonrpc: "2.0", id: "1" }),
     })
 
     await wait(0)
@@ -225,7 +225,7 @@ describe("ConnectionManager", () => {
 
     port._sendExtensionMessage({
       type: "foo" as "rpc",
-      payload: "",
+      jsonRpcMessage: "",
     })
 
     expect(port.postedMessages).toEqual([
@@ -240,7 +240,7 @@ describe("ConnectionManager", () => {
     const { connectPort } = helper
     const { port } = connectPort("chainId", 1, {
       type: "add-well-known-chain",
-      payload: "nonexisting",
+      chainName: "nonexisting",
     })
 
     await wait(0)
@@ -260,7 +260,7 @@ describe("ConnectionManager", () => {
 
     const { chain, chainId, tabId, url } = connectPort("chainId", 1, {
       type: "add-well-known-chain",
-      payload: "polkadot",
+      chainName: "polkadot",
     })
 
     await wait(0)
@@ -310,7 +310,7 @@ describe("ConnectionManager", () => {
         const tabId = Math.floor(idx / 3)
         return connectPort(idx.toString(), tabId, {
           type: "add-well-known-chain",
-          payload: "polkadot",
+          chainName: "polkadot",
         })
       })
     await wait(0)
@@ -354,7 +354,7 @@ describe("ConnectionManager", () => {
       const tabId = Math.floor(idx / 3)
       const { chain } = connectPort(idx.toString(), tabId, {
         type: "add-well-known-chain",
-        payload: "polkadot",
+        chainName: "polkadot",
       })
       return chain
     })
@@ -365,10 +365,8 @@ describe("ConnectionManager", () => {
     // the ones that are not in our tab
     const { chain: newChain } = connectPort("lastOne", 0, {
       type: "add-chain",
-      payload: {
-        chainSpec: JSON.stringify({ name: "parachain" }),
-        potentialRelayChainIds: allIds.map((id) => id.toString()),
-      },
+      chainSpec: JSON.stringify({ name: "parachain" }),
+      potentialRelayChainIds: allIds.map((id) => id.toString()),
     })
 
     await wait(0)
@@ -400,12 +398,12 @@ describe("ConnectionManager", () => {
 
     const { chain: tab1Chain, port: tab1Port } = connectPort(chainId, 1, {
       type: "add-well-known-chain",
-      payload: "polkadot",
+      chainName: "polkadot",
     })
 
     const { chain: tab2Chain, port: tab2Port } = connectPort(chainId, 2, {
       type: "add-well-known-chain",
-      payload: "polkadot",
+      chainName: "polkadot",
     })
 
     await wait(0)
@@ -417,12 +415,12 @@ describe("ConnectionManager", () => {
     // let's make sure that each chain receives *only* their own messages
     tab1Port._sendExtensionMessage({
       type: "rpc",
-      payload: JSON.stringify({ jsonrpc: "2.0", id: "ping1" }),
+      jsonRpcMessage: JSON.stringify({ jsonrpc: "2.0", id: "ping1" }),
     })
 
     tab2Port._sendExtensionMessage({
       type: "rpc",
-      payload: JSON.stringify({ jsonrpc: "2.0", id: "ping2" }),
+      jsonRpcMessage: JSON.stringify({ jsonrpc: "2.0", id: "ping2" }),
     })
 
     await wait(0)
@@ -488,7 +486,7 @@ describe("ConnectionManager", () => {
 
     const { port } = connectPort("chainId", 1, {
       type: "add-well-known-chain",
-      payload: "polkadot",
+      chainName: "polkadot",
     })
 
     expect(client.chains.size).toBe(1)
@@ -509,7 +507,7 @@ describe("ConnectionManager", () => {
 
     const { port } = connectPort("chainId", 1, {
       type: "add-well-known-chain",
-      payload: "polkadot",
+      chainName: "polkadot",
     })
 
     await wait(0)

--- a/projects/extension/src/background/ConnectionManager.test.ts
+++ b/projects/extension/src/background/ConnectionManager.test.ts
@@ -162,7 +162,8 @@ describe("ConnectionManager", () => {
     expect(port.postedMessages).toEqual([
       {
         type: "error",
-        payload: "RPC request received befor the chain was successfully added",
+        errorMessage:
+          "RPC request received befor the chain was successfully added",
       },
     ])
   })
@@ -210,7 +211,7 @@ describe("ConnectionManager", () => {
       },
       {
         type: "rpc",
-        payload: JSON.stringify({
+        jsonRpcMessage: JSON.stringify({
           jsonrpc: "2.0",
           id: "1",
           result: "{}",
@@ -228,12 +229,7 @@ describe("ConnectionManager", () => {
       jsonRpcMessage: "",
     })
 
-    expect(port.postedMessages).toEqual([
-      {
-        type: "error",
-        payload: `Unrecognised message type 'foo' or payload '' received from content script`,
-      },
-    ])
+    expect(port.postedMessages[0].type).toEqual("error")
   })
 
   it("correctly errors when passed a wrong well-known-chain", async () => {
@@ -248,7 +244,7 @@ describe("ConnectionManager", () => {
     expect(port.postedMessages).toEqual([
       {
         type: "error",
-        payload: "Relay chain spec was not found",
+        errorMessage: "Relay chain spec was not found",
       },
     ])
   })
@@ -459,7 +455,7 @@ describe("ConnectionManager", () => {
       },
       {
         type: "rpc",
-        payload: JSON.stringify({
+        jsonRpcMessage: JSON.stringify({
           jsonrpc: "2.0",
           id: "ping1",
           result: '"pong1"',
@@ -472,7 +468,7 @@ describe("ConnectionManager", () => {
       },
       {
         type: "rpc",
-        payload: JSON.stringify({
+        jsonRpcMessage: JSON.stringify({
           jsonrpc: "2.0",
           id: "ping2",
           result: '"pong2"',

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -187,7 +187,7 @@ export class ConnectionManager extends (EventEmitter as {
   }
 
   #handleError(port: chrome.runtime.Port, e: Error) {
-    port.postMessage({ type: "error", payload: e.message })
+    port.postMessage({ type: "error", errorMessage: e.message })
     port.disconnect()
   }
 
@@ -204,7 +204,7 @@ export class ConnectionManager extends (EventEmitter as {
     const rpcCallback = (rpc: string) => {
       const rpcResp = chainConnection.healthChecker.responsePassThrough(rpc)
       if (rpcResp)
-        chainConnection.port.postMessage({ type: "rpc", payload: rpcResp })
+        chainConnection.port.postMessage({ type: "rpc", jsonRpcMessage: rpcResp })
     }
 
     chainConnection.chainName =

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -274,7 +274,8 @@ export class ConnectionManager extends (EventEmitter as {
     }
 
     if (
-      (msg.type === "add-chain" && (!msg.chainSpec || !msg.potentialRelayChainIds)) ||
+      (msg.type === "add-chain" &&
+        (!msg.chainSpec || !msg.potentialRelayChainIds)) ||
       (msg.type === "add-well-known-chain" && !msg.chainName) ||
       (msg.type !== "add-chain" && msg.type !== "add-well-known-chain")
     ) {

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -204,7 +204,10 @@ export class ConnectionManager extends (EventEmitter as {
     const rpcCallback = (rpc: string) => {
       const rpcResp = chainConnection.healthChecker.responsePassThrough(rpc)
       if (rpcResp)
-        chainConnection.port.postMessage({ type: "rpc", jsonRpcMessage: rpcResp })
+        chainConnection.port.postMessage({
+          type: "rpc",
+          jsonRpcMessage: rpcResp,
+        })
     }
 
     chainConnection.chainName =
@@ -279,7 +282,7 @@ export class ConnectionManager extends (EventEmitter as {
       (msg.type === "add-well-known-chain" && !msg.chainName) ||
       (msg.type !== "add-chain" && msg.type !== "add-well-known-chain")
     ) {
-      const errorMsg = `Unrecognised message '${msg}' received from content script`
+      const errorMsg = `Unrecognized message '${msg}' received from content script`
       l.error(errorMsg)
       return this.#handleError(chainConnection.port, new Error(errorMsg))
     }

--- a/projects/extension/src/content/ExtensionMessageRouter.test.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.test.ts
@@ -39,7 +39,7 @@ describe("Disconnect and incorrect cases", () => {
     sendMessage({
       chainId: "test",
       type: "add-well-known-chain",
-      payload: "westend",
+      chainName: "westend",
       origin: "substrate-connect-client",
     })
     await waitForMessageToBePosted()
@@ -88,7 +88,7 @@ describe("Connection and forward cases", () => {
     sendMessage({
       chainId,
       type: "add-well-known-chain",
-      payload: "westend",
+      chainName: "westend",
       origin: "substrate-connect-client",
     })
 
@@ -105,7 +105,7 @@ describe("Connection and forward cases", () => {
     sendMessage({
       chainId: "test",
       type: "add-well-known-chain",
-      payload: "westend",
+      chainName: "westend",
       origin: "substrate-connect-client",
     })
     await waitForMessageToBePosted()
@@ -115,7 +115,7 @@ describe("Connection and forward cases", () => {
       chainId: "test",
       origin: "substrate-connect-client",
       type: "rpc",
-      payload:
+      jsonRpcMessage:
         '{"id":1,"jsonrpc":"2.0","method":"state_getStorage","params":["<hash>"]}',
     }
     sendMessage(rpcMessage)
@@ -124,7 +124,7 @@ describe("Connection and forward cases", () => {
     expect(router.connections.length).toBe(1)
     const sample = {
       type: rpcMessage.type,
-      payload: rpcMessage.payload,
+      payload: rpcMessage.jsonRpcMessage,
     }
     expect(port.postedMessages[port.postedMessages.length - 1]).toEqual(sample)
   })
@@ -136,7 +136,7 @@ describe("Connection and forward cases", () => {
     sendMessage({
       chainId: "test",
       type: "add-well-known-chain",
-      payload: "westend",
+      chainName: "westend",
       origin: "substrate-connect-client",
     })
     await waitForMessageToBePosted()
@@ -145,7 +145,7 @@ describe("Connection and forward cases", () => {
     window.addEventListener("message", handler)
     port._sendAppMessage({
       type: "rpc",
-      payload: '{"id:":1,"jsonrpc:"2.0","result":666}',
+      jsonRpcMessage: '{"id:":1,"jsonrpc:"2.0","result":666}',
     })
     await waitForMessageToBePosted()
 
@@ -168,14 +168,14 @@ describe("Connection and forward cases", () => {
     sendMessage({
       chainId: "test",
       type: "add-well-known-chain",
-      payload: "westend",
+      chainName: "westend",
       origin: "substrate-connect-client",
     })
     await waitForMessageToBePosted()
 
     const handler = jest.fn()
     window.addEventListener("message", handler)
-    port._sendAppMessage({ type: "error", payload: "Boom!" })
+    port._sendAppMessage({ type: "error", errorMessage: "Boom!" })
     await waitForMessageToBePosted()
 
     expect(handler).toHaveBeenCalled()

--- a/projects/extension/src/content/ExtensionMessageRouter.test.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.test.ts
@@ -124,7 +124,7 @@ describe("Connection and forward cases", () => {
     expect(router.connections.length).toBe(1)
     const sample = {
       type: rpcMessage.type,
-      payload: rpcMessage.jsonRpcMessage,
+      jsonRpcMessage: rpcMessage.jsonRpcMessage,
     }
     expect(port.postedMessages[port.postedMessages.length - 1]).toEqual(sample)
   })
@@ -157,7 +157,7 @@ describe("Connection and forward cases", () => {
       chainId: "test",
       origin: "substrate-connect-extension",
       type: "rpc",
-      payload: '{"id:":1,"jsonrpc:"2.0","result":666}',
+      jsonRpcMessage: '{"id:":1,"jsonrpc:"2.0","result":666}',
     })
   })
 
@@ -184,7 +184,7 @@ describe("Connection and forward cases", () => {
       origin: "substrate-connect-extension",
       chainId: "test",
       type: "error",
-      payload: "Boom!",
+      errorMessage: "Boom!",
     })
   })
 })

--- a/projects/extension/src/content/ExtensionMessageRouter.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.ts
@@ -58,7 +58,7 @@ export class ExtensionMessageRouter {
     port.onMessage.addListener((data): void => {
       debug(`RECEIVED MESSAGE FROM ${chainId} PORT`, data)
       sendMessage({
-        ... data,
+        ...data,
         chainId,
         origin: CONTENT_SCRIPT_ORIGIN,
       })

--- a/projects/extension/src/content/ExtensionMessageRouter.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.ts
@@ -56,11 +56,9 @@ export class ExtensionMessageRouter {
 
     // forward any messages: extension -> page
     port.onMessage.addListener((data): void => {
-      const { type, payload } = data
       debug(`RECEIVED MESSAGE FROM ${chainId} PORT`, data)
       sendMessage({
-        type,
-        jsonRpcMessage: payload,
+        ... data,
         chainId,
         origin: CONTENT_SCRIPT_ORIGIN,
       })

--- a/projects/extension/src/content/ExtensionMessageRouter.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.ts
@@ -60,7 +60,7 @@ export class ExtensionMessageRouter {
       debug(`RECEIVED MESSAGE FROM ${chainId} PORT`, data)
       sendMessage({
         type,
-        payload,
+        jsonRpcMessage: payload,
         chainId,
         origin: CONTENT_SCRIPT_ORIGIN,
       })
@@ -72,7 +72,7 @@ export class ExtensionMessageRouter {
         origin: "substrate-connect-extension",
         chainId,
         type: "error",
-        payload: "Lost communication with substrate-connect extension",
+        errorMessage: "Lost communication with substrate-connect extension",
       })
       delete this.#ports[chainId]
     })

--- a/projects/extension/src/content/ExtensionMessageRouter.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.ts
@@ -57,11 +57,15 @@ export class ExtensionMessageRouter {
     // forward any messages: extension -> page
     port.onMessage.addListener((data): void => {
       debug(`RECEIVED MESSAGE FROM ${chainId} PORT`, data)
-      sendMessage({
+      const msg = {
         ...data,
         chainId,
         origin: CONTENT_SCRIPT_ORIGIN,
-      })
+      }
+
+      // Because the construction of the message is hacky, we have no choice but to  cast
+      // to `unknown`. This is expected to be fixed in a later refactor.
+      sendMessage(msg as unknown as ToApplication)
     })
 
     // tell the page when the port disconnects


### PR DESCRIPTION
I don't really understand why we're using the name `payload` everywhere, while these payload represent different things depending on the message.
