### PR TITLE
Bump zombienet to latest release; Change checks to polkadot SDK

### DIFF
--- a/.github/workflows/zombienet.yml
+++ b/.github/workflows/zombienet.yml
@@ -16,15 +16,23 @@ jobs:
           yarn build
       - name: Get zombienet
         run: |
-          curl -L -O https://github.com/paritytech/zombienet/releases/download/v1.3.67/zombienet-linux-x64
+          curl -L -O https://github.com/paritytech/zombienet/releases/download/v1.3.68/zombienet-linux-x64
           chmod +x zombienet-linux-x64
       - name: Get polkadot
         run: |
-          curl -L -O https://github.com/paritytech/polkadot/releases/download/v0.9.43/polkadot
+          curl -L -O https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-v1.1.0/polkadot
           chmod +x polkadot
+      - name: Get polkadot execute worker
+        run: |
+          curl -L -O https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-v1.1.0/polkadot-execute-worker
+          chmod +x polkadot-execute-worker
+      - name: Get polkadot prepare worker
+        run: |
+          curl -L -O https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-v1.1.0/polkadot-prepare-worker
+          chmod +x polkadot-prepare-worker
       - name: Get polkadot-parachain
         run: |
-          curl -L -O https://github.com/paritytech/cumulus/releases/download/v0.9.430/polkadot-parachain
+          curl -L -O https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-v1.1.0/polkadot-parachain
           chmod +x polkadot-parachain
       - name: Run test
         run: |


### PR DESCRIPTION
- Bump zombienet to latest release (v1.3.68)
- Change checks to polkadot SDK (v1.0)