### PR TITLE
chore: remove bogus test

### DIFF
--- a/packages/connect/src/connector/extension.test.ts
+++ b/packages/connect/src/connector/extension.test.ts
@@ -157,21 +157,6 @@ describe("SmoldotConnect::Extension", () => {
       expect(typeof chain.remove).toBe("function")
       expect(typeof chain.sendJsonRpc).toBe("function")
     })
-
-    it("adding a chain rejects the Promise upon receiving an error while waiting for `chain-ready`", async () => {
-      const { addWellKnownChain } = createScClient()
-      const chainPromise = addWellKnownChain(WellKnownChain.polkadot)
-      const addChainMessage = await getClientMessage()
-
-      postToClient({
-        type: "error",
-        origin: "substrate-connect-extension",
-        chainId: addChainMessage.chainId,
-        errorMessage: "",
-      })
-
-      await expect(chainPromise).rejects.toThrow()
-    })
   })
 
   describe("chain.remove", () => {


### PR DESCRIPTION
This test is bogus and it's passing by accident.

As it's explained [in here](https://github.com/paritytech/substrate-connect/blob/3911d973b7e7883f763515ce74a53faaf4048922/packages/connect/src/connector/extension.ts#L180-L185).

> In the situation where we tried to create a well-known chain, the extension isn't supposed to ever return an error. There is however one situation where errors can happen: if the extension doesn't recognize the desired well-known chain because it uses a different list of well-known chains than this code. To handle this, we download the chain spec of the desired well-known chain and try again but this time as a non-well-known chain.

Therefore, we shouldn't have a test that tries to test something that should never happen. What's funny is that the only reason why this test is passing is because [this line of code](https://github.com/paritytech/substrate-connect/blob/3911d973b7e7883f763515ce74a53faaf4048922/packages/connect/src/connector/extension.ts#L200) is throwing due to the fact that the tests run before the script that's responsible for generating the specs, therefore making the [`getSpec` function throw for a valid key](https://github.com/paritytech/substrate-connect/blob/3911d973b7e7883f763515ce74a53faaf4048922/packages/connect/src/connector/specs/index.ts#L18). However, if you try to run the test _after_ generating the specs, then the test fails b/c the promise never resolves or rejects :upside_down_face:.

So, yeah, that test is bogus and it should be removed.