### PR TITLE
Alter base tsconfig in order to avoid missing source map warnings

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "composite": true,
-    "inlineSources": true,
+    "declaration": true,
     "inlineSourceMap": true,
     "paths": {
       "@substrate/connect-extension-protocol": [

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,9 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "composite": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
+    "inlineSources": true,
+    "inlineSourceMap": true,
     "paths": {
       "@substrate/connect-extension-protocol": [
         "./packages/connect-extension-protocol"


### PR DESCRIPTION
Remove `declarationMap` that was generating source map for `.d.ts files` which map back to the original .ts source file since we do not ship those `ts` files - which resulted to the error described in #1196. In addition sourceMap was replaced with `inlineSourceMap` in order to avoid similar issues.

Fixes #1196