### PR TITLE
Use only one port per tab

### DIFF
--- a/projects/extension/src/background/ConnectionManager.test.ts
+++ b/projects/extension/src/background/ConnectionManager.test.ts
@@ -33,7 +33,7 @@ const createHelper = () => {
       url = TEST_URL,
     ) => {
       const port = new MockPort(chainId, tabId)
-      manager.addChainConnection(port)
+      manager.addPort(port)
 
       let chain: MockedChain | null = null
       if (addChainMsg) {

--- a/projects/extension/src/background/ConnectionManager.test.ts
+++ b/projects/extension/src/background/ConnectionManager.test.ts
@@ -13,7 +13,6 @@ import {
   MockPort,
   MockSmoldotClient,
   TEST_URL,
-  HeaderlessToExtension,
 } from "../mocks"
 import { ToExtension } from "@substrate/connect-extension-protocol"
 
@@ -29,11 +28,11 @@ const createHelper = () => {
     connectPort: (
       chainId: string,
       tabId: number,
-      addChainMsg?: HeaderlessToExtension<ToExtension>,
+      addChainMsg?: ToExtension,
       url = TEST_URL,
     ) => {
       const port = new MockPort(chainId, tabId)
-      manager.addPort(port)
+      manager.addTab(port)
 
       let chain: MockedChain | null = null
       if (addChainMsg) {
@@ -77,6 +76,8 @@ describe("ConnectionManager", () => {
     expect(onStateChanged).not.toHaveBeenCalled()
 
     port._sendExtensionMessage({
+      origin: "substrate-connect-client",
+      chainId: "foo",
       type: "add-well-known-chain",
       chainName: "polkadot",
     })
@@ -126,6 +127,8 @@ describe("ConnectionManager", () => {
     expect(client.chains.size).toBe(0)
 
     port._sendExtensionMessage({
+      origin: "substrate-connect-client",
+      chainId: "foo",
       type: "add-well-known-chain",
       chainName: "polkadot",
     })
@@ -148,11 +151,15 @@ describe("ConnectionManager", () => {
     expect(client.chains.size).toBe(0)
 
     port._sendExtensionMessage({
+      origin: "substrate-connect-client",
+      chainId: "foo",
       type: "add-well-known-chain",
       chainName: "polkadot",
     })
 
     port._sendExtensionMessage({
+      origin: "substrate-connect-client",
+      chainId: "foo",
       type: "rpc",
       jsonRpcMessage: JSON.stringify({ jsonrpc: "2.0", id: "1" }),
     })
@@ -161,6 +168,8 @@ describe("ConnectionManager", () => {
 
     expect(port.postedMessages).toEqual([
       {
+        origin: "substrate-connect-extension",
+        chainId: "foo",
         type: "error",
         errorMessage:
           "RPC request received befor the chain was successfully added",
@@ -172,6 +181,8 @@ describe("ConnectionManager", () => {
     const { connectPort } = helper
 
     const { port, chain } = connectPort("chainId", 1, {
+      origin: "substrate-connect-client",
+      chainId: "foo",
       type: "add-well-known-chain",
       chainName: "polkadot",
     })
@@ -179,6 +190,8 @@ describe("ConnectionManager", () => {
     await wait(0)
 
     port._sendExtensionMessage({
+      origin: "substrate-connect-client",
+      chainId: "foo",
       type: "rpc",
       jsonRpcMessage: JSON.stringify({ jsonrpc: "2.0", id: "1" }),
     })
@@ -207,9 +220,13 @@ describe("ConnectionManager", () => {
 
     expect(port.postedMessages).toEqual([
       {
+        origin: "substrate-connect-extension",
+        chainId: "foo",
         type: "chain-ready",
       },
       {
+        origin: "substrate-connect-extension",
+        chainId: "foo",
         type: "rpc",
         jsonRpcMessage: JSON.stringify({
           jsonrpc: "2.0",
@@ -223,6 +240,8 @@ describe("ConnectionManager", () => {
   it("correctly errors when passed a wrong well-known-chain", async () => {
     const { connectPort } = helper
     const { port } = connectPort("chainId", 1, {
+      origin: "substrate-connect-client",
+      chainId: "foo",
       type: "add-well-known-chain",
       chainName: "nonexisting",
     })
@@ -231,6 +250,8 @@ describe("ConnectionManager", () => {
 
     expect(port.postedMessages).toEqual([
       {
+        origin: "substrate-connect-extension",
+        chainId: "foo",
         type: "error",
         errorMessage: "Relay chain spec was not found",
       },
@@ -243,6 +264,8 @@ describe("ConnectionManager", () => {
     manager.on("stateChanged", onStateChanged)
 
     const { chain, chainId, tabId, url } = connectPort("chainId", 1, {
+      origin: "substrate-connect-client",
+      chainId: "foo",
       type: "add-well-known-chain",
       chainName: "polkadot",
     })
@@ -293,6 +316,8 @@ describe("ConnectionManager", () => {
       .map((idx) => {
         const tabId = Math.floor(idx / 3)
         return connectPort(idx.toString(), tabId, {
+          origin: "substrate-connect-client",
+          chainId: "foo",
           type: "add-well-known-chain",
           chainName: "polkadot",
         })
@@ -337,6 +362,8 @@ describe("ConnectionManager", () => {
     const activeChains = allIds.map((idx) => {
       const tabId = Math.floor(idx / 3)
       const { chain } = connectPort(idx.toString(), tabId, {
+        origin: "substrate-connect-client",
+        chainId: "foo",
         type: "add-well-known-chain",
         chainName: "polkadot",
       })
@@ -348,6 +375,8 @@ describe("ConnectionManager", () => {
     // we will try to pass all the ids as potentialRelayChainIds, including
     // the ones that are not in our tab
     const { chain: newChain } = connectPort("lastOne", 0, {
+      origin: "substrate-connect-client",
+      chainId: "foo",
       type: "add-chain",
       chainSpec: JSON.stringify({ name: "parachain" }),
       potentialRelayChainIds: allIds.map((id) => id.toString()),
@@ -381,11 +410,15 @@ describe("ConnectionManager", () => {
     const chainId = "same"
 
     const { chain: tab1Chain, port: tab1Port } = connectPort(chainId, 1, {
+      origin: "substrate-connect-client",
+      chainId: "foo",
       type: "add-well-known-chain",
       chainName: "polkadot",
     })
 
     const { chain: tab2Chain, port: tab2Port } = connectPort(chainId, 2, {
+      origin: "substrate-connect-client",
+      chainId: "foo",
       type: "add-well-known-chain",
       chainName: "polkadot",
     })
@@ -398,11 +431,15 @@ describe("ConnectionManager", () => {
 
     // let's make sure that each chain receives *only* their own messages
     tab1Port._sendExtensionMessage({
+      origin: "substrate-connect-client",
+      chainId: "foo",
       type: "rpc",
       jsonRpcMessage: JSON.stringify({ jsonrpc: "2.0", id: "ping1" }),
     })
 
     tab2Port._sendExtensionMessage({
+      origin: "substrate-connect-client",
+      chainId: "foo",
       type: "rpc",
       jsonRpcMessage: JSON.stringify({ jsonrpc: "2.0", id: "ping2" }),
     })
@@ -439,9 +476,13 @@ describe("ConnectionManager", () => {
 
     expect(tab1Port.postedMessages).toEqual([
       {
+        origin: "substrate-connect-extension",
+        chainId: "foo",
         type: "chain-ready",
       },
       {
+        origin: "substrate-connect-extension",
+        chainId: "foo",
         type: "rpc",
         jsonRpcMessage: JSON.stringify({
           jsonrpc: "2.0",
@@ -452,9 +493,13 @@ describe("ConnectionManager", () => {
     ])
     expect(tab2Port.postedMessages).toEqual([
       {
+        origin: "substrate-connect-extension",
+        chainId: "foo",
         type: "chain-ready",
       },
       {
+        origin: "substrate-connect-extension",
+        chainId: "foo",
         type: "rpc",
         jsonRpcMessage: JSON.stringify({
           jsonrpc: "2.0",
@@ -469,6 +514,8 @@ describe("ConnectionManager", () => {
     const { connectPort, client } = helper
 
     const { port } = connectPort("chainId", 1, {
+      origin: "substrate-connect-client",
+      chainId: "foo",
       type: "add-well-known-chain",
       chainName: "polkadot",
     })
@@ -490,6 +537,8 @@ describe("ConnectionManager", () => {
     const { connectPort, client } = helper
 
     const { port } = connectPort("chainId", 1, {
+      origin: "substrate-connect-client",
+      chainId: "foo",
       type: "add-well-known-chain",
       chainName: "polkadot",
     })
@@ -499,11 +548,15 @@ describe("ConnectionManager", () => {
     expect(client.chains.size).toBe(1)
 
     port._sendExtensionMessage({
+      origin: "substrate-connect-client",
+      chainId: "foo",
       type: "remove-chain",
     })
 
     expect(port.postedMessages).toEqual([
       {
+        origin: "substrate-connect-extension",
+        chainId: "foo",
         type: "chain-ready",
       },
     ])

--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -89,11 +89,7 @@ export class ConnectionManager extends (EventEmitter as {
   disconnectTab(tabId: number): void {
     const tab = this.#tabs.get(tabId)
     if (!tab) return
-
-    tab.chainConnections.forEach((a) => {
-      tab.port.disconnect()
-    })
-    this.#tabs.delete(tabId)
+    tab.port.disconnect()
   }
 
   /**
@@ -120,8 +116,6 @@ export class ConnectionManager extends (EventEmitter as {
       port.onMessage.addListener(onMessageHandler)
 
       const onDisconnect = () => {
-        this.disconnectTab(tabId)
-
         port.onMessage.removeListener(onMessageHandler)
         port.onDisconnect.removeListener(onDisconnect)
 
@@ -226,6 +220,8 @@ export class ConnectionManager extends (EventEmitter as {
       const rpcResp = chainConnection.healthChecker.responsePassThrough(rpc)
       if (rpcResp)
         chainConnection.port.postMessage({
+          origin: "substrate-connect-extension",
+          chainId,
           type: "rpc",
           jsonRpcMessage: rpcResp,
         })
@@ -266,7 +262,11 @@ export class ConnectionManager extends (EventEmitter as {
     }
 
     chainConnection.chain = chain
-    chainConnection.port.postMessage({ type: "chain-ready", chainId })
+    chainConnection.port.postMessage({ 
+      origin: "substrate-connect-extension",
+      type: "chain-ready",
+      chainId
+    })
 
     // Initialize healthChecker
     chainConnection.healthChecker.setSendJsonRpc((rpc: string) => {

--- a/projects/extension/src/background/index.ts
+++ b/projects/extension/src/background/index.ts
@@ -98,7 +98,7 @@ chrome.runtime.onStartup.addListener(() => {
 })
 
 chrome.runtime.onConnect.addListener((port) => {
-  manager.addPort(port)
+  manager.addTab(port)
 })
 
 chrome.storage.local.get(["notifications"], (result) => {

--- a/projects/extension/src/background/index.ts
+++ b/projects/extension/src/background/index.ts
@@ -98,7 +98,7 @@ chrome.runtime.onStartup.addListener(() => {
 })
 
 chrome.runtime.onConnect.addListener((port) => {
-  manager.addChainConnection(port)
+  manager.addPort(port)
 })
 
 chrome.storage.local.get(["notifications"], (result) => {

--- a/projects/extension/src/background/types.ts
+++ b/projects/extension/src/background/types.ts
@@ -11,7 +11,6 @@ export interface ExposedChainConnection {
 }
 
 export interface ChainConnection extends ExposedChainConnection {
-  id: string
   chain?: Chain
   port: chrome.runtime.Port
   healthChecker: HealthChecker

--- a/projects/extension/src/content/ExtensionMessageRouter.test.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.test.ts
@@ -144,6 +144,8 @@ describe("Connection and forward cases", () => {
     const handler = jest.fn()
     window.addEventListener("message", handler)
     port._sendAppMessage({
+      origin: "substrate-connect-extension",
+      chainId: "foo",
       type: "rpc",
       jsonRpcMessage: '{"id:":1,"jsonrpc:"2.0","result":666}',
     })
@@ -175,7 +177,12 @@ describe("Connection and forward cases", () => {
 
     const handler = jest.fn()
     window.addEventListener("message", handler)
-    port._sendAppMessage({ type: "error", errorMessage: "Boom!" })
+    port._sendAppMessage({ 
+      origin: "substrate-connect-extension",
+      chainId: "foo",
+      type: "error",
+      errorMessage: "Boom!"
+    })
     await waitForMessageToBePosted()
 
     expect(handler).toHaveBeenCalled()

--- a/projects/extension/src/content/ExtensionMessageRouter.ts
+++ b/projects/extension/src/content/ExtensionMessageRouter.ts
@@ -8,7 +8,6 @@ import {
 import { debug } from "../utils/debug"
 import checkMessage from "./checkMessage"
 
-const CONTENT_SCRIPT_ORIGIN = "substrate-connect-extension"
 const EXTENSION_PROVIDER_ORIGIN = "substrate-connect-client"
 
 const sendMessage = (msg: ToApplication): void => {
@@ -17,9 +16,8 @@ const sendMessage = (msg: ToApplication): void => {
 
 /* ExtensionMessageRouter is the part of the content script that listens for
  * messages that the ExtensionProvider in an app sends using `window.postMessage`.
- * It establishes connections to the extension background on behalf of the app,
- * forwards RPC requests for the app to the extension background and disconnects
- * the port when the app requests it.
+ * It establishes a connection to the extension background on behalf of the app,
+ * and forwards RPC requests for the app to the extension background.
  *
  * Conversely it listens for messages sent through the port from the extension
  * background and forwards them to the app via `window.postMessage`
@@ -28,7 +26,33 @@ const sendMessage = (msg: ToApplication): void => {
  * to establish the connection with the background itself.
  */
 export class ExtensionMessageRouter {
-  #ports: Record<string, chrome.runtime.Port> = {}
+  #port: chrome.runtime.Port = chrome.runtime.connect()
+  #chainIds: Set<string> = new Set()
+
+  constructor() {
+    // forward any messages: extension -> page
+    this.#port.onMessage.addListener((data: ToApplication): void => {
+      if (data.type == "error")
+        this.#chainIds.delete(data.chainId);
+
+      sendMessage(data)
+    })
+
+    // tell the page when the port disconnects
+    this.#port.onDisconnect.addListener(() => {
+      this.#chainIds.forEach((chainId) => {
+        sendMessage({
+          origin: "substrate-connect-extension",
+          chainId,
+          type: "error",
+          errorMessage: "Lost communication with substrate-connect extension",
+        })
+      });
+
+      this.#chainIds.clear();
+    })
+
+  }
 
   /**
    * connections returns the names of all the ports this `ExtensionMessageRouter`
@@ -37,7 +61,7 @@ export class ExtensionMessageRouter {
    * @returns A list of strings
    */
   get connections(): string[] {
-    return Object.keys(this.#ports)
+    return Object.keys(this.#chainIds)
   }
 
   /** listen starts listening for messages sent by an app.  */
@@ -50,44 +74,9 @@ export class ExtensionMessageRouter {
     window.removeEventListener("message", this.#handleMessage)
   }
 
-  #establishNewConnection = (chainId: string): void => {
-    const port = chrome.runtime.connect({ name: chainId })
-
-    debug(`CONNECTED ${chainId} PORT`, port)
-
-    // forward any messages: extension -> page
-    port.onMessage.addListener((data): void => {
-      debug(`RECEIVED MESSAGE FROM ${chainId} PORT`, data)
-      const msg = {
-        ...data,
-        chainId,
-        origin: CONTENT_SCRIPT_ORIGIN,
-      }
-
-      // Because the construction of the message is hacky, we have no choice but to  cast
-      // to `unknown`. This is expected to be fixed in a later refactor.
-      sendMessage(msg as unknown as ToApplication)
-    })
-
-    // tell the page when the port disconnects
-    port.onDisconnect.addListener(() => {
-      sendMessage({
-        origin: "substrate-connect-extension",
-        chainId,
-        type: "error",
-        errorMessage: "Lost communication with substrate-connect extension",
-      })
-      delete this.#ports[chainId]
-    })
-
-    this.#ports[chainId] = port
-    debug(`CONNECTED TO ${chainId} PORT`)
-  }
-
-  #handleMessage = (msg: MessageEvent<ToExtension>): void => {
+  #handleMessage = (msg: MessageEvent): void => {
     const data = msg.data
-    const { origin, type } = data
-    if (!origin || origin !== EXTENSION_PROVIDER_ORIGIN) {
+    if (!data.origin || data.origin !== EXTENSION_PROVIDER_ORIGIN) {
       return
     }
 
@@ -99,22 +88,13 @@ export class ExtensionMessageRouter {
       return
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { chainId, origin: _, ...forwardMsg } = data
-    if (type === "add-well-known-chain" || type === "add-chain") {
-      this.#establishNewConnection(chainId)
+    if (data.type === "add-well-known-chain" || data.type === "add-chain") {
+      this.#chainIds.add(data.chainId)
     }
 
-    const port = this.#ports[chainId]
-    if (!port) {
-      // this is probably someone trying to abuse the extension.
-      console.warn(
-        `App requested to send message to ${chainId} - no port found`,
-      )
-      return
-    }
+    if (data.type === "remove-chain")
+      this.#chainIds.delete(data.chainId)
 
-    debug(`SENDING RPC MESSAGE TO ${chainId} PORT`, msg)
-    port.postMessage(forwardMsg)
+    this.#port.postMessage(data)
   }
 }

--- a/projects/extension/src/mocks.ts
+++ b/projects/extension/src/mocks.ts
@@ -14,22 +14,10 @@ const noop: any = Function.prototype
 
 export const TEST_URL = "https://test.com"
 
-export type HeaderlessToExtension<T extends ToExtension> = T extends {
-  origin: "substrate-connect-client"
-} & infer V
-  ? Omit<V, "chainId">
-  : unknown
-
-export type HeaderlessToApplication<T extends ToApplication> = T extends {
-  origin: "substrate-connect-extension"
-} & infer V
-  ? Omit<V, "chainId">
-  : unknown
-
 export class MockPort implements chrome.runtime.Port {
   sender: any
   connected = true
-  postedMessages: Array<any> = []
+  postedMessages: Array<ToApplication> = []
   readonly name: string
   #callbacks = {
     onDisconnect: noop,
@@ -54,15 +42,11 @@ export class MockPort implements chrome.runtime.Port {
     this.sender.tab.id = id
   }
 
-  _sendExtensionMessage(message: HeaderlessToExtension<ToExtension>): void {
-    this.#callbacks.onMessageCb({
-      ...message,
-      chainId: this.name,
-      origin: "substrate-connect-client",
-    })
+  _sendExtensionMessage(message: ToExtension): void {
+    this.#callbacks.onMessageCb(message)
   }
 
-  _sendAppMessage(msg: HeaderlessToApplication<ToApplication>): void {
+  _sendAppMessage(msg: ToApplication): void {
     this.#callbacks.onMessageCb(msg)
   }
 


### PR DESCRIPTION
I haven't finished the PR yet, as I haven't tested whether it works and haven't updated the tests.

What this changes is that instead of opening one port between the content script and extension for each chain, we open one only port for the entire tab.

The `ExtensionMessageRouter` only has one port and is generally considerably more simple.

The `ConnectionManager` no longer has a `Map<string, ChainConnection>`, but instead has a `Map<number, Tab>` where `Tab` contains a `Map<string, ChainConnection>`.

This bring benefits when it comes to typing, and will make it possible to continue simplifying the rest of the `ConnectionManager` afterwards.
