### PR TITLE
Only show icon for well-known chains

### DIFF
--- a/projects/extension/src/background/index.ts
+++ b/projects/extension/src/background/index.ts
@@ -106,6 +106,7 @@ chrome.runtime.onMessage.addListener(
 
             chains.push({
               chainId: message.chainId,
+              isWellKnown: message.isWellKnown,
               chainName: message.chainSpecChainName,
               isSyncing: false,
               peers: 0,

--- a/projects/extension/src/background/protocol.ts
+++ b/projects/extension/src/background/protocol.ts
@@ -44,6 +44,7 @@ export interface ToExtensionReset {
 export interface ToExtensionAddChain {
   type: "add-chain"
   chainId: string
+  isWellKnown: boolean
   chainSpecChainName: string
 }
 

--- a/projects/extension/src/containers/Options.tsx
+++ b/projects/extension/src/containers/Options.tsx
@@ -78,12 +78,14 @@ export const Options: React.FunctionComponent = () => {
       environment.getAllActiveChains().then((chains) => {
         const networks = new Map<string, NetworkTabProps>()
         ;(chains || []).forEach((chain) => {
-          const { chainName, tab, isSyncing, peers, bestBlockHeight } = chain
+          const { chainName, tab, isWellKnown, isSyncing, peers, bestBlockHeight } = chain
+          const key = isWellKnown ? "wk" : "nwk" + chainName;
 
-          const network = networks.get(chainName)
+          const network = networks.get(key)
           if (!network) {
-            return networks.set(chainName, {
+            return networks.set(key, {
               name: chainName,
+              isWellKnown,
               health: {
                 isSyncing,
                 peers,

--- a/projects/extension/src/containers/Popup.tsx
+++ b/projects/extension/src/containers/Popup.tsx
@@ -6,6 +6,7 @@ import * as environment from "../environment"
 
 interface PopupChain {
   chainName: string
+  isWellKnown: boolean
   details: ChainDetails[]
 }
 
@@ -26,11 +27,12 @@ const Popup: FunctionComponent = () => {
     environment.getAllActiveChains().then((chains) => {
       const allChains: PopupChain[] = []
       ;(chains || []).forEach((c) => {
-        const i = allChains.findIndex((i) => i.chainName === c.chainName)
+        const i = allChains.findIndex((i) => i.chainName === c.chainName && i.isWellKnown === c.isWellKnown)
         const { peers, isSyncing, chainId, bestBlockHeight } = c
         if (i === -1) {
           allChains.push({
             chainName: c.chainName,
+            isWellKnown: c.isWellKnown,
             details: [
               {
                 tabId: c.tab.id,

--- a/projects/extension/src/content/ClientWithExtension.ts
+++ b/projects/extension/src/content/ClientWithExtension.ts
@@ -451,6 +451,7 @@ export class SmoldotClientWithExtension {
 
     await this.#sendPortThenWaitResponse({
       type: "add-chain",
+      isWellKnown: wellKnownName === undefined ? false : true,
       chainId,
       chainSpecChainName,
     })

--- a/projects/extension/src/environment.ts
+++ b/projects/extension/src/environment.ts
@@ -104,6 +104,7 @@ function keyOf(entry: StorageEntry): string {
 export interface ExposedChainConnection {
   chainId: string
   chainName: string
+  isWellKnown: boolean
   tab: ExposedChainConnectionTabInfo
   isSyncing: boolean
   peers: number

--- a/projects/extension/src/types/index.ts
+++ b/projects/extension/src/types/index.ts
@@ -9,6 +9,7 @@ export interface TabInterface {
 
 export interface NetworkTabProps {
   name: string
+  isWellKnown: boolean
   health: OptionsNetworkTabHealthContent
   apps: App[]
 }


### PR DESCRIPTION
This PR makes it so the extension knows what is a well-known chain and what isn't.

This way, we can show the icon of a chain only if it is well-known.

This is important for security. Right now we just do `if icon.get(chainName)`, but given that `chainName` is untrusted user input, anyone can pretend that they're connecting to for example Polkadot while in fact connecting to a chain that isn't Polkadot.

@wirednkod Could you push on this PR and make it so that the `IconWeb3` also shows `?` if `isWellKnown` is `false`? I don't know how to pass values around with React.
