### PR TITLE
Remove `id` from ChainConnection

### DIFF
--- a/projects/extension/src/background/types.ts
+++ b/projects/extension/src/background/types.ts
@@ -11,7 +11,6 @@ export interface ExposedChainConnection {
 }
 
 export interface ChainConnection extends ExposedChainConnection {
-  id: string
   chain?: Chain
   port: chrome.runtime.Port
   healthChecker: HealthChecker


### PR DESCRIPTION
Replace the `id` field with a `[tabId, chainId]` tuple.

This removes this weird code where we do `${chainId}::${tabId}`.