### PR TITLE
feat(wallet-template): accounts ui revamp

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -742,6 +742,9 @@ importers:
       tailwindcss:
         specifier: ^3.4.3
         version: 3.4.3
+      typescript:
+        specifier: 5.5.0-beta
+        version: 5.5.0-beta
       vite:
         specifier: ^5.2.11
         version: 5.2.11(@types/node@20.12.12)
@@ -13541,6 +13544,12 @@ packages:
     resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  /typescript@5.5.0-beta:
+    resolution: {integrity: sha512-FRg3e/aQg3olEG3ff8YjHOERsO4IM0m4qGrsE4UMvILaq4TdDZ6gQX4+2Rq9SjTpfSe/ebwiHcsjm/7FfWWQ6Q==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
 
   /ua-parser-js@1.0.37:
     resolution: {integrity: sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ==}

--- a/projects/wallet-template/package.json
+++ b/projects/wallet-template/package.json
@@ -46,6 +46,7 @@
     "eslint": "^8.57.0",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.3",
+    "typescript": "5.5.0-beta",
     "vite": "^5.2.11",
     "vite-plugin-web-extension": "^4.1.3",
     "vitest": "^1.5.0",

--- a/projects/wallet-template/src/components/Layout2.tsx
+++ b/projects/wallet-template/src/components/Layout2.tsx
@@ -15,12 +15,20 @@ export const Layout2: React.FC<Props> = ({ children }) => {
     <main
       className={cn(
         "flex items-center justify-center",
-        "min-w-[400px] min-h-screen",
+        "min-h-screen",
         "bg-gradient-to-br from-emerald-600 via-teal-600 to-cyan-600",
         "font-sans",
       )}
     >
-      <div className={cn("bg-background", "flex", "min-h-[600px]")}>
+      <div
+        className={cn(
+          "bg-background",
+          "w-[400px] h-[600px]",
+          "flex flex-col",
+          "shadow-sm",
+          "rounded-none lg:rounded",
+        )}
+      >
         {children}
       </div>
     </main>

--- a/projects/wallet-template/src/containers/Options.tsx
+++ b/projects/wallet-template/src/containers/Options.tsx
@@ -91,10 +91,10 @@ export const Options: FunctionComponent = () => {
   return (
     <>
       <BraveModal show={showModal} isOptions={true} />
-      <div className="w-60 h-full shadow-md bg-white absolute">
-        <div className="pt-4 pb-2 px-6">
+      <div className="absolute h-full bg-white shadow-md w-60">
+        <div className="px-6 pt-4 pb-2">
           <div className="flex items-center">
-            <div className="grow ml-3">
+            <div className="ml-3 grow">
               <div className="flex items-baseline">
                 <Logo textSize="base" />
               </div>
@@ -133,9 +133,9 @@ export const Options: FunctionComponent = () => {
             </Link>
           </li>
         </ul>
-        <div className="text-center bottom-0 absolute w-full">
+        <div className="absolute bottom-0 w-full text-center">
           <hr className="m-0" />
-          <div className="block float-left py-4 px-2 cursor-pointer">
+          <div className="block float-left px-2 py-4 cursor-pointer">
             <a
               rel="noreferrer"
               target="_blank"

--- a/projects/wallet-template/src/containers/WalletPopup.tsx
+++ b/projects/wallet-template/src/containers/WalletPopup.tsx
@@ -1,4 +1,4 @@
-import { HashRouter, Routes, Route, Link, useLocation } from "react-router-dom"
+import { HashRouter, Routes, Route } from "react-router-dom"
 
 import {
   UnlockKeyring,
@@ -6,22 +6,21 @@ import {
   Debug,
   ChangePassword,
   Welcome,
-  Accounts,
   AddAccount,
   SwitchAccount,
   ImportAccounts,
   AccountDetails,
   AddChainByUser,
+  Accounts,
 } from "./WalletPopup/pages"
 import { ProtectedRoute } from "./WalletPopup/components"
-import { KeyringProvider, useKeyring } from "./WalletPopup/hooks"
+import { KeyringProvider } from "./WalletPopup/hooks"
 import { Options } from "./Options"
 import { CreatePassword } from "./WalletPopup/pages/CreatePassword"
 
 export const WalletPopup = () => (
   <HashRouter>
     <KeyringProvider>
-      <Header />
       <Routes>
         <Route element={<ProtectedRoute />}>
           <Route path="/" element={<Debug />} />
@@ -48,18 +47,3 @@ export const WalletPopup = () => (
     </KeyringProvider>
   </HashRouter>
 )
-
-const Header = () => {
-  const {
-    keyring: { isLocked },
-  } = useKeyring()
-  const location = useLocation()
-  const isOptionsPage = location.pathname === "/accounts/options"
-
-  if (isLocked || isOptionsPage) return null
-  return (
-    <header className="w-[32rem] mx-auto px-6 py-2">
-      <Link to={"/debug"}>Debug</Link>
-    </header>
-  )
-}

--- a/projects/wallet-template/src/containers/WalletPopup/pages/Accounts/Accounts.tsx
+++ b/projects/wallet-template/src/containers/WalletPopup/pages/Accounts/Accounts.tsx
@@ -1,194 +1,221 @@
+import { Card, CardDescription, CardTitle } from "@/components/ui/card"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
 import {
-  Settings,
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Home,
   Plus,
-  ChevronRight,
-  ArrowRightLeft,
-  RotateCcw,
-  PlusCircle,
-  Import,
+  Settings,
+  Download,
+  Code,
+  ArrowRight,
+  Globe,
 } from "lucide-react"
+import { useEffect, useState } from "react"
+import { Layout2 } from "@/components/Layout2"
 import { Link, useNavigate } from "react-router-dom"
-import { ss58Address } from "@polkadot-labs/hdkd-helpers"
-import { rpc } from "../../api"
-import { IconButton } from "../../../../components"
-import { CryptoKey, KeystoreAccount } from "../../../../background/types"
 import useSWR from "swr"
-import { Layout } from "../../../../components/Layout"
+import { rpc } from "@/containers/WalletPopup/api"
+import { ss58Address } from "@polkadot-labs/hdkd-helpers"
+import React from "react"
+import { cn } from "@/lib/utils"
 
-type AccountItemProps = {
-  bgColor: string
-  heading?: string
+type AccountCardProps = React.ComponentProps<typeof Card> & {
+  name: string
   ss58Address: string
 }
 
-const AccountItem: React.FC<AccountItemProps> = ({
-  bgColor,
-  heading,
-  ss58Address,
-}) => {
-  const maxLength = 32
-  const ellipsisText =
-    ss58Address.length > maxLength
-      ? `${ss58Address.substring(0, maxLength / 2)}...${ss58Address.substring(ss58Address.length - maxLength / 2, ss58Address.length)}`
-      : ss58Address
-
+const AccountCard: React.FC<AccountCardProps> = (props) => {
   return (
-    <div className="flex items-center px-4 py-2 border-b">
-      <div
-        className={`flex-shrink-0 w-10 h-10 rounded-full ${bgColor} mr-3`}
-      ></div>
-      <div className="flex-grow">
-        {heading ? (
-          <>
-            <div className="text-sm font-medium">{heading}</div>
-            <div className="text-xs text-gray-500">{ellipsisText}</div>
-          </>
-        ) : (
-          <div className="font-medium text-gray-500">{ellipsisText}</div>
-        )}
+    <Card key={props.name} className="p-2">
+      <div className="flex items-center justify-between">
+        <div>
+          <CardTitle className="font-semibold text-base mb-0.5">
+            {props.name}
+          </CardTitle>
+          <CardDescription className="text-xs truncate max-w-[240px]">
+            {props.ss58Address}
+          </CardDescription>
+        </div>
+        <Button variant="ghost" asChild>
+          <Link to={`/accounts/${props.ss58Address}`}>
+            <ArrowRight className="w-4 h-4" />
+          </Link>
+        </Button>
       </div>
-      <Link to={`/accounts/${ss58Address}`}>
-        <button type="button">
-          <ChevronRight className="text-gray-400" />
-        </button>
-      </Link>
-    </div>
+    </Card>
   )
 }
 
-const EmptyAccounts: React.FC = () => {
-  return (
-    <section>
-      <div className="text-center">
-        <div className="mb-6">
-          <PlusCircle className="w-24 h-24 mx-auto text-gray-400" />
+const AccountsSkeleton: React.FC = () => {
+  return new Array(10).fill(null).map((_, i) => (
+    <Card
+      key={`account-skeleton-card-${i}`}
+      className="p-2 mb-2 transition duration-300 border rounded-lg hover:shadow-md"
+    >
+      <div className="flex items-center justify-between">
+        <div className="w-full">
+          <Skeleton className="w-5/12 h-4 mb-2" />
+          <Skeleton className="w-11/12 h-3" />
         </div>
-        <h1 className="mb-2 text-xl font-semibold text-gray-700">
-          No Accounts Added
-        </h1>
-        <p className="mb-4 text-gray-600">
-          You haven't added any accounts yet. Let's get started.
-        </p>
-        <Link to={"/accounts/add"}>
-          <button
-            type="button"
-            className="inline-flex items-center justify-center px-4 py-2 text-white bg-teal-600 border border-transparent rounded-md hover:bg-teal-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-teal-500"
-          >
-            <PlusCircle className="w-5 h-5 mr-2" />
-            Add Account
-          </button>
-        </Link>
+        <Button variant="ghost" disabled>
+          <Skeleton className="w-4 h-4" />
+        </Button>
       </div>
-    </section>
-  )
-}
-
-type AccountsListProps = {
-  cryptoKey: CryptoKey
-}
-
-const AccountsList: React.FC<AccountsListProps> = ({ cryptoKey }) => {
-  const keysetAccounts = cryptoKey.accounts
-    .filter(
-      (account): account is Extract<KeystoreAccount, { type: "Keyset" }> =>
-        account.type === "Keyset",
-    )
-    .map(({ path, publicKey }) => [path, ss58Address(publicKey)] as const)
-  const keypairAccounts = cryptoKey.accounts
-    .filter(
-      (account): account is Extract<KeystoreAccount, { type: "Keypair" }> =>
-        account.type === "Keypair",
-    )
-    .map(({ publicKey }) => ss58Address(publicKey))
-
-  return (
-    <section>
-      <div className="flex flex-col items-center px-4 py-4">
-        <img
-          src="https://i.imgur.com/lp2ruGY.png"
-          alt="Profile"
-          className="w-24 h-24 rounded-full"
-        />
-        <h1 className="text-2xl font-bold mt-2">{cryptoKey.name}</h1>
-      </div>
-      <div className="px-4">
-        <h2 className="text-lg font-semibold mb-2">Crypto Keys</h2>
-        <div className="bg-white rounded-lg shadow mb-4">
-          {keysetAccounts.map(([path, ss58Address]) => (
-            <AccountItem
-              bgColor="bg-purple-200"
-              heading={path}
-              ss58Address={ss58Address}
-            />
-          ))}
-        </div>
-
-        <div className="bg-white rounded-lg shadow mb-4">
-          {keypairAccounts.map((ss58Address) => (
-            <AccountItem bgColor="bg-purple-200" ss58Address={ss58Address} />
-          ))}
-        </div>
-      </div>
-    </section>
-  )
+    </Card>
+  ))
 }
 
 export const Accounts = () => {
   const navigate = useNavigate()
-  const { data: cryptoKeys, mutate } = useSWR(
+  const { data: cryptoKeys, isLoading: isFetchingCryptoKeys } = useSWR(
     "rpc.getCryptoKeys",
     () => rpc.client.getCryptoKeys(),
     {
       revalidateOnFocus: true,
     },
   )
-  const selectedCryptoKeyName = window.localStorage.getItem(
-    "selectedCryptoKeyName",
-  )
-  const cryptoKey =
+
+  const [selectedCryptoKeyName, setSelectedCryptoKeyName] = useState<string>()
+
+  useEffect(() => {
+    const storedCryptoKey = window.localStorage.getItem("selectedCryptoKeyName")
+    if (!storedCryptoKey) return
+
+    setSelectedCryptoKeyName(storedCryptoKey)
+  }, [])
+
+  useEffect(() => {
+    if (!selectedCryptoKeyName) return
+
+    window.localStorage.setItem("selectedCryptoKeyName", selectedCryptoKeyName)
+  }, [selectedCryptoKeyName])
+
+  const keygroup =
     cryptoKeys?.find((k) => k.name === selectedCryptoKeyName) ?? cryptoKeys?.[0]
 
-  const reset = async () => {
-    await rpc.client.clearCryptoKeys()
-    await mutate()
-    navigate(0)
-  }
+  const accounts = keygroup?.accounts ?? []
+
+  const keysetAccounts = accounts
+    .filter((account) => account.type === "Keyset")
+    .map(({ path, publicKey }) => [path, ss58Address(publicKey)] as const)
+  const keypairAccounts = accounts
+    .filter((account) => account.type === "Keypair")
+    .map(({ publicKey }) => ss58Address(publicKey))
+
+  const [selectedNavItem, setSelectedNavItem] = useState("home")
+
+  const navItems = [
+    { name: "home", icon: Home, onClick: () => navigate("/accounts") },
+    {
+      name: "networks",
+      icon: Globe,
+      onClick: () => setSelectedNavItem("networks"),
+    },
+    { name: "add", icon: Plus, onClick: () => navigate("/accounts/add") },
+    {
+      name: "import",
+      icon: Download,
+      onClick: () => navigate("/accounts/import"),
+    },
+    {
+      name: "debug",
+      icon: Code,
+      onClick: () => navigate("/debug"),
+    },
+  ]
 
   return (
-    <Layout>
-      <div className="max-w-xl flex flex-col">
-        <div className="bg-white px-4 py-2 flex items-center justify-between">
-          <IconButton onClick={reset}>
-            <RotateCcw />
-          </IconButton>
-          <div className="flex items-center">
-            <IconButton disabled={!cryptoKeys || cryptoKeys.length === 0}>
-              <Link to="/accounts/import">
-                <Import />
-              </Link>
-            </IconButton>
-            <IconButton>
-              <Link to="/accounts/add">
-                <Plus />
-              </Link>
-            </IconButton>
-            <IconButton disabled={!cryptoKey}>
-              <Link
-                to="/accounts/switch"
-                className={!cryptoKey ? "pointer-events-none" : ""}
-              >
-                <ArrowRightLeft />
-              </Link>
-            </IconButton>
-            <IconButton>
-              <Link to="/options" target="_blank">
-                <Settings />
-              </Link>
-            </IconButton>
-          </div>
+    <Layout2>
+      <header
+        className={cn(
+          "flex items-center justify-between pt-6 pb-4 bg-foreground",
+          "px-6 sm:px-8",
+          "text-primary-foreground",
+        )}
+      >
+        <div className="text-2xl font-semibold leading-4">
+          substrate
+          <span className="text-primary">_</span>
+          <br />
+          <span className="text-4xl text-primary">connect</span>
         </div>
-        {cryptoKey ? <AccountsList cryptoKey={cryptoKey} /> : <EmptyAccounts />}
+        <Link to="/options" target="_blank" rel="noopener noreferrer">
+          <Button type="button" variant="ghost">
+            <Settings className="w-6 h-6" />
+          </Button>
+        </Link>
+      </header>
+
+      <div className="flex items-center justify-between px-6 mt-4 mb-4 sm:px-8">
+        <h2 className="text-xl font-semibold">Your Accounts</h2>
+        <Select
+          disabled={!cryptoKeys || cryptoKeys.length === 0}
+          value={selectedCryptoKeyName}
+          onValueChange={(v) => setSelectedCryptoKeyName(v)}
+        >
+          <SelectTrigger className="w-[180px]">
+            <SelectValue placeholder="Select Crypto Key" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              <SelectLabel>Crypto Keys</SelectLabel>
+              {(cryptoKeys ?? []).map((key) => (
+                <SelectItem key={key.name} value={key.name}>
+                  {key.name}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
       </div>
-    </Layout>
+
+      <ScrollArea className="px-6 mb-4 grow sm:px-8">
+        <section>
+          {isFetchingCryptoKeys && <AccountsSkeleton />}
+          {!isFetchingCryptoKeys && (
+            <div className="pr-2 space-y-2">
+              {keysetAccounts.map(([derivationPath, ss58Address]) => (
+                <AccountCard name={derivationPath} ss58Address={ss58Address} />
+              ))}
+              {keypairAccounts.map((ss58Address, i) => (
+                <AccountCard name={`Account ${i}`} ss58Address={ss58Address} />
+              ))}
+            </div>
+          )}
+        </section>
+      </ScrollArea>
+
+      <nav className="p-4 bg-foreground">
+        <div className="flex justify-around">
+          {navItems.map((item) => (
+            <Button
+              key={item.name}
+              variant="ghost"
+              onClick={item.onClick}
+              className={`flex flex-col items-center space-y-1 hover:bg-muted-foreground ${
+                selectedNavItem === item.name
+                  ? "text-primary"
+                  : "text-secondary hover:text-accent"
+              }`}
+            >
+              <item.icon className="w-6 h-6 min-h-6" />
+              <span className="text-xs font-medium capitalize">
+                {item.name}
+              </span>
+            </Button>
+          ))}
+        </div>
+      </nav>
+    </Layout2>
   )
 }

--- a/projects/wallet-template/src/containers/WalletPopup/pages/CreatePassword.tsx
+++ b/projects/wallet-template/src/containers/WalletPopup/pages/CreatePassword.tsx
@@ -75,8 +75,8 @@ export const CreatePassword = () => {
     <Layout2>
       {isSubmitSuccessful && <Navigate to="/accounts" replace={true} />}
       <Form {...form}>
-        <form onSubmit={handleSubmit(onSubmit)}>
-          <Card className="flex flex-col flex-grow w-full max-w-md min-h-full rounded-none lg:rounded">
+        <form className="relative grow" onSubmit={handleSubmit(onSubmit)}>
+          <Card className="absolute flex flex-col flex-grow w-full max-w-md min-h-full shadow-none">
             <CardHeader className="text-center">
               <CardTitle className="mt-6 text-2xl font-extrabold">
                 Create Password<span className="text-primary">_</span>

--- a/projects/wallet-template/src/containers/WalletPopup/pages/Welcome.tsx
+++ b/projects/wallet-template/src/containers/WalletPopup/pages/Welcome.tsx
@@ -18,7 +18,7 @@ export const Welcome = () => {
 
   return (
     <Layout2>
-      <Card className="flex flex-col flex-grow w-full max-w-md min-h-full rounded-none lg:rounded">
+      <Card className="flex flex-col flex-grow w-full max-w-md min-h-full shadow-none">
         <CardHeader className="text-center">
           <CardTitle className="mt-6 text-2xl leading-4">
             <span className="pl-4 font-semibold">


### PR DESCRIPTION
- Updates the Account page to look better.
- Removes the debug header since it can now be accessed in the Accounts UI under the debug tab
- Adds Typescript 5.5 beta to take advatange of the [type predicate inference feature](https://www.totaltypescript.com/type-predicate-inference), specifically when the accounts are filtered between derivation path based accounts and imported accounts. Before we were writing our own type guards. This release is [almost out](https://devblogs.microsoft.com/typescript/announcing-typescript-5-5-beta/), so this addition should be a non-issue.


![image](https://github.com/paritytech/substrate-connect/assets/21375952/f86ac15c-8758-4bc5-ad8b-7562423289f7)