### PR TITLE
Fix typo error of chain_subscribeNewHeads

### DIFF
--- a/packages/connect/src/createPolkadotJsScClient/Health.ts
+++ b/packages/connect/src/createPolkadotJsScClient/Health.ts
@@ -36,7 +36,7 @@ export interface HealthChecker {
  * the health of the chain.
  *
  * In addition to this, as long as the health check reports that `isSyncing` is `true`, the
- * health checker also maintains a subscription to new best blocks using `chain_subscribeNewHeads`.
+ * health checker also maintains a subscription to new best blocks using `chain_subscribeNewHead`.
  * Whenever a new block is notified, a health check is performed immediately in order to determine
  * whether `isSyncing` has changed to `false`.
  *
@@ -258,7 +258,7 @@ class InnerChecker {
       JSON.stringify({
         jsonrpc: "2.0",
         id: this.#currentSubunsubRequestId,
-        method: "chain_subscribeNewHeads",
+        method: "chain_subscribeNewHead",
         params: [],
       }),
     )

--- a/packages/connect/src/createPolkadotJsScClient/createPolkadotJsScClient.test.ts
+++ b/packages/connect/src/createPolkadotJsScClient/createPolkadotJsScClient.test.ts
@@ -403,7 +403,7 @@ describe("Provider", () => {
       const cb = jest.fn()
       const token = await provider.subscribe(
         "foo",
-        "chain_subscribeNewHeads",
+        "chain_subscribeNewHead",
         ["baz"],
         cb,
       )
@@ -473,7 +473,7 @@ describe("Provider", () => {
       const cb = jest.fn()
       const token = await provider.subscribe(
         "foo",
-        "chain_subscribeNewHeads",
+        "chain_subscribeNewHead",
         ["baz"],
         cb,
       )
@@ -501,7 +501,7 @@ describe("Provider", () => {
       const cb = jest.fn()
       const token = await provider.subscribe(
         "foo",
-        "chain_subscribeNewHeads",
+        "chain_subscribeNewHead",
         ["baz"],
         cb,
       )
@@ -567,7 +567,7 @@ describe("Provider", () => {
     const cb = jest.fn()
     const token = await provider.subscribe(
       "foo",
-      "chain_subscribeNewHeads",
+      "chain_subscribeNewHead",
       ["baz"],
       cb,
     )
@@ -586,7 +586,7 @@ describe("Provider", () => {
     // from the stale subscription, since that request should happen once the
     // chain is no longer syncing
     expect(chain._recevedRequests()).toEqual([
-      '{"id":1,"jsonrpc":"2.0","method":"chain_subscribeNewHeads","params":["baz"]}',
+      '{"id":1,"jsonrpc":"2.0","method":"chain_subscribeNewHead","params":["baz"]}',
     ])
 
     // lets change the sync status back to false
@@ -598,7 +598,7 @@ describe("Provider", () => {
     // let's make sure that we have now sent the request for killing the
     // stale subscription
     expect(chain._recevedRequests()).toEqual([
-      '{"id":1,"jsonrpc":"2.0","method":"chain_subscribeNewHeads","params":["baz"]}',
+      '{"id":1,"jsonrpc":"2.0","method":"chain_subscribeNewHead","params":["baz"]}',
       `{"id":2,"jsonrpc":"2.0","method":"chain_unsubscribeNewHeads","params":["${token}"]}`,
     ])
   })

--- a/packages/connect/src/createPolkadotJsScClient/createPolkadotJsScClient.ts
+++ b/packages/connect/src/createPolkadotJsScClient/createPolkadotJsScClient.ts
@@ -31,7 +31,7 @@ const subscriptionUnsubscriptionMethods = new Map<string, string>([
   ["author_submitAndWatchExtrinsic", "author_unwatchExtrinsic"],
   ["chain_subscribeAllHeads", "chain_unsubscribeAllHeads"],
   ["chain_subscribeFinalizedHeads", "chain_unsubscribeFinalizedHeads"],
-  ["chain_subscribeNewHeads", "chain_unsubscribeNewHeads"],
+  ["chain_subscribeNewHead", "chain_unsubscribeNewHeads"],
   ["state_subscribeRuntimeVersion", "state_unsubscribeRuntimeVersion"],
   ["state_subscribeStorage", "state_unsubscribeStorage"],
 ])


### PR DESCRIPTION
[This](https://github.com/paritytech/substrate-connect/runs/5453459596?check_suite_focus=true#step:7:150) revealed that the `chain_subscribeNewHeads` was typo and needed to be renamed to `chain_subscribeNewHead`