### PR TITLE
Fix source map warnings

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,7 +4,8 @@
     "baseUrl": ".",
     "composite": true,
     "declaration": true,
-    "inlineSourceMap": true,
+    "inlineSources": true,
+    "sourceMap": true,
     "paths": {
       "@substrate/connect-extension-protocol": [
         "./packages/connect-extension-protocol"


### PR DESCRIPTION
These changes were made to generate `sourcesContent` in your source map files, it will allow avoiding the warnings which you tried to fix [here](https://github.com/paritytech/substrate-connect/issues/1196).

Docs:
[ts config inlineSources ](https://www.typescriptlang.org/tsconfig#inlineSources)