### PR TITLE
feat: add @substrate/connect/worker

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -16,6 +16,10 @@
       "require": "./dist/cjs/index.js"
     },
     "./worker": {
+      "node": {
+        "import": "./dist/mjs/worker-node.js",
+        "require": "./dist/cjs/worker-node.js"
+      },
       "import": "./dist/mjs/worker.js",
       "require": "./dist/cjs/worker.js"
     }

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -14,6 +14,10 @@
     ".": {
       "import": "./dist/mjs/index.js",
       "require": "./dist/cjs/index.js"
+    },
+    "./worker": {
+      "import": "./dist/mjs/worker.js",
+      "require": "./dist/cjs/worker.js"
     }
   },
   "repository": {

--- a/packages/connect/src/connector/smoldot-light.ts
+++ b/packages/connect/src/connector/smoldot-light.ts
@@ -38,6 +38,7 @@ const getClientAndIncRef = (config: Config): Promise<Client> => {
 
   const newClientPromise = getStart().then((start) =>
     start({
+      portToWorker: config.portToWorkerFactory?.(),
       forbidTcp: true, // In order to avoid confusing inconsistencies between browsers and NodeJS, TCP connections are always disabled.
       forbidNonLocalWs: true, // Prevents browsers from emitting warnings if smoldot tried to establish non-secure WebSocket connections
       maxLogLevel: 9999999, // The actual level filtering is done in the logCallback
@@ -133,6 +134,8 @@ export interface Config {
    * value will be used.
    */
   maxLogLevel?: number
+
+  portToWorkerFactory?: () => MessagePort
 }
 
 /**

--- a/packages/connect/src/worker-node.ts
+++ b/packages/connect/src/worker-node.ts
@@ -1,12 +1,10 @@
-/// <reference lib="WebWorker" />
-
 // @ts-ignore TODO: fix types in smoldot/worker
 import * as smoldot from "smoldot/worker"
+import { parentPort } from "node:worker_threads"
 
-declare var self: DedicatedWorkerGlobalScope
-
-self.onmessage = ({ data }) =>
+parentPort!.once("message", (data) =>
   smoldot
     .run(data)
     .catch((error: any) => console.error("[smoldot-worker]", error))
-    .finally(self.close)
+    .finally(() => process.exit()),
+)

--- a/packages/connect/src/worker.ts
+++ b/packages/connect/src/worker.ts
@@ -1,0 +1,9 @@
+// @ts-ignore TODO: fix types in smoldot/worker
+import * as smoldot from "smoldot/worker"
+
+self.onmessage = ({ data }) => {
+  smoldot
+    .run(data)
+    .catch((error: any) => console.error("[smoldot-worker]", error))
+    .finally(self.close)
+}

--- a/packages/connect/src/worker.ts
+++ b/packages/connect/src/worker.ts
@@ -1,5 +1,9 @@
+/// <reference lib="WebWorker" />
+
 // @ts-ignore TODO: fix types in smoldot/worker
 import * as smoldot from "smoldot/worker"
+
+declare var self: DedicatedWorkerGlobalScope
 
 self.onmessage = ({ data }) => {
   smoldot


### PR DESCRIPTION
Closes https://github.com/paritytech/capi/issues/47

Add `./worker` subpath to `@substrate/connect`.
Then, `@substrate/connect/worker` is a WebWorker that runs smoldot (see [smoldot usage with a web worker](https://smol-dot.github.io/smoldot/doc-javascript/#md:usage-with-a-worker))

Test it with `vite` [WebWorkers](https://v3.vitejs.dev/guide/features.html#web-workers)

```ts
import { createScClient } from "@substrate/connect"
import ScWorker from "@substrate/connect/worker?worker"

createScClient({
  embeddedNodeConfig: {
    workerFactory: () => new ScWorker(),
  },
})
  .addWellKnownChain("polkadot", (response) =>
    console.log({ response }),
  )
  .then((chain) => {
    chain.sendJsonRpc(
      JSON.stringify({
        jsonrpc: "2.0",
        id: "1",
        method: "chainHead_unstable_follow",
        params: [true],
      }),
    )
  })
```

<img width="899" alt="image" src="https://github.com/paritytech/substrate-connect/assets/1209171/c0791922-cea6-401a-ae13-b836e9b22173">


Test it with Node

```js
// main.mjs
import { createScClient, WellKnownChain } from "@substrate/connect"
import { Worker } from "node:worker_threads"

createScClient({
  embeddedNodeConfig: {
    workerFactory: () => new Worker("./worker.mjs"),
  },
})
  .addWellKnownChain(WellKnownChain.polkadot, (response) =>
    console.log({ response }),
  )
  .then((chain) => {
    chain.sendJsonRpc(
      JSON.stringify({
        jsonrpc: "2.0",
        id: "1",
        method: "chainHead_unstable_follow",
        params: [true],
      }),
    )
  })

```

```js
// worker.mjs
import "@substrate/connect/worker"
```