### PR TITLE
Properly check type of received messages

### DIFF
--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -265,7 +265,7 @@ export class ConnectionManager extends (EventEmitter as {
   #handleMessage(msg: ToExtension, chainConnection: ChainConnection): void {
     if (msg.type === "remove-chain") return chainConnection.port.disconnect()
 
-    if (msg.type === "rpc" && msg.jsonRpcMessage) {
+    if (msg.type === "rpc") {
       if (chainConnection.chain)
         return chainConnection.healthChecker.sendJsonRpc(msg.jsonRpcMessage)
 
@@ -274,17 +274,6 @@ export class ConnectionManager extends (EventEmitter as {
       l.error(errorMsg)
       this.#handleError(chainConnection.port, new Error(errorMsg))
       return
-    }
-
-    if (
-      (msg.type === "add-chain" &&
-        (!msg.chainSpec || !msg.potentialRelayChainIds)) ||
-      (msg.type === "add-well-known-chain" && !msg.chainName) ||
-      (msg.type !== "add-chain" && msg.type !== "add-well-known-chain")
-    ) {
-      const errorMsg = `Unrecognized message '${msg}' received from content script`
-      l.error(errorMsg)
-      return this.#handleError(chainConnection.port, new Error(errorMsg))
     }
 
     const [chainSpec, potentialRelayChainIds]: [string, string[]] =

--- a/projects/extension/src/content/ExtensionMessageRouter.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.ts
@@ -6,6 +6,7 @@ import {
   ToApplication,
 } from "@substrate/connect-extension-protocol"
 import { debug } from "../utils/debug"
+import checkMessage from './checkMessage';
 
 const CONTENT_SCRIPT_ORIGIN = "substrate-connect-extension"
 const EXTENSION_PROVIDER_ORIGIN = "substrate-connect-client"
@@ -92,11 +93,7 @@ export class ExtensionMessageRouter {
 
     debug(`RECEIVED MESSAGE FROM ${EXTENSION_PROVIDER_ORIGIN}`, data)
 
-    if (
-      type !== "rpc" &&
-      type !== "add-chain" &&
-      type !== "add-well-known-chain"
-    ) {
+    if (!checkMessage(data)) {
       // probably someone abusing the extension
       console.warn("Malformed message - unrecognised message.type", data)
       return

--- a/projects/extension/src/content/checkMessage.test.ts
+++ b/projects/extension/src/content/checkMessage.test.ts
@@ -1,0 +1,68 @@
+import checkMessage from "./checkMessage"
+
+describe("checkMessage works", () => {
+  test("checkMessage properly works", () => {
+    expect(checkMessage({})).toBe(false);
+
+    expect(checkMessage({
+      origin: 'substrate-connect-client',
+      type: 'rpc',
+      chainId: 'hello',
+      jsonRpcMessage: 'hi'
+    })).toBe(true);
+
+    // extra fields aren't a problem
+    expect(checkMessage({
+      origin: 'substrate-connect-client',
+      type: 'rpc',
+      chainId: 'hello',
+      jsonRpcMessage: 'hi',
+      hiddenField: true,
+    })).toBe(true);
+
+    expect(checkMessage({
+      type: 'rpc',
+      chainId: 'hello',
+      jsonRpcMessage: 'hi'
+    })).toBe(false);
+
+    expect(checkMessage({
+      origin: 'substrate-connect-client',
+      type: 'add-chain',
+      chainId: 'hello',
+      chainSpec: 'foo',
+      potentialRelayChainIds: ['bar']
+    })).toBe(true);
+
+    expect(checkMessage({
+      origin: 'substrate-connect-client',
+      type: 'add-chain',
+      chainId: 'hello',
+      chainSpec: 'foo',
+      potentialRelayChainIds: [58]
+    })).toBe(false);
+
+    expect(checkMessage({
+      origin: 'substrate-connect-client',
+      type: 'add-chain',
+      chainId: 'hello',
+      chainSpec: 'foo',
+      potentialRelayChainIds: ['bar', 58]
+    })).toBe(false);
+
+    expect(checkMessage({
+      origin: 'substrate-connect-client',
+      type: 'add-chain',
+      chainId: 'hello',
+      chainSpec: 'foo',
+      potentialRelayChainIds: 5,
+    })).toBe(false);
+
+    expect(checkMessage({
+      origin: 'substrate-connect-client',
+      type: 'add-chain',
+      chainId: 'hello',
+      chainSpec: 'foo'
+    })).toBe(false);
+  })
+})

--- a/projects/extension/src/content/checkMessage.ts
+++ b/projects/extension/src/content/checkMessage.ts
@@ -1,0 +1,53 @@
+import { ToExtension } from "@substrate/connect-extension-protocol"
+
+/**
+ * Checks whether a message send on the window matches the `ToExtension` interface.
+ *
+ * Do not forget to update this function if the `ToExtension` interface changes!
+ */
+export default function checkReceivedMessage(message: any): message is ToExtension {
+  if (message.origin !== "substrate-connect-client")
+    return false;
+  if (typeof message.type !== 'string')
+    return false;
+
+  switch (message.type) {
+    case "add-chain": {
+      if (typeof message.chainId !== 'string')
+        return false;
+      if (typeof message.chainSpec !== 'string')
+        return false;
+      if (!Array.isArray(message.potentialRelayChainIds))
+        return false;
+      for (const index in message.potentialRelayChainIds) {
+        if (typeof message.potentialRelayChainIds[index] !== 'string')
+          return false;
+      }
+      break;
+    }
+
+    case "add-well-known-chain": {
+      if (typeof message.chainId !== 'string')
+        return false;
+      if (typeof message.chainName !== 'string')
+        return false;
+      break;
+    }
+
+    case "rpc": {
+      if (typeof message.chainId !== 'string')
+        return false;
+      if (typeof message.jsonRpcMessage !== 'string')
+        return false;
+      break;
+    }
+
+    case "remove-chain": {
+      if (typeof message.chainId !== 'string')
+        return false;
+      break;
+    }
+  }
+
+  return true;
+}


### PR DESCRIPTION
Adds a new `checkReceivedMessage` function in the content script of the extension that makes sure that messages actually conform to the `ToExtension` interface.

All functions received on the `window` must pass this check.

The messages received on the port between the content script and extension are assumed to always match the interface. Consequently I've removed the check in the `ConnectionManager`.

This might solve issues where a malicious or buggy web page sends invalid messages and generates exceptions in the extension.
