### PR TITLE
improve `healthChecker` API

### DIFF
--- a/packages/connect/src/createPolkadotJsScClient/createPolkadotJsScClient.ts
+++ b/packages/connect/src/createPolkadotJsScClient/createPolkadotJsScClient.ts
@@ -11,7 +11,7 @@ import type { Chain, JsonRpcCallback } from "../connector/types.js"
 
 import { WellKnownChain } from "../WellKnownChain.js"
 import { createScClient } from "../connector/index.js"
-import { healthChecker } from "./Health.js"
+import { GetHealthChain, healthChecker, HealthHandler } from "../Health.js"
 
 export interface PolkadotJsScClient {
   addWellKnownChain: (
@@ -24,7 +24,7 @@ type ResponseCallback = (response: string | Error) => void
 
 class Provider implements ProviderInterface {
   readonly #coder: RpcCoder = new RpcCoder()
-  readonly #getChain: (handler: JsonRpcCallback) => Promise<Chain>
+  readonly #getChain: GetHealthChain<Chain>
   readonly #subscriptions: Map<
     string,
     [ResponseCallback, { method: string; id: string | number }]
@@ -35,7 +35,7 @@ class Provider implements ProviderInterface {
   #isChainReady: boolean = false
 
   public constructor(getChain: (handler: JsonRpcCallback) => Promise<Chain>) {
-    this.#getChain = getChain
+    this.#getChain = healthChecker(getChain)
   }
 
   public get hasSubscriptions(): boolean {
@@ -51,6 +51,15 @@ class Provider implements ProviderInterface {
     throw new Error("clone() is not supported.")
   }
 
+  #cleanup() {
+    // If there are any callbacks left, we have to reject/error them.
+    // Otherwise, that would cause a memory leak.
+    const disconnectionError = new Error("Disconnected")
+    this.#requests.forEach((cb) => cb(disconnectionError))
+    this.#subscriptions.forEach(([cb]) => cb(disconnectionError))
+    this.#subscriptions.clear()
+  }
+
   async connect(): Promise<void> {
     if (this.isConnected) throw new Error("Already connected!")
 
@@ -63,12 +72,8 @@ class Provider implements ProviderInterface {
       return
     }
 
-    const hc = healthChecker()
     const onResponse = (res: string): void => {
-      let hcRes = hc.responsePassThrough(res)
-      if (!hcRes) return
-
-      const response = JSON.parse(hcRes) as JsonRpcResponse
+      const response = JSON.parse(res) as JsonRpcResponse
       let decodedResponse: string | Error
       try {
         decodedResponse = this.#coder.decodeResponse(response) as string
@@ -88,76 +93,55 @@ class Provider implements ProviderInterface {
       callback?.(decodedResponse)
     }
 
-    this.#chain = this.#getChain(onResponse).then((chain) => {
-      hc.setSendJsonRpc(chain.sendJsonRpc)
+    let staleSubscriptions: { method: string; id: number | string }[] = []
+    const killStaleSubscriptions = () => {
+      if (staleSubscriptions.length === 0) return
 
-      this.#isChainReady = false
-      const cleanup = () => {
-        // If there are any callbacks left, we have to reject/error them.
-        // Otherwise, that would cause a memory leak.
-        const disconnectionError = new Error("Disconnected")
-        this.#requests.forEach((cb) => cb(disconnectionError))
-        this.#subscriptions.forEach(([cb]) => cb(disconnectionError))
-        this.#subscriptions.clear()
+      const { method, id } = staleSubscriptions.pop()!
+      Promise.race([
+        this.send(method, [id]).catch(() => {}),
+        new Promise((res) => setTimeout(res, 500)),
+      ]).then(killStaleSubscriptions)
+    }
+
+    const onHealthUpdate: HealthHandler = (health) => {
+      const isReady =
+        !health.isSyncing && (health.peers > 0 || !health.shouldHavePeers)
+
+      // if it's the same as before, then nothing has changed and we are done
+      if (this.#isChainReady === isReady) return
+
+      this.#isChainReady = isReady
+      if (!isReady) {
+        // If we've reached this point, that means that the chain used to be "ready"
+        // and now we are about to emit `disconnected`.
+        //
+        // This will cause the PolkadotJs API think that the connection is
+        // actually dead. In reality the smoldot chain is not dead, of course.
+        // However, we have to cleanup all the existing callbacks because when
+        // the smoldot chain stops syncing, then we will emit `connected` and
+        // the PolkadotJs API will try to re-create the previous
+        // subscriptions and requests. Although, now is not a good moment
+        // to be sending unsubscription messages to the smoldot chain, we
+        // should wait until is no longer syncing to send the unsubscription
+        // messages from the stale subscriptions of the previous connection.
+        //
+        // That's why -before we perform the cleanup of `this.#subscriptions`-
+        // we keep the necessary information that we will need later on to
+        // kill the stale subscriptions.
+        ;[...this.#subscriptions.values()].forEach((s) => {
+          staleSubscriptions.push(s[1])
+        })
+        this.#cleanup()
+      } else {
+        killStaleSubscriptions()
       }
 
-      let staleSubscriptions: { method: string; id: number | string }[] = []
-      const killStaleSubscriptions = () => {
-        if (staleSubscriptions.length === 0) return
+      this.#eventemitter.emit(isReady ? "connected" : "disconnected")
+    }
 
-        const { method, id } = staleSubscriptions.pop()!
-        Promise.race([
-          this.send(method, [id]).catch(() => {}),
-          new Promise((res) => setTimeout(res, 500)),
-        ]).then(killStaleSubscriptions)
-      }
-
-      hc.start((health) => {
-        const isReady =
-          !health.isSyncing && (health.peers > 0 || !health.shouldHavePeers)
-
-        // if it's the same as before, then nothing has changed and we are done
-        if (this.#isChainReady === isReady) return
-
-        this.#isChainReady = isReady
-        if (!isReady) {
-          // If we've reached this point, that means that the chain used to be "ready"
-          // and now we are about to emit `disconnected`.
-          //
-          // This will cause the PolkadotJs API think that the connection is
-          // actually dead. In reality the smoldot chain is not dead, of course.
-          // However, we have to cleanup all the existing callbacks because when
-          // the smoldot chain stops syncing, then we will emit `connected` and
-          // the PolkadotJs API will try to re-create the previous
-          // subscriptions and requests. Although, now is not a good moment
-          // to be sending unsubscription messages to the smoldot chain, we
-          // should wait until is no longer syncing to send the unsubscription
-          // messages from the stale subscriptions of the previous connection.
-          //
-          // That's why -before we perform the cleanup of `this.#subscriptions`-
-          // we keep the necessary information that we will need later on to
-          // kill the stale subscriptions.
-          ;[...this.#subscriptions.values()].forEach((s) => {
-            staleSubscriptions.push(s[1])
-          })
-          cleanup()
-        } else {
-          killStaleSubscriptions()
-        }
-
-        this.#eventemitter.emit(isReady ? "connected" : "disconnected")
-      })
-
-      return {
-        ...chain,
-        sendJsonRpc: hc.sendJsonRpc.bind(hc),
-        remove: () => {
-          hc.stop()
-          cleanup()
-          chain.remove()
-        },
-      }
-    })
+    this.#isChainReady = false
+    this.#chain = this.#getChain(onResponse, onHealthUpdate)
 
     try {
       await this.#chain
@@ -173,7 +157,7 @@ class Provider implements ProviderInterface {
 
     const chain = await this.#chain
     this.#chain = null
-    this.#isChainReady = false
+    this.#cleanup()
     try {
       chain.remove()
     } catch (_) {}
@@ -212,6 +196,7 @@ class Provider implements ProviderInterface {
         chain.sendJsonRpc(json)
       } catch (e) {
         this.#chain = null
+        this.#cleanup()
         try {
           chain.remove()
         } catch (_) {}

--- a/packages/connect/src/createPolkadotJsScClient/index.ts
+++ b/packages/connect/src/createPolkadotJsScClient/index.ts
@@ -1,2 +1,1 @@
 export * from "./createPolkadotJsScClient.js"
-export * from "./Health.js"

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -98,4 +98,5 @@
 
 export { WellKnownChain } from "./WellKnownChain.js"
 export * from "./connector/index.js"
+export * from "./Health.js"
 export * from "./createPolkadotJsScClient/index.js"


### PR DESCRIPTION
As I was creating the PR I realized that once we move the polkadotJs stuff into their repo, then the `healthChecker` will actually become part of the public API of `@substrate/connect`.

Sure, it currently already is part of the public API. However, in practice it isn't, as it's something that's not documented and it was there just as a workaround so that we can use it from extension. Meaning that it was never intended for actual consumers of `@substrate/connect` to use it. However, once we move the `createPolkadotJsScClient` to polkadot, then that will no longer be the case.

I think that the API of the `healthChecker` is quite leaky and convoluted, which in all fairness that was not a big deal until now. However, if we have to make the `healthChecker` part of the public API of `@substrate/connect`, then I think that we should expose a better and more simplified API. There are 2 reasons for doing that:

1) It would make its usage a lot simpler
2) It would enable further improvements on the `healthChecker` (as we won't be leaking so many details about its internals)

The API that IMO would be best for this is: 

```ts
export type HealthHandler = (healthUpdate: SmoldotHealth) => void         
export type GetHealthChain<                                               
  T extends {                                                             
    sendJsonRpc: (jsonRpc: string) => void                                
    remove: () => void                                                    
  },                                                                      
> = (handler: JsonRpcCallback, healthHandler: HealthHandler) => Promise<T>
                                                                          
export type GetChain<                                                     
  T extends {                                                             
    sendJsonRpc: (jsonRpc: string) => void                                
    remove: () => void                                                    
  },                                                                      
> = (handler: JsonRpcCallback) => Promise<T>                              
                                                                          
export type HealthChecker = <                                             
  T extends {                                                             
    sendJsonRpc: (jsonRpc: string) => void                                
    remove: () => void                                                    
  },                                                                      
>(                                                                        
  getChain: GetChain<T>,                                                  
) => GetHealthChain<T>                                                    
```

This PR "wraps" the current `healthChecker` implementation so that it exposes this new API, and it also leverages the new `healthChecker` from both the `extension` and from `createPolkadotJsScClient`.

It goes without saying that taken into account this new API: it would be possible to further simplify the implementation of the `healthChecker`, but that's out of scope for this PR as my understanding is that @tomaka wants to eventually rewrite the `healthChecker` in the future.