### PR TITLE
fix: stale unsubscriptions

### DIFF
--- a/packages/connect/src/createPolkadotJsScClient/createPolkadotJsScClient.test.ts
+++ b/packages/connect/src/createPolkadotJsScClient/createPolkadotJsScClient.test.ts
@@ -401,7 +401,12 @@ describe("Provider", () => {
       }, 0)
 
       const cb = jest.fn()
-      const token = await provider.subscribe("foo", "bar", ["baz"], cb)
+      const token = await provider.subscribe(
+        "foo",
+        "chain_subscribeNewHeads",
+        ["baz"],
+        cb,
+      )
 
       expect(token).toBe(unsubscribeToken)
       expect(cb).not.toHaveBeenCalled()
@@ -428,7 +433,7 @@ describe("Provider", () => {
       expect(cb).toHaveBeenCalledTimes(2)
       expect(cb).toHaveBeenLastCalledWith(null, 2)
 
-      provider.unsubscribe("foo", "bar", unsubscribeToken)
+      provider.unsubscribe("foo", "chain_unsubscribeNewHeads", unsubscribeToken)
 
       chain._triggerCallback({
         jsonrpc: "2.0",
@@ -466,7 +471,12 @@ describe("Provider", () => {
       }, 0)
 
       const cb = jest.fn()
-      const token = await provider.subscribe("foo", "bar", ["baz"], cb)
+      const token = await provider.subscribe(
+        "foo",
+        "chain_subscribeNewHeads",
+        ["baz"],
+        cb,
+      )
 
       expect(token).toBe(unsubscribeToken)
       expect(cb).not.toHaveBeenCalled()
@@ -489,7 +499,12 @@ describe("Provider", () => {
       }, 0)
 
       const cb = jest.fn()
-      const token = await provider.subscribe("foo", "bar", ["baz"], cb)
+      const token = await provider.subscribe(
+        "foo",
+        "chain_subscribeNewHeads",
+        ["baz"],
+        cb,
+      )
 
       chain._triggerCallback({
         jsonrpc: "2.0",
@@ -504,6 +519,17 @@ describe("Provider", () => {
       expect(cb).toHaveBeenCalledTimes(1)
       expect(cb.mock.lastCall![0]).toBeInstanceOf(Error)
       expect(cb.mock.lastCall![1]).toBe(undefined)
+    })
+
+    it("errors when subscribing to an unsupported method", async () => {
+      const client = createPolkadotJsScClient()
+      const provider = await client.addChain("")
+      setChainSyncyingStatus(false)
+      await wait(0)
+
+      await expect(
+        provider.subscribe("foo", "bar", ["baz"], () => {}),
+      ).rejects.toThrowError("Unsupported subscribe method: bar")
     })
   })
 
@@ -530,7 +556,6 @@ describe("Provider", () => {
 
     // while connected we create a subscription
     const unsubscribeToken = "unsubscribeToken"
-    const method = "testMethod"
     setTimeout(() => {
       chain._triggerCallback({
         jsonrpc: "2.0",
@@ -540,7 +565,12 @@ describe("Provider", () => {
     }, 0)
 
     const cb = jest.fn()
-    const token = await provider.subscribe("foo", method, ["baz"], cb)
+    const token = await provider.subscribe(
+      "foo",
+      "chain_subscribeNewHeads",
+      ["baz"],
+      cb,
+    )
 
     // setting the syncing status of the chain to fals so that the Provider
     // gets `disconnected`
@@ -556,7 +586,7 @@ describe("Provider", () => {
     // from the stale subscription, since that request should happen once the
     // chain is no longer syncing
     expect(chain._recevedRequests()).toEqual([
-      '{"id":1,"jsonrpc":"2.0","method":"testMethod","params":["baz"]}',
+      '{"id":1,"jsonrpc":"2.0","method":"chain_subscribeNewHeads","params":["baz"]}',
     ])
 
     // lets change the sync status back to false
@@ -568,8 +598,8 @@ describe("Provider", () => {
     // let's make sure that we have now sent the request for killing the
     // stale subscription
     expect(chain._recevedRequests()).toEqual([
-      '{"id":1,"jsonrpc":"2.0","method":"testMethod","params":["baz"]}',
-      `{"id":2,"jsonrpc":"2.0","method":"${method}","params":["${token}"]}`,
+      '{"id":1,"jsonrpc":"2.0","method":"chain_subscribeNewHeads","params":["baz"]}',
+      `{"id":2,"jsonrpc":"2.0","method":"chain_unsubscribeNewHeads","params":["${token}"]}`,
     ])
   })
 })

--- a/packages/connect/src/createPolkadotJsScClient/createPolkadotJsScClient.ts
+++ b/packages/connect/src/createPolkadotJsScClient/createPolkadotJsScClient.ts
@@ -22,12 +22,22 @@ export interface PolkadotJsScClient {
 
 type ResponseCallback = (response: string | Error) => void
 
+const subscriptionUnsubscritionMethods = new Map<string, string>([
+  ["author_submitAndWatchExtrinsic", "author_unwatchExtrinsic"],
+  ["chain_subscribeAllHeads", "chain_unsubscribeAllHeads"],
+  ["chain_subscribeFinalizedHeads", "chain_unsubscribeFinalizedHeads"],
+  ["chain_subscribeNewHeads", "chain_unsubscribeNewHeads"],
+  ["state_subscribeRuntimeVersion", "state_unsubscribeRuntimeVersion"],
+  ["state_subscribeStorage", "state_unsubscribeStorage"],
+  ["transaction_unstable_submitAndWatch", "transaction_unstable_unwatch"],
+])
+
 class Provider implements ProviderInterface {
   readonly #coder: RpcCoder = new RpcCoder()
   readonly #getChain: (handler: JsonRpcCallback) => Promise<Chain>
   readonly #subscriptions: Map<
     string,
-    [ResponseCallback, { method: string; id: string | number }]
+    [ResponseCallback, { unsubscribeMethod: string; id: string | number }]
   > = new Map()
   readonly #requests: Map<number, ResponseCallback> = new Map()
   readonly #eventemitter: EventEmitter = new EventEmitter()
@@ -101,13 +111,16 @@ class Provider implements ProviderInterface {
         this.#subscriptions.clear()
       }
 
-      let staleSubscriptions: { method: string; id: number | string }[] = []
+      let staleSubscriptions: {
+        unsubscribeMethod: string
+        id: number | string
+      }[] = []
       const killStaleSubscriptions = () => {
         if (staleSubscriptions.length === 0) return
 
-        const { method, id } = staleSubscriptions.pop()!
+        const { unsubscribeMethod, id } = staleSubscriptions.pop()!
         Promise.race([
-          this.send(method, [id]).catch(() => {}),
+          this.send(unsubscribeMethod, [id]).catch(() => {}),
           new Promise((res) => setTimeout(res, 500)),
         ]).then(killStaleSubscriptions)
       }
@@ -231,14 +244,14 @@ class Provider implements ProviderInterface {
   }
 
   public async subscribe(
-    // the "method" property of the JSON response to this subscription
     type: string,
-    // the "method" property of the JSON request to register the subscription
     method: string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     params: any[],
     callback: ProviderInterfaceCallback,
   ): Promise<number | string> {
+    if (!subscriptionUnsubscritionMethods.has(method))
+      throw new Error(`Unsupported subscribe method: ${method}`)
+
     const id = await this.send(method, params)
     const subscriptionId = `${type}::${id}`
     const cb = (response: Error | string) => {
@@ -249,7 +262,8 @@ class Provider implements ProviderInterface {
       }
     }
 
-    this.#subscriptions.set(subscriptionId, [cb, { method, id }])
+    const unsubscribeMethod = subscriptionUnsubscritionMethods.get(method)!
+    this.#subscriptions.set(subscriptionId, [cb, { unsubscribeMethod, id }])
     return id
   }
 

--- a/packages/connect/src/createPolkadotJsScClient/createPolkadotJsScClient.ts
+++ b/packages/connect/src/createPolkadotJsScClient/createPolkadotJsScClient.ts
@@ -26,7 +26,7 @@ type ResponseCallback = (response: string | Error) => void
 // https://github.com/paritytech/smoldot/blob/17425040ddda47d539556eeaf62b88c4240d1d42/src/json_rpc/methods.rs#L338-L462
 // It's important to take into account that smoldot is adding support to the new
 // json-rpc-interface https://paritytech.github.io/json-rpc-interface-spec/
-// However, these list should only include methods that belong to the "old" API
+// However, at the moment this list only includes methods that belong to the "old" API
 const subscriptionUnsubscriptionMethods = new Map<string, string>([
   ["author_submitAndWatchExtrinsic", "author_unwatchExtrinsic"],
   ["chain_subscribeAllHeads", "chain_unsubscribeAllHeads"],

--- a/packages/connect/src/createPolkadotJsScClient/createPolkadotJsScClient.ts
+++ b/packages/connect/src/createPolkadotJsScClient/createPolkadotJsScClient.ts
@@ -22,14 +22,18 @@ export interface PolkadotJsScClient {
 
 type ResponseCallback = (response: string | Error) => void
 
-const subscriptionUnsubscritionMethods = new Map<string, string>([
+// These methods have been taken from:
+// https://github.com/paritytech/smoldot/blob/17425040ddda47d539556eeaf62b88c4240d1d42/src/json_rpc/methods.rs#L338-L462
+// It's important to take into account that smoldot is adding support to the new
+// json-rpc-interface https://paritytech.github.io/json-rpc-interface-spec/
+// However, these list should only include methods that belong to the "old" API
+const subscriptionUnsubscriptionMethods = new Map<string, string>([
   ["author_submitAndWatchExtrinsic", "author_unwatchExtrinsic"],
   ["chain_subscribeAllHeads", "chain_unsubscribeAllHeads"],
   ["chain_subscribeFinalizedHeads", "chain_unsubscribeFinalizedHeads"],
   ["chain_subscribeNewHeads", "chain_unsubscribeNewHeads"],
   ["state_subscribeRuntimeVersion", "state_unsubscribeRuntimeVersion"],
   ["state_subscribeStorage", "state_unsubscribeStorage"],
-  ["transaction_unstable_submitAndWatch", "transaction_unstable_unwatch"],
 ])
 
 class Provider implements ProviderInterface {
@@ -249,7 +253,7 @@ class Provider implements ProviderInterface {
     params: any[],
     callback: ProviderInterfaceCallback,
   ): Promise<number | string> {
-    if (!subscriptionUnsubscritionMethods.has(method))
+    if (!subscriptionUnsubscriptionMethods.has(method))
       throw new Error(`Unsupported subscribe method: ${method}`)
 
     const id = await this.send(method, params)
@@ -262,7 +266,7 @@ class Provider implements ProviderInterface {
       }
     }
 
-    const unsubscribeMethod = subscriptionUnsubscritionMethods.get(method)!
+    const unsubscribeMethod = subscriptionUnsubscriptionMethods.get(method)!
     this.#subscriptions.set(subscriptionId, [cb, { unsubscribeMethod, id }])
     return id
   }


### PR DESCRIPTION
I made a mistake when I tried to tackle the issue with stale subscriptions that remain on the smoldot chain after the chain has changed its status to "syncing". This PR addresses the issue. The list of supported subscription methods was taken from [here](https://github.com/paritytech/smoldot/blob/17425040ddda47d539556eeaf62b88c4240d1d42/src/json_rpc/methods.rs#L338-L462). While reviewing, please ensure that I didn't miss any methods :pray:.