### PR TITLE
Revert change to health checker made during transfer

### DIFF
--- a/packages/connect/src/createScClient/ScProvider/Health.ts
+++ b/packages/connect/src/createScClient/ScProvider/Health.ts
@@ -110,9 +110,9 @@ class InnerChecker {
 
   sendJsonRpc = (request: string): void => {
     // Replace the `id` in the request to prefix the request ID with `extern:`.
-    let parsedRequest;
+    let parsedRequest
     try {
-      parsedRequest = JSON.parse(request);
+      parsedRequest = JSON.parse(request)
     } catch (err) {
       return
     }

--- a/packages/connect/src/createScClient/ScProvider/Health.ts
+++ b/packages/connect/src/createScClient/ScProvider/Health.ts
@@ -110,17 +110,19 @@ class InnerChecker {
 
   sendJsonRpc = (request: string): void => {
     // Replace the `id` in the request to prefix the request ID with `extern:`.
+    let parsedRequest;
     try {
-      const parsedRequest = JSON.parse(request)
-      if (parsedRequest.id) {
-        const newId = "extern:" + JSON.stringify(parsedRequest.id)
-        parsedRequest.id = newId
-      }
-
-      this.#requestToSmoldot(JSON.stringify(parsedRequest))
+      parsedRequest = JSON.parse(request);
     } catch (err) {
       return
     }
+
+    if (parsedRequest.id) {
+      const newId = "extern:" + JSON.stringify(parsedRequest.id)
+      parsedRequest.id = newId
+    }
+
+    this.#requestToSmoldot(JSON.stringify(parsedRequest))
   }
 
   responsePassThrough = (jsonRpcResponse: string): string | null => {


### PR DESCRIPTION
This was modified in https://github.com/paritytech/substrate-connect/pull/737 for no good reason.

The only thing we want to catch is errors in `JSON.parse`. Nothing else. If `requestToSmoldot` throws, we must **not** catch the exception.
