### PR TITLE
Don't use the `SmoldotHealth` interface from health checker

### DIFF
--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -6,7 +6,6 @@ import {
 import {
   healthChecker as smHealthChecker,
   HealthChecker as SmoldotHealthChecker,
-  SmoldotHealth,
 } from "@substrate/connect"
 
 import {

--- a/projects/extension/src/background/index.ts
+++ b/projects/extension/src/background/index.ts
@@ -42,7 +42,8 @@ const notifyListener = (
           chainName: info.chainName,
           tabId: info.apiInfo!.sandboxId.sender!.tab!.id!,
           url: info.apiInfo!.sandboxId.sender!.tab!.url!,
-          healthStatus: info.healthStatus,
+          isSyncing: info.isSyncing,
+          peers: info.peers,
         }
       }),
   )

--- a/projects/extension/src/background/types.ts
+++ b/projects/extension/src/background/types.ts
@@ -1,9 +1,8 @@
-import { SmoldotHealth } from "@substrate/connect"
-
 export interface ExposedChainConnection {
   chainId: string
   chainName: string
   tabId: number
   url: string
-  healthStatus?: SmoldotHealth
+  isSyncing: boolean
+  peers: number
 }

--- a/projects/extension/src/components/NetworkTab.tsx
+++ b/projects/extension/src/components/NetworkTab.tsx
@@ -100,9 +100,6 @@ interface NetworkContentProps {
 }
 
 const NetworkContent = ({ network, health, apps }: NetworkContentProps) => {
-  const peers = health && health.peers
-  const status = health && health.status
-  const isSyncing = health && health.isSyncing
   return (
     <Typography variant="subtitle2" component="div">
       <Grid container>
@@ -110,20 +107,20 @@ const NetworkContent = ({ network, health, apps }: NetworkContentProps) => {
           {emojis.seedling} Light Client
         </Grid>
         <Grid item xs={9}>
-          {isSyncing ? "Synchronizing" : "Synchronized"}
+          {health.isSyncing ? "Synchronizing" : "Synchronized"}
         </Grid>
         <Grid item xs={3}>
           {emojis.star} Network
         </Grid>
         <Grid item xs={9}>
           {network}
-          <br /> Chain is {status}
+          <br /> Chain is {health.status}
         </Grid>
         <Grid item xs={3}>
           {emojis.deal} Peers
         </Grid>
         <Grid item xs={9}>
-          {peers}
+          {health.peers}
         </Grid>
         <Grid item xs={3}>
           {emojis.apps} Apps

--- a/projects/extension/src/containers/Options.tsx
+++ b/projects/extension/src/containers/Options.tsx
@@ -93,7 +93,8 @@ const Options: React.FunctionComponent = () => {
             return networks.set(app.chainName, {
               name: app.chainName,
               health: {
-                ...(app.healthStatus ?? {}),
+                isSyncing: app.isSyncing,
+                peers: app.peers,
                 status: "connected",
               },
               apps: [{ name: app.url, url: app.url }],

--- a/projects/extension/src/types/index.ts
+++ b/projects/extension/src/types/index.ts
@@ -33,9 +33,8 @@ export interface NetworkTabProps {
 }
 
 export interface OptionsNetworkTabHealthContent {
-  isSyncing?: boolean
-  peers?: number
-  shouldHavePeers?: boolean
+  isSyncing: boolean
+  peers: number
   status: NetworkStatus
 }
 export interface App {


### PR DESCRIPTION
I wanted to do this change as part of my ConnectionManager refactor, but I didn't want my first PR to spill over the UI stuff.

This PR removes the usage of the `SmoldotHealth` interface, because the health checker is an implementation detail that has no place in an API.
It also makes the `isSyncing` and `peers` fields non-optional, which is more correct.
