### PR TITLE
Fix error about unpinning null block

### DIFF
--- a/projects/extension/src/background/ConnectionManagerWithHealth.ts
+++ b/projects/extension/src/background/ConnectionManagerWithHealth.ts
@@ -411,6 +411,8 @@ export class ConnectionManagerWithHealth<SandboxId> {
                     ...pruned,
                     ...finalized,
                   ].forEach((blockHash) => {
+                    // `chain.finalizedBlockHashHex` can be null
+                    if (blockHash === null) return
                     this.#inner.sandboxMessage(sandboxId, {
                       origin: "substrate-connect-client",
                       type: "rpc",


### PR DESCRIPTION
Fixes errors in the logs:

> [13:20:25 280][json-rpc-polkadot]Error in JSON-RPC method call: Parameter #1 is invalid when calling chainHead_unstable_unpin: invalid type: null, expected a string at line 1 column 4

Needs a changelog entry, which I'll add after https://github.com/paritytech/substrate-connect/pull/1111
