### PR TITLE
fix: rename deploy script to deploy-projects-and-docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,9 +111,9 @@ jobs:
         run: |
           git remote set-branches origin gh-pages
           git fetch --depth 1 origin gh-pages
-      - name: Deploy
+      - name: Deploy Projects & Docs
         if: steps.publish_connect.outputs.type || steps.publish_connect_extension_protocol.outputs.type
-        run: pnpm deploy
+        run: pnpm deploy-projects-and-docs
 
   upload-extension-artifacts:
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy-projects-and-docs.yml
+++ b/.github/workflows/deploy-projects-and-docs.yml
@@ -1,0 +1,19 @@
+name: Deploy Projects and API Docs
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - uses: ./.github/actions/turbo-build
+      - name: Fetch gh-pages
+        run: |
+          git remote set-branches origin gh-pages
+          git fetch --depth 1 origin gh-pages
+      - name: Deploy Projects & Docs
+        run: pnpm deploy-projects-and-docs
+

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "dev:burnr": "pnpm --filter @substrate/burnr dev",
     "dev:demo": "pnpm --filter @substrate/demo dev",
     "dev:extension": "pnpm --filter @substrate/extension dev",
-    "deploy": "./deploy.sh",
+    "deploy-projects-and-docs": "./deploy.sh",
     "format": "prettier --write .",
     "checkResolutions": "node ./.ensure-resolution.mjs",
     "postinstall": "husky install"


### PR DESCRIPTION
Rename `pnpm deploy` script to `pnpm deploy-projects-and-docs` 
This is needed because `pnpm deploy` built-in command conflicts with existing NPM scripts named deploy (see [issue](https://github.com/pnpm/pnpm/issues/5163))