### PR TITLE
Allow triggering spec update workflow by github UI

### DIFF
--- a/.github/workflows/update-chain-specs.yml
+++ b/.github/workflows/update-chain-specs.yml
@@ -3,6 +3,7 @@ name: chain-specs-periodic-update
 on:
   schedule:
     - cron: '0 8 * * *'  # every day at 8am
+  workflow_dispatch: # allow triggering through the UI
 
 
 jobs:


### PR DESCRIPTION
This change means we can run the periodic spec update workflow from the github actions UI as well as the cron timer running it.  I have created a new `substrate-connect` user in github which I have access to so that I can sign the CLI on behalf of the bot and I have generated a new personal access token from that account and updated the GH_TOKEN secret.  Once this PR is merged I should be able to rerun the workflow from the CI to generate new pull request witha  commit from this new `substrate-connect` user instead of the `mergify` user.