### PR TITLE
fix: code splitting problem

### DIFF
--- a/packages/connect/src/connector/smoldot-light.ts
+++ b/packages/connect/src/connector/smoldot-light.ts
@@ -1,9 +1,8 @@
-import {
+import type {
   Chain as SChain,
   Client,
   ClientOptions,
   ClientOptionsWithBytecode,
-  QueueFullError,
 } from "smoldot"
 import { getSpec } from "./specs/index.js"
 import {
@@ -19,10 +18,15 @@ import { WellKnownChain } from "../WellKnownChain.js"
 
 const isBrowser = ![typeof window, typeof document].includes("undefined")
 
+let QueueFullError = class {}
+
 let startPromise: Promise<(options: ClientOptions) => Client> | null = null
 const getStart = () => {
   if (startPromise) return startPromise
-  startPromise = import("smoldot").then((sm) => sm.start)
+  startPromise = import("smoldot").then((sm) => {
+    QueueFullError = sm.QueueFullError
+    return sm.start
+  })
   return startPromise
 }
 


### PR DESCRIPTION
The dynamic import of `smoldot` used on the `smoldot-light.ts` file was pointless due to the fact that the class `QueueFullError` was not being dynamically imported. As a result of this,  all users of `@substrate/connect` end up with the smoldot binary included in the main-bundle of their projects, this is specially annoying for those ones who have the extension installed.

This PR is a pragmatic fix to this issue.