### PR TITLE
Better error message when extension rejects a chain

### DIFF
--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- The reason why the extension rejects a chain is now explained in the exception being thrown.
+
 ## 0.7.2 - 2022-04-07
 
 ### Changed

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- The reason why the extension rejects a chain is now explained in the exception being thrown.
+- The reason why the extension rejects a chain is now explained in the exception being thrown. ([#968](https://github.com/paritytech/substrate-connect/pull/968))
 
 ## 0.7.2 - 2022-04-07
 

--- a/packages/connect/src/connector/extension.test.ts
+++ b/packages/connect/src/connector/extension.test.ts
@@ -89,11 +89,11 @@ describe("SmoldotConnect::Extension", () => {
         type: "error",
         origin: "substrate-connect-extension",
         chainId: addChainMessage.chainId,
-        errorMessage: "",
+        errorMessage: "test",
       })
 
       await expect(chainPromise).rejects.toThrow(
-        "There was an error creating the smoldot chain.",
+        "There was an error creating the smoldot chain: test",
       )
     })
 

--- a/packages/connect/src/connector/extension.ts
+++ b/packages/connect/src/connector/extension.ts
@@ -78,7 +78,15 @@ export const createScClient = (): ScClient => {
         listeners.set(chainId, (msg) => {
           listeners.delete(chainId)
           if (msg.type === "chain-ready") return res()
-          rej(new Error("There was an error creating the smoldot chain."))
+          const errMsg =
+            msg.type === "error"
+              ? msg.errorMessage
+              : "Unexpected message from the extension"
+          rej(
+            new Error(
+              "There was an error creating the smoldot chain: " + errMsg,
+            ),
+          )
         })
 
         postToExtension(msg)


### PR DESCRIPTION
`"There was an error creating the smoldot chain."` is not an acceptable error message