### PR TITLE
Make the ConnectionManager robust to smoldot exceptions

### DIFF
--- a/projects/extension/src/background/ConnectionManager.ts
+++ b/projects/extension/src/background/ConnectionManager.ts
@@ -492,7 +492,8 @@ export class ConnectionManager<SandboxId> {
    * Well-known chains aren't touched.
    */
   #resetAllNonWellKnownChains(errorMessage: string) {
-    for (const [_sandboxId, sandbox] of this.#sandboxes) {
+    for (const sandboxTuple of this.#sandboxes) {
+      const sandbox = sandboxTuple[1] // A stupid lint prevents us from doing `[_, sandbox]` above
       for (const [chainId, chain] of sandbox.chains) {
         sandbox.chains.delete(chainId)
         sandbox.pushMessagesQueue({

--- a/projects/extension/src/background/ConnectionManagerWithHealth.ts
+++ b/projects/extension/src/background/ConnectionManagerWithHealth.ts
@@ -151,6 +151,8 @@ export class ConnectionManagerWithHealth<SandboxId> {
   /**
    * Returns the content of the database of the well-known chain with the given name.
    *
+   * Returns `undefined` if the database content couldn't be obtained.
+   *
    * The `maxUtf8BytesSize` parameter is the maximum number of bytes that the string must occupy
    * in its UTF-8 encoding. The returned string is guaranteed to not be larger than this number.
    * If not provided, "infinite" is implied.
@@ -161,7 +163,7 @@ export class ConnectionManagerWithHealth<SandboxId> {
   async wellKnownChainDatabaseContent(
     chainName: string,
     maxUtf8BytesSize?: number,
-  ): Promise<string> {
+  ): Promise<string | undefined> {
     return await this.#inner.wellKnownChainDatabaseContent(
       chainName,
       maxUtf8BytesSize,
@@ -193,6 +195,15 @@ export class ConnectionManagerWithHealth<SandboxId> {
         ...chainInfo,
       }
     })
+  }
+
+  /**
+   * Returns `true` if the underlying client has crashed in the past.
+   *
+   * A crash is non-reversible. The only solution is to rebuild a new manager.
+   */
+  get hasCrashed(): boolean {
+    return this.#inner.hasCrashed
   }
 
   /**

--- a/projects/extension/src/background/index.ts
+++ b/projects/extension/src/background/index.ts
@@ -225,7 +225,8 @@ chrome.runtime.onConnect.addListener((port) => {
           // If an error happened, this might be an indication that the manager has crashed.
           // If that is the case, we need to notify the UI and restart everything.
           // TODO: this isn't implemented yet
-          if (message.type === "error" && manager.hasCrashed) true
+          if (message.type === "error" && manager.hasCrashed) {
+          }
         }
       }
     })()

--- a/projects/extension/src/background/index.ts
+++ b/projects/extension/src/background/index.ts
@@ -142,7 +142,10 @@ const saveChainDbContent = async (
     key,
     chrome.storage.local.QUOTA_BYTES / wellKnownChains.size,
   )
-  chrome.storage.local.set({ [key]: db })
+
+  // `db` can be `undefined` if the database content couldn't be obtained. In that case, we leave
+  // the database as it was before.
+  if (db) chrome.storage.local.set({ [key]: db })
 }
 
 // Start initializing a `ConnectionManagerWithHealth`.
@@ -218,6 +221,11 @@ chrome.runtime.onConnect.addListener((port) => {
           // We make sure that the message is indeed of type `ToApplication`.
           const messageCorrectType: ToApplication = message
           port.postMessage(messageCorrectType)
+
+          // If an error happened, this might be an indication that the manager has crashed.
+          // If that is the case, we need to notify the UI and restart everything.
+          // TODO: this isn't implemented yet
+          if (message.type === "error" && manager.hasCrashed) true
         }
       }
     })()


### PR DESCRIPTION
This modifies the connection manager to properly absorb exceptions coming from the smoldot library.

If smoldot crashes, the connection manager kills all active chains and sets an internal `hasCrashed` boolean to true.
When the `index.ts` file sees that errors are being sent to the frontend, it checks this internal boolean. The rest isn't implemented as it is out of scope of this PR.