### PR TITLE
CI: ensure resolutions version matches local version

### DIFF
--- a/.ensure-resolution.mjs
+++ b/.ensure-resolution.mjs
@@ -1,0 +1,22 @@
+import { readFile as cbReadFile } from "fs"
+import { promisify } from "util"
+
+const readFile = promisify(cbReadFile)
+
+const [rootPkg, connectPkg] = await Promise.all([
+  readFile("./package.json"),
+  readFile("./packages/connect/package.json"),
+]).then((pkgs) => pkgs.map((rawPkg) => JSON.parse(rawPkg)))
+
+const rootVersion = rootPkg.resolutions?.["@substrate/connect"]
+const connectVersion = connectPkg.version
+
+const isMismatch = rootVersion !== connectVersion
+
+if (isMismatch) {
+  console.error(
+    "The @substrate/connect resolution on the root package.json does not match the version of packages/connect/package.json",
+  )
+}
+
+process.exit(isMismatch ? 1 : 0)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: node .ensure-resolutions.mjs
+    - run: yarn checkResolutions
     - run: yarn install --frozen-lockfile
     - run: yarn build
     - run: yarn lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - run: node .ensure-resolutions.mjs
     - run: yarn install --frozen-lockfile
     - run: yarn build
     - run: yarn lint

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "dev:landing-page": "yarn workspace @substrate/landing-page run dev",
     "dev:extension": "yarn workspace @substrate/extension run dev",
     "deploy": "./deploy.sh",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "checkResolutions": "node ./.ensure-resolution.mjs"
   },
   "devDependencies": {
     "@babel/core": "^7.17.5",


### PR DESCRIPTION
Adds a new step in the CI to ensure that we don't accidentally forget to update the `resolutions` entry on the root `package.json`.