### PR TITLE
feat: improve extension discovery

### DIFF
--- a/projects/extension/src/content/index.ts
+++ b/projects/extension/src/content/index.ts
@@ -1,21 +1,19 @@
 import { register } from "@substrate/light-client-extension-helpers/content-script"
 import { DOM_ELEMENT_ID } from "@substrate/connect-extension-protocol"
 
-register(DOM_ELEMENT_ID)
-
-// inject as soon as possible the DOM element necessary for web pages to know that the extension
-// is available
-window.document.addEventListener("readystatechange", () => {
-  if (window.document.readyState !== "interactive") return
-
-  // If there is already a DOM element inject, don't create another element and don't listen.
-  // This way, if multiple extensions are installed, only one will actually be active on any
-  // given page.
-  if (document.getElementById(DOM_ELEMENT_ID) !== null) return
-
-  const s = document.createElement("span")
-  s.id = DOM_ELEMENT_ID
-  s.setAttribute("style", "display:none")
-  s.setAttribute("channelid", DOM_ELEMENT_ID)
-  document.body.appendChild(s)
+window.addEventListener("message", ({ source, origin, data }: MessageEvent) => {
+  if (
+    source !== window ||
+    origin !== window.origin ||
+    typeof data !== "object" ||
+    data.origin !== "substrate-connect-client" ||
+    data.type !== "is-extension-present"
+  )
+    return
+  window.postMessage({
+    origin: "substrate-connect-extension",
+    type: "is-extension-present",
+  })
 })
+
+register(DOM_ELEMENT_ID)


### PR DESCRIPTION
Use `window.postMessage` to detect if the extension is present.

Note: Given that the content script uses a different event loop, at least 3 macro tasks need to be awaited before checking the presence of the extension.  