### PR TITLE
fix(zombienet-tests): update default image

### DIFF
--- a/zombienet-tests/src/0002-parachain.toml
+++ b/zombienet-tests/src/0002-parachain.toml
@@ -2,31 +2,31 @@
 timeout = 1000
 
 [relaychain]
-default_image = "docker.io/paritypr/synth-wave:4131-0.9.12-ccd09bbf-29a1ac18"
+default_image = "docker.io/paritypr/polkadot-debug:master"
 chain = "rococo-local"
 command = "polkadot"
 
-  [[relaychain.nodes]]
-  name = "alice"
-  validator = true
-  extra_args = [ "--alice", "-lparachain=debug" ]
+[[relaychain.nodes]]
+name = "alice"
+validator = true
+extra_args = ["--alice", "-lparachain=debug"]
 
-  [[relaychain.nodes]]
-  name = "bob"
-  validator = true
-  extra_args = [ "--bob", "-lparachain=debug" ]
-  add_to_bootnodes = true
+[[relaychain.nodes]]
+name = "bob"
+validator = true
+extra_args = ["--bob", "-lparachain=debug"]
+add_to_bootnodes = true
 
 
 [[parachains]]
 id = 100
 cumulus_based = true
 
-  [[parachains.collator_groups]]
-    count = 2
-    name = "collator"
-    command = "polkadot-parachain"
-    args = ["-lparachain=debug"]
+[[parachains.collator_groups]]
+count = 2
+name = "collator"
+command = "polkadot-parachain"
+args = ["-lparachain=debug"]
 
 [types.Header]
 number = "u64"


### PR DESCRIPTION
Have no idea what "docker.io/paritypr/synth-wave:4131-0.9.12-ccd09bbf-29a1ac18" is ... likely is very outdated. Updating the zombienet test to "docker.io/paritypr/polkadot-debug:master" seems sensible.