### PR TITLE
fix(wallet-template): substrate branding

### DIFF
--- a/projects/wallet-template/src/components/Layout2.tsx
+++ b/projects/wallet-template/src/components/Layout2.tsx
@@ -20,7 +20,7 @@ export const Layout2: React.FC<Props> = ({ children }) => {
         "font-sans",
       )}
     >
-      <div className={cn("flex", "min-h-[600px]", "lg:px-8 lg:py-12")}>
+      <div className={cn("bg-background", "flex", "min-h-[600px]")}>
         {children}
       </div>
     </main>

--- a/projects/wallet-template/src/containers/WalletPopup/pages/CreatePassword.tsx
+++ b/projects/wallet-template/src/containers/WalletPopup/pages/CreatePassword.tsx
@@ -78,9 +78,9 @@ export const CreatePassword = () => {
         <form onSubmit={handleSubmit(onSubmit)}>
           <Card className="flex flex-col flex-grow w-full max-w-md min-h-full rounded-none lg:rounded">
             <CardHeader className="flex-grow text-center">
-              <div className="relative text-6xl font-bold text-teal-400">_</div>
               <CardTitle className="mt-6 text-2xl font-extrabold">
-                Create Password
+                Create Password<span className="text-primary">_</span>
+                <br />
               </CardTitle>
               <CardDescription className="mt-2 text-sm">
                 We recommend creating a strong password that is at least 6

--- a/projects/wallet-template/src/containers/WalletPopup/pages/CreatePassword.tsx
+++ b/projects/wallet-template/src/containers/WalletPopup/pages/CreatePassword.tsx
@@ -77,7 +77,7 @@ export const CreatePassword = () => {
       <Form {...form}>
         <form onSubmit={handleSubmit(onSubmit)}>
           <Card className="flex flex-col flex-grow w-full max-w-md min-h-full rounded-none lg:rounded">
-            <CardHeader className="flex-grow text-center">
+            <CardHeader className="text-center">
               <CardTitle className="mt-6 text-2xl font-extrabold">
                 Create Password<span className="text-primary">_</span>
                 <br />
@@ -88,7 +88,7 @@ export const CreatePassword = () => {
                 letters, numbers, and special characters.
               </CardDescription>
             </CardHeader>
-            <CardContent className="flex-grow">
+            <CardContent className="content-center flex-grow">
               <FormField
                 control={control}
                 name="password"

--- a/projects/wallet-template/src/containers/WalletPopup/pages/Welcome.tsx
+++ b/projects/wallet-template/src/containers/WalletPopup/pages/Welcome.tsx
@@ -18,12 +18,16 @@ export const Welcome = () => {
 
   return (
     <Layout2>
-      <Card className="flex-grow w-full max-w-md min-h-full rounded-none lg:rounded">
+      <Card className="flex flex-col flex-grow w-full max-w-md min-h-full rounded-none lg:rounded">
         <CardHeader className="text-center">
-          <CardTitle className="mt-6 text-2xl font-extrabold">
-            substrate<span className="text-primary">_</span>
+          <CardTitle className="mt-6 text-2xl leading-4">
+            <span className="pl-4 font-semibold">
+              substrate<span className="text-primary">_</span>
+            </span>
             <br />
-            <span className="text-5xl text-primary">Connect</span>
+            <span className="text-5xl font-extrabold text-primary">
+              Connect
+            </span>
           </CardTitle>
           <CardDescription className="mt-2">
             The easiest way to connect to Polkadot, Kusama, and Substrate-based
@@ -31,7 +35,7 @@ export const Welcome = () => {
           </CardDescription>
         </CardHeader>
         {/* TODO: Replace the filler text below with something real */}
-        <CardContent>
+        <CardContent className="content-center flex-grow">
           <ul className="space-y-4">
             <li className="flex items-start">
               <Lock className="w-6 h-6 text-primary" aria-hidden="true" />
@@ -56,7 +60,7 @@ export const Welcome = () => {
             </li>
           </ul>
         </CardContent>
-        <CardFooter className="flex flex-col space-y-4">
+        <CardFooter className="flex flex-col flex-grow space-y-4">
           <Button
             className={cn(
               "w-full py-3",

--- a/projects/wallet-template/src/containers/WalletPopup/pages/Welcome.tsx
+++ b/projects/wallet-template/src/containers/WalletPopup/pages/Welcome.tsx
@@ -20,9 +20,8 @@ export const Welcome = () => {
     <Layout2>
       <Card className="flex-grow w-full max-w-md min-h-full rounded-none lg:rounded">
         <CardHeader className="text-center">
-          <div className="relative text-6xl font-bold text-teal-400">_</div>
           <CardTitle className="mt-6 text-2xl font-extrabold">
-            substrate
+            substrate<span className="text-primary">_</span>
             <br />
             <span className="text-5xl text-primary">Connect</span>
           </CardTitle>


### PR DESCRIPTION
Fixes the branding on the welcome and create password pages to match the official substrate branding with the underscore at the end of substrate.

![image](https://github.com/paritytech/substrate-connect/assets/21375952/13d9dd65-d329-47dd-8632-3bae94cb1131)

![image](https://github.com/paritytech/substrate-connect/assets/21375952/cb710570-f116-4287-a477-60c0f30e7132)