### PR TITLE
Set author and committer in update spec workflow

### DIFF
--- a/.github/workflows/update-chain-specs.yml
+++ b/.github/workflows/update-chain-specs.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
+        persist-credentials: false
+        fetch-depth: 0
         path: repo
         ref: main
     - run: |

--- a/.github/workflows/update-chain-specs.yml
+++ b/.github/workflows/update-chain-specs.yml
@@ -74,6 +74,8 @@ jobs:
         # request triggers other actions such as the CI checks. GitHub prevents actions that use
         # GITHUB_TOKEN from triggering further actions, to avoid recursive actions.
         token: ${{ secrets.GH_TOKEN }}
+        committer: Substrate Connect <raoul@parity.io>
+        author: Substrate Connect <raoul@parity.io>
         path: repo
         branch: automatic-checkpoints-update
         base: main


### PR DESCRIPTION
This PR disables credential caching when checking out the repo during a spec update workflow and then always sets the committer and author to the substrate connect user.  When merged this shold stop the `mergify` user being the author when this workflow is triggered by cron.