### PR TITLE
feat(wallet-template): cascade delete parachains

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -610,6 +610,9 @@ importers:
       vitest:
         specifier: ^1.5.0
         version: 1.5.0(@types/node@20.12.7)(jsdom@24.0.0)
+      vitest-mock-extended:
+        specifier: ^1.3.1
+        version: 1.3.1(typescript@5.4.5)(vitest@1.5.0)
       web-ext:
         specifier: ^7.11.0
         version: 7.11.0
@@ -11405,6 +11408,17 @@ packages:
       typescript: 5.4.5
     dev: true
 
+  /ts-essentials@9.4.2(typescript@5.4.5):
+    resolution: {integrity: sha512-mB/cDhOvD7pg3YCLk2rOtejHjjdSi9in/IBYE13S+8WA5FBSraYf4V/ws55uvs0IvQ/l0wBOlXy5yBNZ9Bl8ZQ==}
+    peerDependencies:
+      typescript: '>=4.1.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      typescript: 5.4.5
+    dev: true
+
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -11967,6 +11981,17 @@ packages:
       rollup: 4.13.0
     optionalDependencies:
       fsevents: 2.3.3
+    dev: true
+
+  /vitest-mock-extended@1.3.1(typescript@5.4.5)(vitest@1.5.0):
+    resolution: {integrity: sha512-OpghYjh4BDuQ/Mzs3lFMQ1QRk9D8/2O9T47MLUA5eLn7K4RWIy+MfIivYOWEyxjTENjsBnzgMihDjyNalN/K0Q==}
+    peerDependencies:
+      typescript: 3.x || 4.x || 5.x
+      vitest: '>=0.31.1'
+    dependencies:
+      ts-essentials: 9.4.2(typescript@5.4.5)
+      typescript: 5.4.5
+      vitest: 1.5.0(@types/node@20.12.7)(jsdom@24.0.0)
     dev: true
 
   /vitest@1.5.0(@types/node@20.12.7)(jsdom@24.0.0):

--- a/projects/wallet-template/package.json
+++ b/projects/wallet-template/package.json
@@ -48,6 +48,7 @@
     "vite": "^5.2.8",
     "vite-plugin-web-extension": "^4.1.3",
     "vitest": "^1.5.0",
+    "vitest-mock-extended": "^1.3.1",
     "web-ext": "^7.11.0",
     "wxt": "^0.17.12"
   },

--- a/projects/wallet-template/src/background/rpc/chainspec.test.ts
+++ b/projects/wallet-template/src/background/rpc/chainspec.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, it, expect } from "vitest"
+import { removeChainSpecHandler as removeChainSpec } from "./chainspec"
+import { wellKnownChainIdByGenesisHash } from "../../constants"
+import { Context } from "./types"
+import { mock } from "vitest-mock-extended"
+import {
+  LightClientPageHelper,
+  PageChain,
+} from "@substrate/light-client-extension-helpers/extension-page"
+import { JsonRpcProvider } from "@polkadot-api/json-rpc-provider"
+
+describe("chainspec rpc", () => {
+  const mockContext = mock<Context>()
+  const mockLightClientPageHelper = mock<LightClientPageHelper>()
+  mockContext.lightClientPageHelper = mockLightClientPageHelper
+
+  describe("remove well know chain fails", () => {
+    Object.entries(wellKnownChainIdByGenesisHash).map(
+      ([genesisHash, chainId]) =>
+        test.fails(`${chainId}`, async () => {
+          await removeChainSpec([genesisHash], mockContext)
+        }),
+    )
+  })
+
+  it("should cascade delete parachains when its relay chain is deleted", async () => {
+    const relayChainGenesisHash =
+      "0x759b9d9f1426b8a53769eb41b390f9f398a27f8165e54929784caf840dac9887"
+    const parachainGenesisHash =
+      "0x7467ca58bc9757d08c13ceea3b840c770c741e21ece1c6ede3c03be3eccba342"
+    const fakeNetwork: PageChain[] = [
+      {
+        genesisHash: relayChainGenesisHash,
+        name: "not-westend",
+        ss58Format: 0,
+        chainSpec: "{}",
+        provider: mock<JsonRpcProvider>(),
+        bootNodes: [],
+      },
+      {
+        genesisHash: parachainGenesisHash,
+        name: "not-westend-asset-hub",
+        ss58Format: 0,
+        provider: mock<JsonRpcProvider>(),
+        relayChainGenesisHash: relayChainGenesisHash,
+        chainSpec: "{}",
+        bootNodes: [],
+      },
+    ]
+
+    mockLightClientPageHelper.getChains.mockResolvedValueOnce(fakeNetwork)
+
+    await removeChainSpec([relayChainGenesisHash], mockContext)
+
+    expect(mockLightClientPageHelper.deleteChain).toHaveBeenCalledWith(
+      relayChainGenesisHash,
+    )
+    expect(mockLightClientPageHelper.deleteChain).toHaveBeenCalledWith(
+      parachainGenesisHash,
+    )
+  })
+})


### PR DESCRIPTION
When you delete a relaychain from the allowlist chainspec UI. It should also delete their associated parachains.