### PR TITLE
Add the latest block height to the chain information provided by the manager

### DIFF
--- a/projects/extension/src/background/ConnectionManagerWithHealth.ts
+++ b/projects/extension/src/background/ConnectionManagerWithHealth.ts
@@ -401,7 +401,7 @@ export class ConnectionManagerWithHealth<SandboxId> {
                   // When one or more new blocks get finalized, we unpin all blocks except for
                   // the new current finalized.
                   let finalized = jsonRpcMessage.params.result
-                    .finalizedBlockHashes as [string]
+                    .finalizedBlocksHashes as [string]
                   let pruned = jsonRpcMessage.params.result
                     .prunedBlocksHashes as [string]
                   let newCurrentFinalized = finalized.pop()

--- a/projects/extension/src/background/ConnectionManagerWithHealth.ts
+++ b/projects/extension/src/background/ConnectionManagerWithHealth.ts
@@ -230,6 +230,7 @@ export class ConnectionManagerWithHealth<SandboxId> {
               "Internal error: inconsistency between lists of chains",
             )
 
+          // TODO: we don't unpin blocks :-/
           this.#inner.sandboxMessage(sandboxId, {
             origin: "substrate-connect-client",
             type: "rpc",

--- a/projects/extension/src/background/ConnectionManagerWithHealth.ts
+++ b/projects/extension/src/background/ConnectionManagerWithHealth.ts
@@ -287,7 +287,7 @@ export class ConnectionManagerWithHealth<SandboxId> {
             } else if (jsonRpcMessageId.startsWith("best-block-header:")) {
               // We might receive responses to header requests concerning blocks that were but are
               // no longer the best block of the chain. Ignore these responses.
-              if (jsonRpcMessageId == chain.bestBlockHeaderRequestId) {
+              if (jsonRpcMessageId === chain.bestBlockHeaderRequestId) {
                 delete chain.bestBlockHeaderRequestId
                 // The RPC call might return `null` if the subscription is dead.
                 if (jsonRpcMessage.result) {

--- a/projects/extension/src/background/ConnectionManagerWithHealth.ts
+++ b/projects/extension/src/background/ConnectionManagerWithHealth.ts
@@ -324,6 +324,7 @@ export class ConnectionManagerWithHealth<SandboxId> {
                       params: [true],
                     }),
                   })
+                  this.#nextHealthCheckRqId += 1
                   break
                 }
               }

--- a/projects/extension/src/background/ConnectionManagerWithHealth.ts
+++ b/projects/extension/src/background/ConnectionManagerWithHealth.ts
@@ -567,9 +567,9 @@ function headerToHeight(hexHeader: String): number {
     throw new Error("Not a hexadecimal number")
   hexHeader = hexHeader.slice(2)
 
-  // The header should start with 4 bytes containing the parent hash.
-  if (hexHeader.length < 8) throw new Error("Too short")
-  hexHeader = hexHeader.slice(8)
+  // The header should start with 32 bytes containing the parent hash.
+  if (hexHeader.length < 64) throw new Error("Too short")
+  hexHeader = hexHeader.slice(64)
 
   // The next field is the block number (which is what interests us) encoded in SCALE compact.
   // Unfortunately this format is a bit complicated to decode.

--- a/projects/extension/src/background/ConnectionManagerWithHealth.ts
+++ b/projects/extension/src/background/ConnectionManagerWithHealth.ts
@@ -123,7 +123,7 @@ export class ConnectionManagerWithHealth<SandboxId> {
   // that the underlying `ConnectionManager` has already removed.
   #sandboxesChains: Map<SandboxId, Map<string, Chain>> = new Map()
   #pingInterval: ReturnType<typeof globalThis.setInterval>
-  #nextHealthCheckRqId: number = 0
+  #nextRpcRqId: number = 0
 
   constructor(
     wellKnownChainSpecs: Map<string, string>,
@@ -229,12 +229,12 @@ export class ConnectionManagerWithHealth<SandboxId> {
             chainId: toApplication.chainId,
             jsonRpcMessage: JSON.stringify({
               jsonrpc: "2.0",
-              id: "ready-sub:" + this.#nextHealthCheckRqId,
+              id: "ready-sub:" + this.#nextRpcRqId,
               method: "chainHead_unstable_follow",
               params: [true],
             }),
           })
-          this.#nextHealthCheckRqId += 1
+          this.#nextRpcRqId += 1
           return toApplication
         }
 
@@ -296,12 +296,12 @@ export class ConnectionManagerWithHealth<SandboxId> {
                     chainId: toApplication.chainId,
                     jsonRpcMessage: JSON.stringify({
                       jsonrpc: "2.0",
-                      id: "health-check:" + this.#nextHealthCheckRqId,
+                      id: "health-check:" + this.#nextRpcRqId,
                       method: "system_health",
                       params: [],
                     }),
                   })
-                  this.#nextHealthCheckRqId += 1
+                  this.#nextRpcRqId += 1
 
                   // Notify of the change in status.
                   return {
@@ -319,12 +319,12 @@ export class ConnectionManagerWithHealth<SandboxId> {
                     chainId: toApplication.chainId,
                     jsonRpcMessage: JSON.stringify({
                       jsonrpc: "2.0",
-                      id: "ready-sub:" + this.#nextHealthCheckRqId,
+                      id: "ready-sub:" + this.#nextRpcRqId,
                       method: "chainHead_unstable_follow",
                       params: [true],
                     }),
                   })
-                  this.#nextHealthCheckRqId += 1
+                  this.#nextRpcRqId += 1
                   break
                 }
               }
@@ -415,12 +415,12 @@ export class ConnectionManagerWithHealth<SandboxId> {
           chainId,
           jsonRpcMessage: JSON.stringify({
             jsonrpc: "2.0",
-            id: "health-check:" + this.#nextHealthCheckRqId,
+            id: "health-check:" + this.#nextRpcRqId,
             method: "system_health",
             params: [],
           }),
         })
-        this.#nextHealthCheckRqId += 1
+        this.#nextRpcRqId += 1
       }
     }
   }


### PR DESCRIPTION
This also fixes two issues:

- We didn't properly bump `nextRpcRqId` when restarting the subscription.
- We didn't unpin the blocks that were notified to us.

Can be reviewed commit by commit.

I haven't tested whether it works, sorry.
