### PR TITLE
feat: use `package.json` version as the source of truth for the `manifest.json` version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,24 +7,6 @@ on:
     branches: [ main ]
 
 jobs:
-  check-extension-versions:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3.5.3
-    - id: package-version
-      run: echo "version=`jq .version ./projects/extension/package.json`" >> $GITHUB_OUTPUT
-    - id: manifest-version-2
-      run: echo "version=`jq .version ./projects/extension/assets/manifest-v2.json`" >> $GITHUB_OUTPUT
-    - id: manifest-version-3
-      run: echo "version=`jq .version ./projects/extension/assets/manifest-v3.json`" >> $GITHUB_OUTPUT
-    - run: exit 1
-      if: ${{ steps.package-version.outputs.version != steps.manifest-version-2.outputs.version }}
-    - run: exit 1
-      if: ${{ steps.package-version.outputs.version != steps.manifest-version-3.outputs.version }}
-    - run: exit 1
-      if: ${{steps.package-version.outputs.version == '' || steps.manifest-version-2.outputs.version == '' || steps.manifest-version-3.outputs.version == ''}}
-
   build:
     runs-on: ubuntu-latest
 
@@ -49,7 +31,7 @@ jobs:
   all:
     # This dummy job depends on all the mandatory checks. It succeeds if and only if all CI checks
     # are successful.
-    needs: [check-extension-versions, build]
+    needs: [build]
     runs-on: ubuntu-latest
     steps:
      - run: echo Success

--- a/projects/extension/assets/manifest-v2.json
+++ b/projects/extension/assets/manifest-v2.json
@@ -4,7 +4,7 @@
   "homepage_url": "https://github.com/paritytech/substrate-connect",
   "name": "Substrate Connect Extension",
   "short_name": "substrate-connect",
-  "version": "0.2.9",
+  "version": "0.0.0",
   "manifest_version": 2,
   "permissions": ["notifications", "storage", "tabs", "alarms"],
   "background": {

--- a/projects/extension/assets/manifest-v3.json
+++ b/projects/extension/assets/manifest-v3.json
@@ -4,7 +4,7 @@
   "homepage_url": "https://github.com/paritytech/substrate-connect",
   "name": "Substrate Connect Extension",
   "short_name": "substrate-connect",
-  "version": "0.2.9",
+  "version": "0.0.0",
   "manifest_version": 3,
   "permissions": ["notifications", "storage", "tabs", "alarms"],
   "background": {

--- a/projects/extension/package.json
+++ b/projects/extension/package.json
@@ -7,8 +7,8 @@
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {
-    "prep:m3": "mkdir -p dist && cp -r ./assets/icons ./dist && cp ./assets/manifest-v3.json ./dist/manifest.json",
-    "prep:m2": "mkdir -p dist && cp -r ./assets/icons ./dist && cp ./assets/manifest-v2.json ./dist/manifest.json",
+    "prep:m3": "mkdir -p dist && cp -r ./assets/icons ./dist && node scripts/generateManifest.js ./assets/manifest-v3.json ./dist/manifest.json",
+    "prep:m2": "mkdir -p dist && cp -r ./assets/icons ./dist && node scripts/generateManifest.js ./assets/manifest-v2.json ./dist/manifest.json",
     "build": "yarn build:m3 && yarn build:m2",
     "build:m3": "yarn clean && yarn prep:m3 && concurrently \"yarn:build-*\" && cd dist && zip -r packed-m3-extension.zip .",
     "build:m2": "yarn clean && yarn prep:m2 && concurrently \"yarn:build-*\" && cd dist && zip -r packed-m2-extension.zip .",

--- a/projects/extension/scripts/generateManifest.js
+++ b/projects/extension/scripts/generateManifest.js
@@ -1,0 +1,21 @@
+import fs from "node:fs/promises"
+import path from "node:path"
+import url from "node:url"
+
+const [src, dst] = process.argv.slice(2)
+
+const manifest = JSON.parse(await fs.readFile(src, { encoding: "utf-8" }))
+const pkg = JSON.parse(
+  await fs.readFile(
+    path.resolve(
+      path.dirname(url.fileURLToPath(import.meta.url)),
+      "../package.json",
+    ),
+  ),
+)
+
+manifest.version = pkg.version
+
+await fs.writeFile(dst, JSON.stringify(manifest, undefined, 2), {
+  encoding: "utf8",
+})


### PR DESCRIPTION
Use `package.json` version as the source of truth for the `manifest.json` version