### PR TITLE
feat: add heartbeat to background service worker

### DIFF
--- a/projects/extension/src/background/heartbeat.ts
+++ b/projects/extension/src/background/heartbeat.ts
@@ -1,0 +1,39 @@
+/**
+ * Tracks when a service worker was last alive and extends the service worker
+ * lifetime by writing the current time to extension storage every 20 seconds.
+ * You should still prepare for unexpected termination - for example, if the
+ * extension process crashes or your extension is manually stopped at
+ * chrome://serviceworker-internals.
+ *
+ * @link {https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers}
+ */
+let heartbeatInterval: NodeJS.Timeout | number = 0
+
+async function runHeartbeat() {
+  await chrome.storage.local.set({ "last-heartbeat": new Date().getTime() })
+}
+
+/**
+ * Starts the heartbeat interval which keeps the service worker alive. Call
+ * this sparingly when you are doing work which requires persistence, and call
+ * stopHeartbeat once that work is complete.
+ */
+export async function startHeartbeat() {
+  // Run the heartbeat once at service worker startup.
+  runHeartbeat().then(() => {
+    // Then again every 20 seconds.
+    heartbeatInterval = setInterval(runHeartbeat, 20 * 1000)
+  })
+}
+
+export async function stopHeartbeat() {
+  clearInterval(heartbeatInterval)
+}
+
+/**
+ * Returns the last heartbeat stored in extension storage, or undefined if
+ * the heartbeat has never run before.
+ */
+export async function getLastHeartbeat() {
+  return (await chrome.storage.local.get("last-heartbeat"))["last-heartbeat"]
+}

--- a/projects/extension/src/background/index.ts
+++ b/projects/extension/src/background/index.ts
@@ -1,5 +1,6 @@
 import { start } from "smoldot"
 import { register } from "@substrate/light-client-extension-helpers/background"
+import { startHeartbeat } from "./heartbeat"
 
 register({
   smoldotClient: start({ maxLogLevel: 4 }),
@@ -22,3 +23,5 @@ register({
       ),
     ),
 })
+
+startHeartbeat()

--- a/projects/wallet-template/src/background/heartbeat.ts
+++ b/projects/wallet-template/src/background/heartbeat.ts
@@ -1,0 +1,39 @@
+/**
+ * Tracks when a service worker was last alive and extends the service worker
+ * lifetime by writing the current time to extension storage every 20 seconds.
+ * You should still prepare for unexpected termination - for example, if the
+ * extension process crashes or your extension is manually stopped at
+ * chrome://serviceworker-internals.
+ *
+ * @link {https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers}
+ */
+let heartbeatInterval: NodeJS.Timeout | number = 0
+
+async function runHeartbeat() {
+  await chrome.storage.local.set({ "last-heartbeat": new Date().getTime() })
+}
+
+/**
+ * Starts the heartbeat interval which keeps the service worker alive. Call
+ * this sparingly when you are doing work which requires persistence, and call
+ * stopHeartbeat once that work is complete.
+ */
+export async function startHeartbeat() {
+  // Run the heartbeat once at service worker startup.
+  runHeartbeat().then(() => {
+    // Then again every 20 seconds.
+    heartbeatInterval = setInterval(runHeartbeat, 20 * 1000)
+  })
+}
+
+export async function stopHeartbeat() {
+  clearInterval(heartbeatInterval)
+}
+
+/**
+ * Returns the last heartbeat stored in extension storage, or undefined if
+ * the heartbeat has never run before.
+ */
+export async function getLastHeartbeat() {
+  return (await chrome.storage.local.get("last-heartbeat"))["last-heartbeat"]
+}

--- a/projects/wallet-template/src/background/index.ts
+++ b/projects/wallet-template/src/background/index.ts
@@ -3,6 +3,7 @@ import { register } from "@substrate/light-client-extension-helpers/background"
 import { createBackgroundRpc } from "./createBackgroundRpc"
 import * as storage from "./storage"
 import type { Account } from "./types"
+import { startHeartbeat } from "./heartbeat"
 
 const { lightClientPageHelper, addOnAddChainByUserListener } = register({
   smoldotClient: start({ maxLogLevel: 4 }),
@@ -95,3 +96,5 @@ addOnAddChainByUserListener(async (inputChain) => {
     throw new Error("User rejected")
   }
 })
+
+startHeartbeat()


### PR DESCRIPTION
Improves the stability of the extension by ensuring it doesnt shutdown randomly due to the nature of chrome background service worker lifecycle. 

This doesn't fix #1786 but reduces the likelihood of the extension getting stuck in the past.

See: https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers, section: "Keep a service worker alive continuously"