### PR TITLE
Allow setting maxLoglevel and logCallback

### DIFF
--- a/packages/connect/src/connector/index.ts
+++ b/packages/connect/src/connector/index.ts
@@ -33,3 +33,13 @@ export const isExtensionPresent =
 export const createScClient = isExtensionPresent
   ? extensionScClient
   : smoldotScClient
+
+/**
+ * Returns an in-page {@link ScClient} ignoring if the extension is installed.
+ *
+ * @param clientOptions options to be used when creating smoldot-light instance
+ * This is inteded for debugging issues with smoldot connecting to chains.
+ *
+ * @internal
+ */
+export const createSmoldotScClient = smoldotScClient


### PR DESCRIPTION
Moving the discussion in #965 into a draft pull request.  This is a start at the implementation updated with some changes discussed in the aforementioned issue conversation:
* Introduces a new separate type that defines the options that substrate connect can override when initialising smoldot.  
* Merge the options properly: no argument passed uses defaults, argument passed overwrites defaults with suppplied values.
 
Note this still doesn't resolve my worry.  In the following usage scenario:

 ```js
  const relayChain = ...;
  const relayChain2 = ...;
  const chain1 = await createScClient().addChain(relayChain);
  const chain2 = await createScClient({ maxLogLevel: 3 }).addChain(relayChain2);
 ```

`chain2` will not respect the `maxLogLevel` because at the point the first time `addChain` is  called the internal smoldot client has been configured with the default options.  The second call to `addChain` reuses the original internal smoldot client (and therefor the default options).  I'm failing to see any way round this if we are sharing the smoldot client internally.  Moving the configuration to `addChain` has the same problem.  Having it on `createScClient` at least moves the configuration slightly closer to where the actual initialisation of the smoldot client happens (before the first call to `addChain`).