### PR TITLE
Pin version of Rober19/compare-npm-versions-ci GHA to specific commit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - run: yarn install --immutable
       - run: yarn build
       - name: Compare versions of npm with local
-        uses: Rober19/compare-npm-versions-ci@master
+        uses: Rober19/compare-npm-versions-ci@a38b02a14bbee73badddf83e13ebcb3e674c6df5 # latest from original maintainer
         id: package_version
         with:
           path: './packages/connect'


### PR DESCRIPTION
Addresses https://gitlab.parity.io/parity/vulnerability-response/-/issues/50
Quick fix is to pin GHA to specific commit so further possible changes may not affect our setup.