### PR TITLE
feat: simplify `tsconfig.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "deep-clean": "yarn workspaces foreach run deep-clean && rm -rf node_modules",
     "clean": " yarn workspaces foreach run clean",
     "lint": "prettier --check . && yarn workspaces foreach run lint",
-    "build": "yarn workspaces foreach run build",
+    "build": "yarn workspaces foreach --topological run build",
     "test": "yarn workspaces foreach run test",
     "dev:api-docs": "concurrently -n typedoc,http-server 'nodemon -e ts --watch ./packages/connect --watch ./packages/connect-extension-protocol --exec typedoc --entryPoints ./packages/connect/src/index.ts --entryPoints ./packages/connect-extension-protocol/src/index.ts' 'http-server _site/api'",
     "dev:burnr": "yarn workspace @substrate/burnr run dev",

--- a/packages/connect-extension-protocol/tsconfig-cjs.json
+++ b/packages/connect-extension-protocol/tsconfig-cjs.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "./dist/cjs",
-    "target": "es2015"
-  }
+    "target": "es2015",
+    "noEmit": false,
+    "verbatimModuleSyntax": false
+  },
+  "include": ["src"]
 }

--- a/packages/connect-extension-protocol/tsconfig-cjs.json
+++ b/packages/connect-extension-protocol/tsconfig-cjs.json
@@ -4,8 +4,7 @@
     "module": "commonjs",
     "outDir": "./dist/cjs",
     "target": "es2015",
-    "noEmit": false,
-    "verbatimModuleSyntax": false
+    "noEmit": false
   },
   "include": ["src"]
 }

--- a/packages/connect-extension-protocol/tsconfig-mjs.json
+++ b/packages/connect-extension-protocol/tsconfig-mjs.json
@@ -3,6 +3,8 @@
   "compilerOptions": {
     "module": "es2020",
     "outDir": "./dist/mjs",
-    "target": "es2018"
-  }
+    "target": "es2018",
+    "noEmit": false
+  },
+  "include": ["src"]
 }

--- a/packages/connect-extension-protocol/tsconfig.json
+++ b/packages/connect-extension-protocol/tsconfig.json
@@ -1,14 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
-    "baseUrl": ".",
-    "rootDir": "./src",
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "strict": true,
+    "composite": true,
+    "rootDir": "src",
     "downlevelIteration": true
   }
 }

--- a/packages/connect/.eslintignore
+++ b/packages/connect/.eslintignore
@@ -1,10 +1,15 @@
 # don't ever lint node_modules
+
 node_modules
+
 # don't lint build output (make sure it's set to your correct build folder name)
+
 dist
 coverage
+
 # don't lint .cache
+
 .chains
 
-src/connector/specs/*.json
-src/connector/specs/js/*.ts
+src/connector/specs/_.json
+src/connector/specs/js/_.ts

--- a/packages/connect/src/connector/extension.test.ts
+++ b/packages/connect/src/connector/extension.test.ts
@@ -4,8 +4,8 @@
 import { it, describe, expect } from "vitest"
 import { randomBytes } from "crypto"
 import {
-  ToApplication,
-  ToExtension,
+  type ToApplication,
+  type ToExtension,
 } from "@substrate/connect-extension-protocol"
 import { createScClient } from "./extension"
 import { AlreadyDestroyedError, CrashError } from "./types"
@@ -22,7 +22,7 @@ if (!globalThis.crypto) {
       tmp.set(randomBytesBuffer)
       const test = new DataView(arr.buffer)
       for (let i = 0; i < tmp.length; i++) {
-        test.setUint8(i, tmp[i])
+        test.setUint8(i, tmp[i]!)
       }
       return arr
     },

--- a/packages/connect/src/connector/extension.ts
+++ b/packages/connect/src/connector/extension.ts
@@ -6,9 +6,9 @@ import {
   AlreadyDestroyedError,
   CrashError,
   JsonRpcDisabledError,
-  Chain,
-  JsonRpcCallback,
-  ScClient,
+  type Chain,
+  type JsonRpcCallback,
+  type ScClient,
 } from "./types.js"
 import { WellKnownChain } from "../WellKnownChain.js"
 import { getSpec } from "./specs/index.js"
@@ -28,7 +28,7 @@ function getRandomChainId(): string {
   const arr = new BigUint64Array(2)
   // It can only be used from the browser, so this is fine.
   crypto.getRandomValues(arr)
-  const result = (arr[1] << BigInt(64)) | arr[0]
+  const result = (arr[1]! << BigInt(64)) | arr[0]!
   return result.toString(36)
 }
 

--- a/packages/connect/src/connector/index.ts
+++ b/packages/connect/src/connector/index.ts
@@ -1,12 +1,12 @@
 import {
   createScClient as smoldotScClient,
-  Config as EmbeddedNodeConfig,
+  type Config as EmbeddedNodeConfig,
 } from "./smoldot-light.js"
 import { createScClient as extensionScClient } from "./extension.js"
 import { DOM_ELEMENT_ID } from "@substrate/connect-extension-protocol"
 
 export * from "./types.js"
-export { EmbeddedNodeConfig }
+export type { EmbeddedNodeConfig }
 
 /**
  * `true` if the substrate-connect extension is installed and available.

--- a/packages/connect/src/connector/smoldot-light.test.ts
+++ b/packages/connect/src/connector/smoldot-light.test.ts
@@ -181,23 +181,25 @@ describe("SmoldotConnect::smoldot", () => {
         const { addChain, addWellKnownChain } = smoldot.createScClient()
         const chainSpec = "testChainSpec"
         await addChain(chainSpec)
-        let mockedChain = mockedSmoldotLight.getLatestClient()._getLatestChain()
+        let mockedChain = mockedSmoldotLight
+          .getLatestClient()
+          ._getLatestChain()!
         expect(mockedChain._addChainOptions.chainSpec).toEqual(chainSpec)
 
         await addWellKnownChain(WellKnownChain.polkadot)
-        mockedChain = mockedSmoldotLight.getLatestClient()._getLatestChain()
+        mockedChain = mockedSmoldotLight.getLatestClient()._getLatestChain()!
         expect(mockedChain._addChainOptions.chainSpec).toEqual(
           "fake-polkadot-spec",
         )
 
         await addWellKnownChain(WellKnownChain.ksmcc3)
-        mockedChain = mockedSmoldotLight.getLatestClient()._getLatestChain()
+        mockedChain = mockedSmoldotLight.getLatestClient()._getLatestChain()!
         expect(mockedChain._addChainOptions.chainSpec).toEqual(
           "fake-ksmcc3-spec",
         )
 
         await addWellKnownChain(WellKnownChain.rococo_v2_2)
-        mockedChain = mockedSmoldotLight.getLatestClient()._getLatestChain()
+        mockedChain = mockedSmoldotLight.getLatestClient()._getLatestChain()!
         expect(mockedChain._addChainOptions.chainSpec).toEqual(
           "fake-rococo_v2_2-spec",
         )
@@ -212,14 +214,14 @@ describe("SmoldotConnect::smoldot", () => {
             .fill(null)
             .map(() => addChain("")),
         )
-        prevChains[0].remove()
+        prevChains[0]!.remove()
         await addChain("")
         const mockedChains = mockedSmoldotLight
           .getLatestClient()
           ._getChains()
           .slice(-4)
         const lastMockedChain = mockedChains[3]
-        expect(lastMockedChain._addChainOptions.potentialRelayChains).toEqual([
+        expect(lastMockedChain!._addChainOptions.potentialRelayChains).toEqual([
           mockedChains[1],
           mockedChains[2],
         ])

--- a/packages/connect/src/connector/smoldot-light.ts
+++ b/packages/connect/src/connector/smoldot-light.ts
@@ -1,10 +1,15 @@
-import { Chain as SChain, Client, ClientOptions, QueueFullError } from "smoldot"
+import {
+  type Chain as SChain,
+  type Client,
+  type ClientOptions,
+  QueueFullError,
+} from "smoldot"
 import { getSpec } from "./specs/index.js"
 import {
-  AddChain,
-  AddWellKnownChain,
-  Chain,
-  ScClient,
+  type AddChain,
+  type AddWellKnownChain,
+  type Chain,
+  type ScClient,
   AlreadyDestroyedError,
   CrashError,
   JsonRpcDisabledError,

--- a/packages/connect/tsconfig-cjs.json
+++ b/packages/connect/tsconfig-cjs.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "./dist/cjs",
-    "target": "es2015"
+    "target": "es2015",
+    "noEmit": false
   },
   "references": [{ "path": "../connect-extension-protocol/tsconfig-cjs.json" }]
 }

--- a/packages/connect/tsconfig-mjs.json
+++ b/packages/connect/tsconfig-mjs.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "es2020",
     "outDir": "./dist/mjs",
-    "target": "ES2018"
+    "target": "ES2018",
+    "noEmit": false
   },
   "references": [{ "path": "../connect-extension-protocol/tsconfig-mjs.json" }]
 }

--- a/packages/connect/tsconfig.json
+++ b/packages/connect/tsconfig.json
@@ -1,22 +1,9 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
-    "rootDir": "./src",
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "strict": true,
+    "rootDir": "src",
     "downlevelIteration": true
   },
-  "exclude": [
-    "**/*.test.ts",
-    "tsconfig*",
-    "*node_modules*",
-    "../../node_modules*"
-  ],
-  "include": ["src/**/*", "src/**/*.json"],
   "references": [{ "path": "../connect-extension-protocol/tsconfig-mjs.json" }]
 }

--- a/projects/burnr/tsconfig.json
+++ b/projects/burnr/tsconfig.json
@@ -1,19 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
-    "outDir": "./dist",
-    "lib": ["es6", "dom"],
-    "module": "es6",
-    "target": "ES2015",
-    "types": [],
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "strict": true,
+    "moduleResolution": "Bundler",
     "jsx": "react-jsx"
   },
-  "include": ["src/**/*"],
-  "references": [{ "path": "../../packages/connect/tsconfig-mjs.json" }]
+  "include": ["src"]
 }

--- a/projects/demo/tsconfig.json
+++ b/projects/demo/tsconfig.json
@@ -1,15 +1,7 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
-    "outDir": "./dist",
-    "rootDir": "./src",
-    "lib": ["es6", "dom"],
-    "target": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "module": "ES2015"
+    "moduleResolution": "Bundler"
   },
-  "include": ["src", "src/**/*.json"]
+  "include": ["src"]
 }

--- a/projects/extension/tsconfig.json
+++ b/projects/extension/tsconfig.json
@@ -1,30 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "jsx": "react",
-    "outDir": "./dist/",
-    "lib": ["es6", "dom"],
-    "noImplicitAny": true,
-    "noImplicitThis": true,
-    "strictNullChecks": true,
-    "target": "ES2015",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "module": "es6",
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "downlevelIteration": true
+    "moduleResolution": "Bundler",
+    "jsx": "react"
   },
-  "include": [
-    "src/**/*",
-    "public/assets/*.json",
-    "src/background/settings.json",
-    "package.json"
-  ],
-  "exclude": ["*node_modules*", "../../node_modules*", "**/*.test.ts"],
-  "references": [
-    { "path": "../../packages/connect-extension-protocol/tsconfig-mjs.json" }
-  ]
+  "include": ["src"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,7 +14,6 @@
     "noEmit": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "verbatimModuleSyntax": true,
 
     /* Linting */
     "strict": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,16 +1,26 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "baseUrl": ".",
-    "composite": true,
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
     "declaration": true,
-    "sourceMap": true,
-    "inlineSources": true,
-    "paths": {
-      "@substrate/connect-extension-protocol": [
-        "./packages/connect-extension-protocol"
-      ],
-      "@substrate/connect": ["./packages/connect"]
-    }
+    "noEmit": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "verbatimModuleSyntax": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,0 @@
-{
-  "files": [],
-  "references": [
-    { "path": "./packages/connect-extension-protocol" },
-    { "path": "./packages/connect" },
-    { "path": "./projects/burnr" },
-    { "path": "./projects/extension" }
-  ]
-}


### PR DESCRIPTION
- Add a `tsconfig.base.json` where each workspace extends from it
- set `moduleResolution` to `Bundler` for `projects/*/tsconfig.json`
- Remove root `tsconfig.json` because the project build configurations do not use root `tsconfig.json` references