### PR TITLE
Fix how Options Page of extension show networks and app connected to them

### DIFF
--- a/projects/extension/src/containers/Options.tsx
+++ b/projects/extension/src/containers/Options.tsx
@@ -86,7 +86,7 @@ export const Options: React.FunctionComponent = () => {
             peers,
             bestBlockHeight,
           } = chain
-          const key = isWellKnown ? "wk" : "nwk" + chainName
+          const key = (isWellKnown ? "wk" : "nwk") + chainName
 
           const network = networks.get(key)
           if (!network) {


### PR DESCRIPTION
Fix bug that was showing all networks and urls under the 1st known network

![image](https://user-images.githubusercontent.com/5408605/197527709-256f9fee-f9b9-4149-9df2-6a2c41406ff3.png)
