### PR TITLE
fix: healthChecker bug

### DIFF
--- a/packages/connect/src/createScClient/ScProvider/Health.ts
+++ b/packages/connect/src/createScClient/ScProvider/Health.ts
@@ -185,7 +185,7 @@ class InnerChecker {
       // actually possible for the health to have changed in between as the
       // current best block might have been updated during the subscription
       // request.
-      this.startHealthCheck()
+      if (!this.#currentHealthCheckId) this.startHealthCheck()
       this.update()
       return null
     }


### PR DESCRIPTION
It happens quite frequently that starting the health check when receiving an update on the "current subscription" it throws an error because there is already an ongoing request for the "health check", so I suppose that the intention was to only start a new "health check" if there isn't an ongoing one, already.