### PR TITLE
Replace '?' with actual icon

### DIFF
--- a/projects/extension/src/components/IconWeb3.tsx
+++ b/projects/extension/src/components/IconWeb3.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from "react"
+import { MdOutlineGridView } from "react-icons/md"
 import "../main.css"
 
 interface Props {
@@ -16,8 +17,12 @@ export const IconWeb3: FunctionComponent<Props> = ({
   isWellKnown,
 }) => {
   return (
-    <span className="icon text-xl w-10">
-      {isWellKnown && children && hasGlyph(children) ? children : "?"}
-    </span>
+    <>
+      {isWellKnown && children && hasGlyph(children) ? (
+        <span className="icon text-xl w-10">{children}</span>
+      ) : (
+        <MdOutlineGridView className="ml-2.5 mt-1.5 mr-1.5" />
+      )}
+    </>
   )
 }


### PR DESCRIPTION
Fixes #1327

Replacing '?' with a more "seal of authenticity" icon (see Westmint chain below):

![image](https://user-images.githubusercontent.com/5408605/202177947-04485ae1-9bd8-4975-b133-c93152b4106f.png)
