### PR TITLE
Prettier ignore generated docs folder

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -66,6 +66,7 @@ package-lock.json
 
 # Project specifics
 .chains
+_site
 .github
 CONTRIBUTING*
 DEPLOY-RELEASE*


### PR DESCRIPTION
I've been tweaking my setup to account for the style and formatting changes that have happened in my absence. I hadn't noticed that the `_site` folder wasn't' ignored by prettier when I was making my documentation PR because I wasn't linting.  This stops prettier checking the autogenerated `_site` folder and shouting about lots of issues that we shouldn't care about.