### PR TITLE
Catch CrashError of smoldot, restart smoldot and add UI indications

### DIFF
--- a/projects/extension/CHANGELOG.md
+++ b/projects/extension/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Introduce catch smoldot crash/panic during initilization. When this happen new icons appear on Popup that indicates the error and allow user to manually reload the extension. Indication icon redirects to latest logs. ([#958](https://github.com/paritytech/substrate-connect/pull/958))
+- Add catch of smoldot crash/panic during initilization of client. When this happen new icons appear on Popup that indicates the error and allow user to manually reload the extension. Indication icon redirects to latest logs. ([#958](https://github.com/paritytech/substrate-connect/pull/958))
 
 ### Changed
 

--- a/projects/extension/CHANGELOG.md
+++ b/projects/extension/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Introduce mechanism that restarts 3 times (5 sec interval) smoldot when crash/panic occurs. After these tries, new icons appear on Popup that indicates the error and allow user to manually reload the extension. Indication icon redirects to latest logs. ([#958](https://github.com/paritytech/substrate-connect/pull/958))
+- Introduce catch smoldot crash/panic during initilization. When this happen new icons appear on Popup that indicates the error and allow user to manually reload the extension. Indication icon redirects to latest logs. ([#958](https://github.com/paritytech/substrate-connect/pull/958))
 
 ### Changed
 

--- a/projects/extension/CHANGELOG.md
+++ b/projects/extension/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Introduce mechanism that restarts 3 times (5 sec interval) smoldot when crash/panic occurs. After these tries, new icons appear on Popup that indicates the error and allow user to manually reload the extension. Indication icon redirects to latest logs. ([#958](https://github.com/paritytech/substrate-connect/pull/958))
+
 ### Changed
 
 - Update @substrate/smoldot-light to [version 0.6.15](https://github.com/paritytech/smoldot/blob/main/bin/wasm-node/CHANGELOG.md#0615---2022-04-07) ([#955](https://github.com/paritytech/substrate-connect/pull/955))

--- a/projects/extension/src/background/index.ts
+++ b/projects/extension/src/background/index.ts
@@ -35,12 +35,6 @@ export interface Background extends Window {
   }
 }
 
-interface ErrorStruct {
-  name: string
-  message: string
-  stack?: string
-}
-
 interface logStructure {
   unix_timestamp: number
   level: number
@@ -174,11 +168,11 @@ const managerPromise: Promise<
     // time in localstorage. When 3rd time occurs - stop retrying, save the error in localstorage
     // for UI to be able to retrieve it and allow only manual retry
     const errString =
-      (err as ErrorStruct).name +
+      (err as Error).name +
       ":" +
-      (err as ErrorStruct).message +
+      (err as Error).message +
       "\n" +
-      (err as ErrorStruct).stack
+      (err as Error).stack
     chrome.storage.local.set({
       crashError: errString,
     })

--- a/projects/extension/src/background/index.ts
+++ b/projects/extension/src/background/index.ts
@@ -179,26 +179,15 @@ const managerPromise: Promise<
       (err as ErrorStruct).message +
       "\n" +
       (err as ErrorStruct).stack
-    chrome.storage.local.get(["smoldotCrash"], (result) => {
-      if (result.smoldotCrash <= 2) {
-        chrome.storage.local.set({ smoldotCrash: result.smoldotCrash + 1 })
-        setTimeout(() => {
-          chrome.runtime.reload()
-        }, 5000)
-      } else {
-        chrome.storage.local.set({ smoldotCrash: 0 })
-        chrome.storage.local.set({
-          crashError: errString,
-        })
-      }
-      logger(1, "Smoldot", errString)
-      console.error(err)
+    chrome.storage.local.set({
+      crashError: errString,
     })
+    logger(1, "Smoldot", errString)
+    console.error(err)
     // This is a dumb return - in order to avoid returning "undfined" as a type which
     // leads to unecessary extra code. "Unecessary" cause the Extension supposebly is already crashed
     return {} as ConnectionManagerWithHealth<chrome.runtime.Port>
   }
-  chrome.storage.local.set({ smoldotCrash: 0 })
   for (const [key, value] of wellKnownChains.entries()) {
     const dbContent = await new Promise<string | undefined>((res) =>
       chrome.storage.local.get([key], (val) => res(val[key] as string)),
@@ -303,12 +292,6 @@ chrome.storage.local.get(["notifications"], (result) => {
         console.error(chrome.runtime.lastError)
       }
     })
-  }
-})
-
-chrome.storage.local.get(["smoldotCrash"], (result) => {
-  if (!result.smoldotCrash && result.smoldotCrash !== 0) {
-    chrome.storage.local.set({ smoldotCrash: 0 })
   }
 })
 

--- a/projects/extension/src/containers/Options.tsx
+++ b/projects/extension/src/containers/Options.tsx
@@ -184,6 +184,12 @@ const Options: React.FunctionComponent = () => {
   }, [poolingLogs])
 
   useEffect(() => {
+    chrome.storage.local.get(["crashError"], (res) => {
+      if (res.crashError) {
+        setValue(2)
+      }
+    })
+
     chrome.storage.local.get(["notifications"], (res) => {
       setNotifications(res.notifications as SetStateAction<boolean>)
     })

--- a/projects/extension/src/containers/Options.tsx
+++ b/projects/extension/src/containers/Options.tsx
@@ -135,7 +135,7 @@ const TabPanel = (props: TabPanelProps) => {
 const Options: React.FunctionComponent = () => {
   const classes = useStyles()
   const appliedTheme = createTheme(light)
-  const [value, setValue] = useState<number>(0)
+  const [tab, setTab] = useState<number>(0)
   const [networks, setNetworks] = useState<NetworkTabProps[]>([])
   const [notifications, setNotifications] = useState<boolean>(false)
   const [allLogs, setAllLogs] = useState<logStructure[]>([])
@@ -186,7 +186,7 @@ const Options: React.FunctionComponent = () => {
   useEffect(() => {
     chrome.storage.local.get(["crashError"], (res) => {
       if (res.crashError) {
-        setValue(2)
+        setTab(2)
       }
     })
 
@@ -232,9 +232,9 @@ const Options: React.FunctionComponent = () => {
 
   const handleChange = (
     event: React.ChangeEvent<unknown>,
-    newValue: number,
+    chosenTab: number,
   ) => {
-    setValue(newValue)
+    setTab(chosenTab)
   }
 
   const getLevelInfo = (level: number) => {
@@ -269,7 +269,7 @@ const Options: React.FunctionComponent = () => {
         <Logo />
       </Box>
       <MenuTabs
-        value={value}
+        value={tab}
         onChange={handleChange}
         TabIndicatorProps={{
           style: {
@@ -281,7 +281,7 @@ const Options: React.FunctionComponent = () => {
         <MenuTab label="Settings"></MenuTab>
         <MenuTab label="Logs"></MenuTab>
       </MenuTabs>
-      <TabPanel value={value} index={0}>
+      <TabPanel value={tab} index={0}>
         {networks.length ? (
           networks.map((network: NetworkTabProps, i: number) => {
             const { name, health, apps } = network
@@ -293,7 +293,7 @@ const Options: React.FunctionComponent = () => {
           <div>No networks or apps are connected to the extension.</div>
         )}
       </TabPanel>
-      <TabPanel value={value} index={1}>
+      <TabPanel value={tab} index={1}>
         <FormControl component="fieldset">
           <FormGroup aria-label="position" row>
             <FormControlLabel
@@ -315,7 +315,7 @@ const Options: React.FunctionComponent = () => {
           </FormGroup>
         </FormControl>
       </TabPanel>
-      <TabPanel value={value} index={2}>
+      <TabPanel value={tab} index={2}>
         <div className={classes.logs}>
           <div className={classes.logTitle}>
             <Button

--- a/projects/extension/src/containers/Popup.tsx
+++ b/projects/extension/src/containers/Popup.tsx
@@ -1,23 +1,46 @@
 import React, { FunctionComponent, useEffect, useRef, useState } from "react"
 import * as material from "@material-ui/core"
 import GlobalFonts from "../fonts/fonts"
+import { makeStyles } from "@material-ui/core/styles"
 import { light, MenuButton, Tab, Logo } from "../components"
 import CallMadeIcon from "@material-ui/icons/CallMade"
 import { Background } from "../background/"
 import { TabInterface } from "../types"
+import { Tooltip } from "@material-ui/core"
+import ErrorIcon from "@material-ui/icons/Error"
+import ReplayIcon from "@material-ui/icons/Replay"
 
 const { createTheme, ThemeProvider, Box, Divider } = material
 
+const useStyles = makeStyles(() => ({
+  flexBetween: {
+    display: "flex",
+    justifyContent: "space-between",
+  },
+  replayIcon: {
+    width: "1.2rem",
+    marginLeft: "0.2rem",
+    color: "green",
+    cursor: "pointer",
+  },
+  errorIcon: { width: "1.2rem", color: "red", cursor: "pointer" },
+}))
+
 const Popup: FunctionComponent = () => {
+  const classes = useStyles()
   const disconnectTabRef = useRef<(tapId: number) => void>((_: number) => {})
   const [activeTab, setActiveTab] = useState<TabInterface | undefined>()
   const [otherTabs, setOtherTabs] = useState<TabInterface[]>([])
+  const [crashError, setCrashError] = useState<string>("")
   const appliedTheme = createTheme(light)
 
   useEffect(() => {
     let isActive = true
     let unsubscribe = () => {}
 
+    chrome.storage.local.get(["crashError"], (res) => {
+      setCrashError(res.crashError)
+    })
     ;(async () => {
       // retrieve open tabs and assign to local state
       const browserTabs = await new Promise<chrome.tabs.Tab[]>((res) =>
@@ -62,16 +85,35 @@ const Popup: FunctionComponent = () => {
     }
   }, [])
 
-  const goToOptions = (): void => {
-    chrome.runtime.openOptionsPage()
-  }
-
   return (
     <ThemeProvider theme={appliedTheme}>
       <Box width={"320px"} pl={1.5} pr={1.5}>
         <GlobalFonts />
         <Box pt={2} pb={1} pl={1} pr={1}>
-          <Logo />
+          {crashError ? (
+            <div className={classes.flexBetween}>
+              <div>
+                <Logo />
+              </div>
+              <div>
+                <ErrorIcon
+                  className={classes.errorIcon}
+                  onClick={() => chrome.runtime.openOptionsPage()}
+                />
+                <Tooltip
+                  placement="bottom"
+                  title={"Click for manual reload of the extension"}
+                >
+                  <ReplayIcon
+                    onClick={() => chrome.runtime.reload()}
+                    className={classes.replayIcon}
+                  />
+                </Tooltip>
+              </div>
+            </div>
+          ) : (
+            <Logo />
+          )}
         </Box>
 
         {activeTab && (
@@ -97,7 +139,7 @@ const Popup: FunctionComponent = () => {
             ))}
           </Box>
         )}
-        <MenuButton fullWidth onClick={goToOptions}>
+        <MenuButton fullWidth onClick={() => chrome.runtime.openOptionsPage()}>
           Options
         </MenuButton>
         <Divider />


### PR DESCRIPTION
This PR takes care of the possible smoldot panic/error that crashes the extension - and addresses the last bullet on [Pierre's comment](https://github.com/paritytech/substrate-connect/issues/429#issuecomment-1059754226) and issue [#507](https://github.com/paritytech/substrate-connect/issues/507)
When an error happens on smoldot client, the extension catches the error, prints it in the logs <del>and starts a series of extension restarts. There will be 3 restarts of the extension with a 5 seconds delay between each restart.</del>
If <del>at the 3rd retry</del> a CrashError occurs <del>again</del>, then 2 icons appear on the Popup window. 
1 "alert" icon that indicates the issue in the extension and user can hover and read the error. If icon is clicked user is redirected to "paused" logs (that contain ofc the error log last - that lead to the crash)

I did not follow exactly the proposal of Pierre on the 4th bullet of his comment - meaning that if smoldot crashes but recovers the only thing that will happen will be to get disconnected from apps and try to run smoldot again. 

The only way that the _average Joe_ will understand that something really happened is if smoldot crashes 3 consecutive times and then the indication will appear (and the manual "restart extension" button)

EDIT: This covers a potential crash only during initialization of smoldot

![image](https://user-images.githubusercontent.com/5408605/162290566-bddb80dc-d0bb-46ed-8451-5077ec5b5319.png)
![image](https://user-images.githubusercontent.com/5408605/162290679-8f3108d0-1b4b-418e-9d30-ff095da28438.png)
