### PR TITLE
chore: make dependabot ignore major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,6 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 4
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
I noticed that dependabot opened a PR for React 18, which surprised me b/c I wasn't expecting dependabot to open PRs for major upgrades since they usually imply breaking changes and therefore the intervention from a developer in order to adjust to the new API. So, I looked into the docs and I found [this section](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore). If I understood it correctly (please double check :pray:), then I think that this PR should make dependabot to stop sending PRs for major updates.