### PR TITLE
CI: fix gha set-output command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3.5.2
     - id: package-version
-      run: echo "::set-output name=version::`jq .version ./projects/extension/package.json`"
+      run: echo "version=`jq .version ./projects/extension/package.json`" >> $GITHUB_OUTPUT
     - id: webpack-version
-      run: echo "::set-output name=version::`grep -rnw './projects/extension/webpack.config.js' -e 'PKG_VERSION' | grep -o '".*"'`"
+      run: echo "version=`grep -rnw './projects/extension/webpack.config.js' -e 'PKG_VERSION' | grep -o '".*"'`" >> $GITHUB_OUTPUT
     - id: manifest-version
-      run: echo "::set-output name=version::`jq .version ./projects/extension/public/manifest.json`"
+      run: echo "version=`jq .version ./projects/extension/public/manifest.json`" >> $GITHUB_OUTPUT
     - run: exit 1
       if: ${{ steps.package-version.outputs.version != steps.webpack-version.outputs.version }}
     - run: exit 1
@@ -26,7 +26,7 @@ jobs:
       if: ${{ steps.package-version.outputs.version != steps.manifest-version.outputs.version }}
     - run: exit 1
       if: ${{steps.package-version.outputs.version == '' || steps.webpack-version.outputs.version == ''  || steps.manifest-version.outputs.version == '' }}
-    
+
   build:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/update-chain-specs.yml
+++ b/.github/workflows/update-chain-specs.yml
@@ -35,7 +35,7 @@ jobs:
           ./websocat_linux64 -n1 -B 99999999 ${{ matrix.rpc-node-address }} > rpc_answer.json
     - run: cat ./rpc_answer.json | jq .result > chain_spec.json
     - id: get-chain-id  # Reads the `id` field in the newly-downloaded chain spec
-      run: echo "::set-output name=id::`jq -r .id ./chain_spec.json`"
+      run: echo "id=`jq -r .id ./chain_spec.json`" >> $GITHUB_OUTPUT
     - if: ${{ steps.get-chain-id.outputs.id == '' }}
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
GitHub is going to deprecate `save-state` and `set-output` commands. [More info](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

This PR adjusts GHA workflow to use new syntax.

Part of https://github.com/paritytech/ci_cd/issues/805