### PR TITLE
fix(extension): @substrate/connect dynamic import

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -46,11 +46,12 @@
   },
   "dependencies": {
     "@substrate/connect-extension-protocol": "^1.0.1",
-    "smoldot": "2.0.7"
+    "smoldot": "2.0.6"
   },
   "devDependencies": {
     "eslint": "^8.53.0",
     "jsdom": "^22.1.0",
+    "typescript": "^5.2.2",
     "vitest": "^0.34.6"
   }
 }

--- a/projects/extension/package.json
+++ b/projects/extension/package.json
@@ -50,6 +50,6 @@
     "react-dom": "^18.2.0",
     "react-icons": "^4.11.0",
     "scale-ts": "^1.4.2",
-    "smoldot": "2.0.7"
+    "smoldot": "2.0.6"
   }
 }

--- a/projects/extension/package.json
+++ b/projects/extension/package.json
@@ -43,7 +43,6 @@
     "web-ext": "^7.8.0"
   },
   "dependencies": {
-    "@substrate/connect": "*",
     "@substrate/connect-extension-protocol": "*",
     "@unstoppablejs/utils": "^1.1.0",
     "react": "^18.2.0",

--- a/projects/extension/src/background/addChain.ts
+++ b/projects/extension/src/background/addChain.ts
@@ -1,0 +1,150 @@
+import type { Chain, Client } from "smoldot"
+import {
+  start,
+  QueueFullError,
+  JsonRpcDisabledError,
+  AlreadyDestroyedError,
+  CrashError,
+} from "smoldot"
+
+let clientReferences: number = 0
+let client: Client | null = null
+const getClientAndIncRef = () => {
+  if (client) {
+    clientReferences++
+    return client
+  }
+
+  client = start({
+    forbidTcp: true, // In order to avoid confusing inconsistencies between browsers and NodeJS, TCP connections are always disabled.
+    forbidNonLocalWs: true, // Prevents browsers from emitting warnings if smoldot tried to establish non-secure WebSocket connections
+    maxLogLevel: 3,
+    cpuRateLimit: 0.5, // Politely limit the CPU usage of the smoldot background worker.
+  })
+
+  clientReferences++
+  return client
+}
+
+const decRef = () => {
+  clientReferences--
+  if (clientReferences < 0) throw new Error("Internal error within smoldot")
+
+  if (clientReferences === 0) {
+    client?.terminate()
+    client = null
+  }
+}
+
+const transformErrors = (thunk: () => void) => {
+  try {
+    thunk()
+  } catch (e) {
+    const error = e as Error | undefined
+    if (error?.name === "JsonRpcDisabledError") throw new JsonRpcDisabledError()
+    if (error?.name === "CrashError") throw new CrashError(error.message)
+    if (error?.name === "AlreadyDestroyedError")
+      throw new AlreadyDestroyedError()
+    throw new CrashError(
+      e instanceof Error ? e.message : `Unexpected error ${e}`,
+    )
+  }
+}
+
+const chains = new Map<ScChain, Chain>()
+
+export type ScChain = Pick<Chain, "sendJsonRpc" | "remove">
+export type AddChainOptions = Parameters<AddChain>
+export type AddChain = (
+  chainSpec: string,
+  jsonRpcCallback?: (msg: string) => void,
+  potentialRelayChains?: ScChain[],
+  databaseContent?: string,
+) => Promise<ScChain>
+
+export const addChain: AddChain = async (
+  chainSpec,
+  jsonRpcCallback,
+  potentialRelayChains,
+  databaseContent,
+) => {
+  const client = await getClientAndIncRef()
+  try {
+    const internalChain = await client.addChain({
+      chainSpec,
+      potentialRelayChains: potentialRelayChains
+        ?.map((c) => chains.get(c))
+        .filter((sc): sc is Chain => !!sc) ?? [...chains.values()],
+      disableJsonRpc: jsonRpcCallback === undefined,
+      databaseContent,
+    })
+
+    ;(async () => {
+      while (true) {
+        let jsonRpcResponse
+        try {
+          jsonRpcResponse = await internalChain.nextJsonRpcResponse()
+        } catch (_) {
+          break
+        }
+
+        // `nextJsonRpcResponse` throws an exception if we pass `disableJsonRpc: true` in the
+        // config. We pass `disableJsonRpc: true` if `jsonRpcCallback` is undefined. Therefore,
+        // this code is never reachable if `jsonRpcCallback` is undefined.
+        try {
+          jsonRpcCallback!(jsonRpcResponse)
+        } catch (error) {
+          console.error("JSON-RPC callback has thrown an exception:", error)
+        }
+      }
+    })()
+
+    const chain: ScChain = {
+      sendJsonRpc: (rpc: string) => {
+        transformErrors(() => {
+          try {
+            internalChain.sendJsonRpc(rpc)
+          } catch (error) {
+            if (error instanceof QueueFullError) {
+              // If the queue is full, we immediately send back a JSON-RPC response indicating
+              // the error.
+              try {
+                const parsedRq = JSON.parse(rpc)
+                jsonRpcCallback!(
+                  JSON.stringify({
+                    jsonrpc: "v2",
+                    id: parsedRq.id,
+                    error: {
+                      code: -32000,
+                      message: "JSON-RPC server is too busy",
+                    },
+                  }),
+                )
+              } catch (_error) {
+                // An error here counts as a malformed JSON-RPC request, which are ignored.
+              }
+            } else {
+              throw error
+            }
+          }
+        })
+      },
+      remove: () => {
+        try {
+          transformErrors(() => {
+            internalChain.remove()
+          })
+        } finally {
+          chains.delete(chain)
+          decRef()
+        }
+      },
+    }
+
+    chains.set(chain, internalChain)
+    return chain
+  } catch (error) {
+    decRef()
+    throw error
+  }
+}

--- a/projects/extension/src/background/updateDatabases.ts
+++ b/projects/extension/src/background/updateDatabases.ts
@@ -1,9 +1,9 @@
-import type { ScClient } from "@substrate/connect"
 import * as environment from "../environment"
+import { type AddChain } from "./addChain"
 import { loadWellKnownChains } from "./loadWellKnownChains"
 
 // TODO: use substrate-client when it supports custom RPC calls like chainHead_unstable_finalizedDatabase
-export const updateDatabases = async (client: ScClient) => {
+export const updateDatabases = async (addChain: AddChain) => {
   const wellKnownChains = [...(await loadWellKnownChains()).entries()]
   await Promise.allSettled(
     wellKnownChains.map(async ([chainName, chainSpec]) => {
@@ -28,7 +28,7 @@ export const updateDatabases = async (client: ScClient) => {
                   chain.remove()
                 }
               }
-              const chain = await client.addChain(
+              const chain = await addChain(
                 chainSpec,
                 (rawMessage) => {
                   const message = JSON.parse(rawMessage)

--- a/projects/extension/vite.script.config.js
+++ b/projects/extension/vite.script.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from "vite"
 
 const input = process.env.INPUT
-const isBackground = input === "background"
 
 export default defineConfig(({ mode }) => ({
   build: {
@@ -14,12 +13,7 @@ export default defineConfig(({ mode }) => ({
       },
       output: {
         entryFileNames: (chunk) => `${chunk.name}.js`,
-        inlineDynamicImports: !isBackground,
-        manualChunks: isBackground
-          ? {
-              "substrate-connect": ["@substrate/connect"],
-            }
-          : undefined,
+        inlineDynamicImports: true,
       },
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3313,7 +3313,8 @@ __metadata:
     "@substrate/connect-extension-protocol": ^1.0.1
     eslint: ^8.53.0
     jsdom: ^22.1.0
-    smoldot: 2.0.7
+    smoldot: 2.0.6
+    typescript: ^5.2.2
     vitest: ^0.34.6
   languageName: unknown
   linkType: soft
@@ -3336,7 +3337,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@substrate/extension@workspace:projects/extension"
   dependencies:
-    "@substrate/connect": "*"
     "@substrate/connect-extension-protocol": "*"
     "@unstoppablejs/utils": ^1.1.0
     "@vitejs/plugin-react-swc": ^3.4.1
@@ -3348,7 +3348,7 @@ __metadata:
     react-dom: ^18.2.0
     react-icons: ^4.11.0
     scale-ts: ^1.4.2
-    smoldot: 2.0.7
+    smoldot: 2.0.6
     tailwindcss: ^3.3.5
     typescript: ^5.2.2
     vite: ^4.5.0
@@ -11518,12 +11518,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"smoldot@npm:2.0.7":
-  version: 2.0.7
-  resolution: "smoldot@npm:2.0.7"
+"smoldot@npm:2.0.6":
+  version: 2.0.6
+  resolution: "smoldot@npm:2.0.6"
   dependencies:
     ws: ^8.8.1
-  checksum: fc039bfa0560312ae09c2136dd506f2a1994ead804b7234b49b2ecfac2fd19d306973a0fcfb66019645a8cf9a1702c270bc544a622ae40b63cf14790ea3531e0
+  checksum: 733996d5635521a0b63363ebdd2a4a5b4d4fc55fe73b9a1a5f0724d7d2d4aa72eb41e7d58e592b6c5991ad8ab345a898f68115a12c8cde88c0c7996ee8063934
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Removes `@substrate/connect` lib from the extension because it uses a dynamic import to create the `smoldot` client.
Dynamic imports are not supported in the extension background script ServiceWorker. 

Note: downgraded `smoldot` to `2.0.6` until this [issue](https://github.com/smol-dot/smoldot/issues/1330) is fixed.