### PR TITLE
feat: use substrate-connect in an offscreen document [WIP]

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@babel/preset-env": "^7.22.5",
     "@babel/preset-react": "^7.22.5",
     "@types/asap": "^2.0.0",
-    "@types/chrome": "^0.0.237",
+    "@types/chrome": "^0.0.244",
     "@types/jsdom": "^21.1.1",
     "@types/node": "^18.16.17",
     "@types/qrcode.react": "^1.0.2",

--- a/projects/extension/public/manifest-v3.json
+++ b/projects/extension/public/manifest-v3.json
@@ -6,7 +6,7 @@
   "short_name": "substrate-connect",
   "version": "0.2.9",
   "manifest_version": 3,
-  "permissions": ["notifications", "storage", "tabs", "alarms"],
+  "permissions": ["notifications", "storage", "tabs", "alarms", "offscreen"],
   "background": {
     "service_worker": "background.js"
   },

--- a/projects/extension/public/offscreen.html
+++ b/projects/extension/public/offscreen.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<script src="offscreen.js"></script>

--- a/projects/extension/src/background/createOffscreenPort.ts
+++ b/projects/extension/src/background/createOffscreenPort.ts
@@ -1,0 +1,52 @@
+let port: chrome.runtime.Port | undefined
+export async function createOffscreenPort() {
+  await setupOffscreenDocument("offscreen.html")
+  if (!port) {
+    port = chrome.runtime.connect({ name: "offscreen" })
+    port.onDisconnect.addListener(() => {
+      port = undefined
+    })
+  }
+  return port
+}
+
+let creatingOffscreenDocument: Promise<void> | undefined = undefined
+async function setupOffscreenDocument(url: string) {
+  // Check all windows controlled by the service worker to see if one
+  // of them is the offscreen document with the given path
+  if (!creatingOffscreenDocument && (await hasOffscreenDocument(url))) return
+
+  // create offscreen document
+  if (creatingOffscreenDocument) {
+    await creatingOffscreenDocument
+  } else {
+    creatingOffscreenDocument = chrome.offscreen.createDocument({
+      url,
+      reasons: [chrome.offscreen.Reason.WORKERS],
+      justification: "instantiate smoldot in a different thread",
+    })
+    await creatingOffscreenDocument
+    creatingOffscreenDocument = undefined
+  }
+}
+
+async function hasOffscreenDocument(path: string) {
+  const offscreenUrl = chrome.runtime.getURL(path)
+  // TODO: fix TS, chrome.runtime.getContexts was added in Chrome 116
+  if (chrome.runtime.getContexts) {
+    const existingContexts = await chrome.runtime.getContexts({
+      contextTypes: ["OFFSCREEN_DOCUMENT"],
+      documentUrls: [offscreenUrl],
+    })
+    return existingContexts.length > 0
+  }
+  // TODO: fix TS, clients is a service worker object
+  const matchedClients = await clients.matchAll()
+
+  for (const client of matchedClients) {
+    if (client.url === offscreenUrl) {
+      return true
+    }
+  }
+  return false
+}

--- a/projects/extension/src/background/index.ts
+++ b/projects/extension/src/background/index.ts
@@ -1,5 +1,9 @@
 import { AddChainError, MalformedJsonRpcError } from "smoldot"
 import { AddChain, Chain, createScClient } from "@substrate/connect"
+import type {
+  ToApplication,
+  ToExtension,
+} from "@substrate/connect-extension-protocol"
 
 import { updateDatabases } from "./updateDatabases"
 import { enqueueAsyncFn } from "./enqueueAsyncFn"
@@ -9,6 +13,7 @@ import * as environment from "../environment"
 import { PORTS } from "../shared"
 import type { ToBackground, ToContent } from "../protocol"
 import { loadWellKnownChains } from "./loadWellKnownChains"
+import { createOffscreenPort } from "./createOffscreenPort"
 
 enqueueAsyncFn(() => environment.clearAllActiveChains())
 
@@ -95,6 +100,7 @@ const postMessage = (port: chrome.runtime.Port, message: ToContent) =>
 chrome.runtime.onConnect.addListener((port) => {
   if ([PORTS.POPUP, PORTS.OPTIONS].includes(port.name)) {
     const untrackChains = trackChains(
+      // TODO: switch offscreen substrate-connect/smoldot
       scClient,
       () =>
         Object.fromEntries(
@@ -128,113 +134,151 @@ chrome.runtime.onConnect.addListener((port) => {
     )
     port.onDisconnect.addListener(untrackChains)
   } else if (port.name === PORTS.CONTENT && port.sender?.tab?.id) {
-    const tab = port.sender.tab
-    const tabId = tab.id!
-    resetTab(tabId)
+    ;(chrome.offscreen
+      ? handleMessagesInOffscreen
+      : handleMessagesInBackground)(port)
+  } else {
+    console.warn("unrecognized port.name", port.name, port.sender?.tab?.url)
+  }
+})
 
-    port.onDisconnect.addListener(() => resetTab(tabId))
+function handleMessagesInBackground(port: chrome.runtime.Port) {
+  if (!port.sender?.tab?.id) return
 
-    port.onMessage.addListener(async (msg: ToBackground, port) => {
-      switch (msg.type) {
-        case "keep-alive": {
-          postMessage(port, { type: "keep-alive-ack" })
+  const tab = port.sender.tab
+  const tabId = tab.id!
+  resetTab(tabId)
+
+  port.onDisconnect.addListener(() => resetTab(tabId))
+
+  port.onMessage.addListener(async (msg: ToBackground, port) => {
+    switch (msg.type) {
+      case "keep-alive": {
+        postMessage(port, { type: "keep-alive-ack" })
+        return
+      }
+
+      case "add-chain":
+      case "add-well-known-chain": {
+        if (activeChains[msg.chainId]) {
+          postMessage(port, {
+            origin: "substrate-connect-extension",
+            type: "error",
+            chainId: msg.chainId,
+            errorMessage: "Requested chainId already in use",
+          })
           return
         }
 
-        case "add-chain":
-        case "add-well-known-chain": {
-          if (activeChains[msg.chainId]) {
+        activeChains[msg.chainId] = { tab }
+
+        const isWellKnown = msg.type === "add-well-known-chain"
+
+        try {
+          let addChainOptions: Parameters<AddChain>
+          const jsonRpcCallback = (jsonRpcMessage: string) => {
             postMessage(port, {
               origin: "substrate-connect-extension",
-              type: "error",
+              type: "rpc",
               chainId: msg.chainId,
-              errorMessage: "Requested chainId already in use",
+              jsonRpcMessage,
             })
+          }
+          if (isWellKnown) {
+            const chainSpec = (await loadWellKnownChains()).get(msg.chainName)
+
+            // Given that the chain name is user input, we have no guarantee that it is correct. The
+            // extension might report that it doesn't know about this well-known chain.
+            if (!chainSpec) throw new AddChainError("Unknown well-known chain")
+
+            const databaseContent = await environment.get({
+              type: "database",
+              chainName: msg.chainName,
+            })
+            addChainOptions = [
+              chainSpec,
+              jsonRpcCallback,
+              undefined,
+              databaseContent,
+            ]
+          } else {
+            addChainOptions = [
+              msg.chainSpec,
+              jsonRpcCallback,
+              await Promise.all(
+                msg.potentialRelayChainIds
+                  .filter((c) => !!activeChains[c]?.chain)
+                  .map((c) => activeChains[c]?.chain!),
+              ),
+            ]
+          }
+          const chain = await scClient.addChain(...addChainOptions)
+
+          // As documented in the protocol, if a "remove-chain" message was received before
+          // a "chain-ready" message was sent back, the chain can be discarded
+          if (!activeChains[msg.chainId]) {
+            chain.remove()
             return
           }
 
-          activeChains[msg.chainId] = { tab }
+          enqueueAsyncFn(async () => {
+            const chains =
+              (await environment.get({
+                type: "activeChains",
+                tabId,
+              })) ?? []
 
-          const isWellKnown = msg.type === "add-well-known-chain"
-
-          try {
-            let addChainOptions: Parameters<AddChain>
-            const jsonRpcCallback = (jsonRpcMessage: string) => {
-              postMessage(port, {
-                origin: "substrate-connect-extension",
-                type: "rpc",
-                chainId: msg.chainId,
-                jsonRpcMessage,
-              })
-            }
-            if (isWellKnown) {
-              const chainSpec = (await loadWellKnownChains()).get(msg.chainName)
-
-              // Given that the chain name is user input, we have no guarantee that it is correct. The
-              // extension might report that it doesn't know about this well-known chain.
-              if (!chainSpec)
-                throw new AddChainError("Unknown well-known chain")
-
-              const databaseContent = await environment.get({
-                type: "database",
-                chainName: msg.chainName,
-              })
-              addChainOptions = [
-                chainSpec,
-                jsonRpcCallback,
-                undefined,
-                databaseContent,
-              ]
-            } else {
-              addChainOptions = [
-                msg.chainSpec,
-                jsonRpcCallback,
-                await Promise.all(
-                  msg.potentialRelayChainIds
-                    .filter((c) => !!activeChains[c]?.chain)
-                    .map((c) => activeChains[c]?.chain!),
-                ),
-              ]
-            }
-            const chain = await scClient.addChain(...addChainOptions)
-
-            // As documented in the protocol, if a "remove-chain" message was received before
-            // a "chain-ready" message was sent back, the chain can be discarded
-            if (!activeChains[msg.chainId]) {
-              chain.remove()
-              return
-            }
-
-            enqueueAsyncFn(async () => {
-              const chains =
-                (await environment.get({
-                  type: "activeChains",
-                  tabId,
-                })) ?? []
-
-              chains.push({
-                chainId: msg.chainId,
-                isWellKnown,
-                chainName: isWellKnown
-                  ? msg.chainName
-                  : (JSON.parse(msg.chainSpec).name as string),
-                isSyncing: false,
-                peers: 0,
-                tab: {
-                  id: tab.id!,
-                  url: tab.url!,
-                },
-              })
-              await environment.set({ type: "activeChains", tabId }, chains)
-            })
-            activeChains[msg.chainId].chain = chain
-            activeChains[msg.chainId].addChainOptions = addChainOptions
-            postMessage(port, {
-              origin: "substrate-connect-extension",
-              type: "chain-ready",
+            chains.push({
               chainId: msg.chainId,
+              isWellKnown,
+              chainName: isWellKnown
+                ? msg.chainName
+                : (JSON.parse(msg.chainSpec).name as string),
+              isSyncing: false,
+              peers: 0,
+              tab: {
+                id: tab.id!,
+                url: tab.url!,
+              },
             })
-          } catch (error) {
+            await environment.set({ type: "activeChains", tabId }, chains)
+          })
+          activeChains[msg.chainId].chain = chain
+          activeChains[msg.chainId].addChainOptions = addChainOptions
+          postMessage(port, {
+            origin: "substrate-connect-extension",
+            type: "chain-ready",
+            chainId: msg.chainId,
+          })
+        } catch (error) {
+          removeChain(msg.chainId)
+          postMessage(port, {
+            origin: "substrate-connect-extension",
+            type: "error",
+            chainId: msg.chainId,
+            errorMessage:
+              error instanceof Error
+                ? error.toString()
+                : "Unknown error when adding chain",
+          })
+        }
+
+        return
+      }
+
+      case "rpc": {
+        const { chain } = activeChains[msg.chainId]
+
+        // If the chainId is invalid, the message is silently discarded, as documented.
+        if (!chain) return
+
+        try {
+          chain.sendJsonRpc(msg.jsonRpcMessage)
+        } catch (error) {
+          // As documented in the protocol, malformed JSON-RPC requests are silently ignored.
+          if (error instanceof MalformedJsonRpcError) {
+            return
+          } else {
             removeChain(msg.chainId)
             postMessage(port, {
               origin: "substrate-connect-extension",
@@ -243,50 +287,184 @@ chrome.runtime.onConnect.addListener((port) => {
               errorMessage:
                 error instanceof Error
                   ? error.toString()
-                  : "Unknown error when adding chain",
+                  : "Unknown error when sending RPC message",
             })
           }
-
-          return
         }
 
-        case "rpc": {
-          const { chain } = activeChains[msg.chainId]
-
-          // If the chainId is invalid, the message is silently discarded, as documented.
-          if (!chain) return
-
-          try {
-            chain.sendJsonRpc(msg.jsonRpcMessage)
-          } catch (error) {
-            // As documented in the protocol, malformed JSON-RPC requests are silently ignored.
-            if (error instanceof MalformedJsonRpcError) {
-              return
-            } else {
-              removeChain(msg.chainId)
-              postMessage(port, {
-                origin: "substrate-connect-extension",
-                type: "error",
-                chainId: msg.chainId,
-                errorMessage:
-                  error instanceof Error
-                    ? error.toString()
-                    : "Unknown error when sending RPC message",
-              })
-            }
-          }
-
-          return
-        }
-
-        case "remove-chain": {
-          // If the chainId is invalid, the message is silently discarded, as documented.
-          removeChain(msg.chainId)
-          return
-        }
+        return
       }
-    })
-  } else {
-    console.warn("unrecognized port.name", port.name, port.sender?.tab?.url)
+
+      case "remove-chain": {
+        // If the chainId is invalid, the message is silently discarded, as documented.
+        removeChain(msg.chainId)
+        return
+      }
+    }
+  })
+}
+
+function handleMessagesInOffscreen(port: chrome.runtime.Port) {
+  if (!port.sender?.tab?.id) return
+
+  const tab = port.sender.tab
+  const tabId = tab.id!
+  resetTab(tabId)
+
+  const handleOffscreenMessage = (msg: ToApplication) => {
+    if (activeChains[msg.chainId].tab.id !== port.sender?.tab?.id) return
+    if (msg.type === "error") removeChain(msg.chainId)
+
+    postMessage(port, msg)
   }
-})
+  const offscreenPortPromise = createOffscreenPort()
+  port.onDisconnect.addListener(async () => {
+    resetTab(tabId)
+    const offscreenPort = await offscreenPortPromise
+    offscreenPort.onMessage.removeListener(handleOffscreenMessage)
+    // TODO: disconnect if there are no activeChains
+    // if (Object.keys(activeChains).length === 0) offscreenPort.disconnect()
+  })
+  offscreenPortPromise.then((offscreenPort) =>
+    offscreenPort.onMessage.addListener(handleOffscreenMessage),
+  )
+
+  port.onMessage.addListener(async (msg: ToBackground) => {
+    const offscreenPort = await offscreenPortPromise
+    switch (msg.type) {
+      case "keep-alive": {
+        postMessage(port, { type: "keep-alive-ack" })
+        return
+      }
+      case "add-well-known-chain": {
+        if (activeChains[msg.chainId]) {
+          postMessage(port, {
+            origin: "substrate-connect-extension",
+            type: "error",
+            chainId: msg.chainId,
+            errorMessage: "Requested chainId already in use",
+          })
+          return
+        }
+        const chainSpec = (await loadWellKnownChains()).get(msg.chainName)
+
+        // Given that the chain name is user input, we have no guarantee that it is correct. The
+        // extension might report that it doesn't know about this well-known chain.
+        if (!chainSpec) {
+          postMessage(port, {
+            origin: "substrate-connect-extension",
+            type: "error",
+            chainId: msg.chainId,
+            errorMessage: "Unknown well-known chain",
+          })
+          return
+        }
+
+        const databaseContent = await environment.get({
+          type: "database",
+          chainName: msg.chainName,
+        })
+        activeChains[msg.chainId] = {
+          tab,
+          chain: {
+            sendJsonRpc() {},
+            remove() {
+              offscreenPort.postMessage({
+                origin: "substrate-connect-client",
+                type: "remove-chain",
+                chainId: msg.chainId,
+              } as ToExtension)
+            },
+          },
+          addChainOptions: [chainSpec, undefined, undefined, databaseContent],
+        }
+        // TODO: send databaseContent to add-chain
+        offscreenPort.postMessage({
+          origin: "substrate-connect-client",
+          type: "add-chain",
+          chainId: msg.chainId,
+          chainSpec,
+          potentialRelayChainIds: [],
+        } as ToExtension)
+
+        enqueueAsyncFn(async () => {
+          const chains =
+            (await environment.get({
+              type: "activeChains",
+              tabId,
+            })) ?? []
+
+          chains.push({
+            chainId: msg.chainId,
+            isWellKnown: true,
+            chainName: msg.chainName,
+            isSyncing: false,
+            peers: 0,
+            tab: {
+              id: tab.id!,
+              url: tab.url!,
+            },
+          })
+          await environment.set({ type: "activeChains", tabId }, chains)
+        })
+        return
+      }
+      case "add-chain": {
+        if (activeChains[msg.chainId]) {
+          postMessage(port, {
+            origin: "substrate-connect-extension",
+            type: "error",
+            chainId: msg.chainId,
+            errorMessage: "Requested chainId already in use",
+          })
+          return
+        }
+        activeChains[msg.chainId] = {
+          tab,
+          chain: {
+            sendJsonRpc() {},
+            remove() {
+              offscreenPort.postMessage({
+                origin: "substrate-connect-client",
+                type: "remove-chain",
+                chainId: msg.chainId,
+              } as ToExtension)
+            },
+          },
+          // FIXME: addChainOptions expects potentialRelayChains
+          // addChainOptions
+        }
+        offscreenPort.postMessage(msg)
+        enqueueAsyncFn(async () => {
+          const chains =
+            (await environment.get({
+              type: "activeChains",
+              tabId,
+            })) ?? []
+
+          chains.push({
+            chainId: msg.chainId,
+            isWellKnown: false,
+            chainName: JSON.parse(msg.chainSpec).name as string,
+            isSyncing: false,
+            peers: 0,
+            tab: {
+              id: tab.id!,
+              url: tab.url!,
+            },
+          })
+          await environment.set({ type: "activeChains", tabId }, chains)
+        })
+        return
+      }
+      case "remove-chain": {
+        removeChain(msg.chainId)
+        return
+      }
+      case "rpc": {
+        offscreenPort.postMessage(msg)
+        return
+      }
+    }
+  })
+}

--- a/projects/extension/src/offscreen.ts
+++ b/projects/extension/src/offscreen.ts
@@ -1,0 +1,121 @@
+import { Chain, createScClient } from "@substrate/connect"
+import {
+  ToApplication,
+  ToExtension,
+} from "@substrate/connect-extension-protocol"
+import { MalformedJsonRpcError } from "smoldot"
+
+const client = createScClient({ embeddedNodeConfig: { maxLogLevel: 3 } })
+const activeChains: Record<string, { chain: Chain | undefined }> = {}
+
+const postMessage = (port: chrome.runtime.Port, message: ToApplication) =>
+  port.postMessage(message)
+
+chrome.runtime.onConnect.addListener((port) => {
+  if (port.name !== "offscreen") return
+
+  port.onDisconnect.addListener(() => window.close())
+
+  port.onMessage.addListener(async (msg: ToExtension) => {
+    switch (msg.type) {
+      // add-well-known-chain is transformed to add-chain in the background script.
+      // This is because only the chrome.runtime messaging APIs are exposed to
+      // the offscreen document so it is not possible to access chrome.storage
+      // to get well-known-chain chain-spec
+      case "add-chain": {
+        if (activeChains[msg.chainId]) {
+          postMessage(port, {
+            origin: "substrate-connect-extension",
+            type: "error",
+            chainId: msg.chainId,
+            errorMessage: "Requested chainId already in use",
+          })
+          return
+        }
+        try {
+          activeChains[msg.chainId] = { chain: undefined }
+          const chain = await client.addChain(
+            msg.chainSpec,
+            (jsonRpcMessage) =>
+              postMessage(port, {
+                origin: "substrate-connect-extension",
+                type: "rpc",
+                chainId: msg.chainId,
+                jsonRpcMessage,
+              }),
+            msg.potentialRelayChainIds
+              .map((chainId) => activeChains[chainId].chain)
+              .filter((chain): chain is Chain => !!chain),
+          )
+
+          if (!activeChains[msg.chainId]) {
+            chain.remove()
+          }
+
+          activeChains[msg.chainId] = { chain }
+
+          postMessage(port, {
+            origin: "substrate-connect-extension",
+            type: "chain-ready",
+            chainId: msg.chainId,
+          })
+        } catch (error) {
+          removeChain(msg.chainId)
+          postMessage(port, {
+            origin: "substrate-connect-extension",
+            type: "error",
+            chainId: msg.chainId,
+            errorMessage:
+              error instanceof Error
+                ? error.toString()
+                : "Unknown error when adding chain",
+          })
+        }
+        break
+      }
+      case "rpc": {
+        if (!activeChains[msg.chainId]) return
+
+        const { chain } = activeChains[msg.chainId]
+
+        try {
+          chain?.sendJsonRpc(msg.jsonRpcMessage)
+        } catch (error) {
+          // As documented in the protocol, malformed JSON-RPC requests are silently ignored.
+          if (error instanceof MalformedJsonRpcError) {
+            return
+          } else {
+            removeChain(msg.chainId)
+            postMessage(port, {
+              origin: "substrate-connect-extension",
+              type: "error",
+              chainId: msg.chainId,
+              errorMessage:
+                error instanceof Error
+                  ? error.toString()
+                  : "Unknown error when sending RPC message",
+            })
+          }
+        }
+
+        break
+      }
+      case "remove-chain": {
+        removeChain(msg.chainId)
+        break
+      }
+    }
+  })
+})
+
+function removeChain(chainId: string) {
+  if (!activeChains[chainId]) return
+
+  const { chain } = activeChains[chainId]
+  delete activeChains[chainId]
+  try {
+    chain?.remove()
+  } catch (error) {
+    console.error("error removing chain", error)
+  }
+}

--- a/projects/extension/webpack.config.js
+++ b/projects/extension/webpack.config.js
@@ -10,6 +10,7 @@ const config = {
     options: path.resolve("src/options.tsx"),
     content: path.resolve("src/content/index.ts"),
     background: path.resolve("src/background/index.ts"),
+    offscreen: path.resolve("src/offscreen.ts"),
   },
   output: {
     path: path.resolve("dist"),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4447,13 +4447,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/chrome@npm:^0.0.237":
-  version: 0.0.237
-  resolution: "@types/chrome@npm:0.0.237"
+"@types/chrome@npm:^0.0.244":
+  version: 0.0.244
+  resolution: "@types/chrome@npm:0.0.244"
   dependencies:
     "@types/filesystem": "*"
     "@types/har-format": "*"
-  checksum: 9dfb0070065ca4667ef2fa9ec45af2f604b9ba98b6429d38607c6bfcc8dc2178e83eea4eeedbe88a8299dfe9dda029c9341e454c4eff7b715b90e9d5fc7b990d
+  checksum: 45f3ba21b558fb9de18b443cfe24864ccd6ae5e90d648deab3f3ae3a3240e11933e8091a1301bbe9136ec72617acc450f31a1362719c3d381f4042e90f8c79be
   languageName: node
   linkType: hard
 
@@ -15598,7 +15598,7 @@ __metadata:
     "@babel/preset-env": ^7.22.5
     "@babel/preset-react": ^7.22.5
     "@types/asap": ^2.0.0
-    "@types/chrome": ^0.0.237
+    "@types/chrome": ^0.0.244
     "@types/jsdom": ^21.1.1
     "@types/node": ^18.16.17
     "@types/qrcode.react": ^1.0.2


### PR DESCRIPTION
https://github.com/paritytech/capi/issues/47

Related to #1515 

TODOs
- [ ] for options/popup UIs, use offscreen substrate-connect to track chain updates 
- [ ] for options/popup UIs, fix `potentialRelayChains` to track chain updates
- [ ] update background-2-offscreen protocol to pass an optional `databaseContent` (because offscreen docs do not have `chorme.storage` access)
- [ ] dedupe code for handling messages for subsctrate-connect in the background vs in an offscreen document
