### PR TITLE
fix: force substrate connect version

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,10 @@
     "typedoc": "^0.25.13",
     "typescript": "^5.4.5"
   },
-  "packageManager": "pnpm@8.14.0"
+  "packageManager": "pnpm@8.14.0",
+  "pnpm": {
+    "overrides": {
+      "@substrate/connect": "workspace:^"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@substrate/connect': workspace:^
+
 importers:
 
   .:
@@ -308,7 +311,7 @@ importers:
         version: 7.8.1
       smoldot:
         specifier: 2.x
-        version: 2.0.22
+        version: 2.0.26
     devDependencies:
       '@types/chrome':
         specifier: ^0.0.266
@@ -352,7 +355,7 @@ importers:
         specifier: ^12.5.1
         version: 12.6.2(@polkadot/util@12.6.2)
       '@substrate/connect':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../packages/connect
       bn.js:
         specifier: ^5.2.1
@@ -404,7 +407,7 @@ importers:
         specifier: ^0.1.2
         version: 0.1.2
       '@substrate/connect':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../packages/connect
       '@substrate/connect-known-chains':
         specifier: workspace:*
@@ -770,7 +773,7 @@ importers:
         specifier: ^0.1.2
         version: 0.1.2
       '@substrate/connect':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../packages/connect
 
 packages:
@@ -3174,20 +3177,6 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@polkadot-api/client@0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0(rxjs@7.8.1):
-    resolution: {integrity: sha512-0fqK6pUKcGHSG2pBvY+gfSS+1mMdjd/qRygAcKI5d05tKsnZLRnmhb9laDguKmGEIB0Bz9vQqNK3gIN/cfvVwg==}
-    requiresBuild: true
-    peerDependencies:
-      rxjs: '>=7.8.0'
-    dependencies:
-      '@polkadot-api/metadata-builders': 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
-      '@polkadot-api/substrate-bindings': 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
-      '@polkadot-api/substrate-client': 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
-      '@polkadot-api/utils': 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
-      rxjs: 7.8.1
-    dev: false
-    optional: true
-
   /@polkadot-api/codegen@0.5.0:
     resolution: {integrity: sha512-saG4doKcN7Hr9KwiIMrpC+n+VBHknEOItBZkx0Qc+d5O/NAfIumIRJiHFHfH59N2JIvQlCR5mbuLMH7HcYuf6w==}
     dependencies:
@@ -3200,24 +3189,12 @@ packages:
     resolution: {integrity: sha512-gmVDUP8LpCH0BXewbzqXF2sdHddq1H1q+XrAW2of+KZj4woQkIGBRGTJHeBEVHe30EB+UejR1N2dT4PO/RvDdg==}
     dev: false
 
-  /@polkadot-api/json-rpc-provider-proxy@0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0:
-    resolution: {integrity: sha512-0hZ8vtjcsyCX8AyqP2sqUHa1TFFfxGWmlXJkit0Nqp9b32MwZqn5eaUAiV2rNuEpoglKOdKnkGtUF8t5MoodKw==}
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@polkadot-api/json-rpc-provider-proxy@0.1.0:
     resolution: {integrity: sha512-8GSFE5+EF73MCuLQm8tjrbCqlgclcHBSRaswvXziJ0ZW7iw3UEMsKkkKvELayWyBuOPa2T5i1nj6gFOeIsqvrg==}
 
   /@polkadot-api/json-rpc-provider@0.0.1:
     resolution: {integrity: sha512-/SMC/l7foRjpykLTUTacIH05H3mr9ip8b5xxfwXlVezXrNVLp3Cv0GX6uItkKd+ZjzVPf3PFrDF2B2/HLSNESA==}
     dev: false
-
-  /@polkadot-api/json-rpc-provider@0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0:
-    resolution: {integrity: sha512-EaUS9Fc3wsiUr6ZS43PQqaRScW7kM6DYbuM/ou0aYjm8N9MBqgDbGm2oL6RE1vAVmOfEuHcXZuZkhzWtyvQUtA==}
-    requiresBuild: true
-    dev: false
-    optional: true
 
   /@polkadot-api/known-chains@0.1.3:
     resolution: {integrity: sha512-vLbv3iAjDqZiqlJmAPRCQc8c2pErX2z7awkp27Eb4l7V9HPhMPAZiDTNRpMkynNJy5JOl7waCi182nYLZZ/+aA==}
@@ -3241,15 +3218,6 @@ packages:
       '@polkadot-api/utils': 0.0.1
     dev: false
 
-  /@polkadot-api/metadata-builders@0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0:
-    resolution: {integrity: sha512-BD7rruxChL1VXt0icC2gD45OtT9ofJlql0qIllHSRYgama1CR2Owt+ApInQxB+lWqM+xNOznZRpj8CXNDvKIMg==}
-    requiresBuild: true
-    dependencies:
-      '@polkadot-api/substrate-bindings': 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
-      '@polkadot-api/utils': 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
-    dev: false
-    optional: true
-
   /@polkadot-api/metadata-builders@0.2.0:
     resolution: {integrity: sha512-Nyu2oC6ZG3vThO0Y5/hVsE5m+1DCBirkMdi2Kg9QiSrZpWDAif4STkUZHNZ5KJcFBtfooBMh64t/hpaDwokvBg==}
     dependencies:
@@ -3263,20 +3231,6 @@ packages:
       '@polkadot-api/substrate-bindings': 0.4.0
       '@polkadot-api/utils': 0.0.1
     dev: false
-
-  /@polkadot-api/observable-client@0.1.0(rxjs@7.8.1):
-    resolution: {integrity: sha512-GBCGDRztKorTLna/unjl/9SWZcRmvV58o9jwU2Y038VuPXZcr01jcw/1O3x+yeAuwyGzbucI/mLTDa1QoEml3A==}
-    requiresBuild: true
-    peerDependencies:
-      rxjs: '>=7.8.0'
-    dependencies:
-      '@polkadot-api/metadata-builders': 0.0.1
-      '@polkadot-api/substrate-bindings': 0.0.1
-      '@polkadot-api/substrate-client': 0.0.1
-      '@polkadot-api/utils': 0.0.1
-      rxjs: 7.8.1
-    dev: false
-    optional: true
 
   /@polkadot-api/observable-client@0.3.0(rxjs@7.8.1):
     resolution: {integrity: sha512-l29E9MfINzPh8SGf6vT5ZoQuW2LEvn/so5NV7SVyqnm8pVOvqyWLGdGLYMPAi03pVWamG30v6EXH2GvqIu65+Q==}
@@ -3343,17 +3297,6 @@ packages:
       scale-ts: 1.6.0
     dev: false
 
-  /@polkadot-api/substrate-bindings@0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0:
-    resolution: {integrity: sha512-N4vdrZopbsw8k57uG58ofO7nLXM4Ai7835XqakN27MkjXMp5H830A1KJE0L9sGQR7ukOCDEIHHcwXVrzmJ/PBg==}
-    requiresBuild: true
-    dependencies:
-      '@noble/hashes': 1.4.0
-      '@polkadot-api/utils': 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
-      '@scure/base': 1.1.6
-      scale-ts: 1.6.0
-    dev: false
-    optional: true
-
   /@polkadot-api/substrate-bindings@0.2.0:
     resolution: {integrity: sha512-lG47UIJwnesakR52IdymXmqdE/da29kvVFoGm2TenIPn9sVx5TqKQub2cXlkzzIt6xtlbvPm3Y4KI9vqMRpSjg==}
     dependencies:
@@ -3381,30 +3324,12 @@ packages:
       scale-ts: 1.6.0
     dev: false
 
-  /@polkadot-api/substrate-client@0.0.1:
-    resolution: {integrity: sha512-9Bg9SGc3AwE+wXONQoW8GC00N3v6lCZLW74HQzqB6ROdcm5VAHM4CB/xRzWSUF9CXL78ugiwtHx3wBcpx4H4Wg==}
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@polkadot-api/substrate-client@0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0:
-    resolution: {integrity: sha512-lcdvd2ssUmB1CPzF8s2dnNOqbrDa+nxaaGbuts+Vo8yjgSKwds2Lo7Oq+imZN4VKW7t9+uaVcKFLMF7PdH0RWw==}
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@polkadot-api/substrate-client@0.1.2:
     resolution: {integrity: sha512-rSyjQKUkclfmLTVAVVpR8t8ow52uwd88wbCaBHGwg6aiNNnyMzg8/Su6mi2KpiOtrFnLKG7y96BTR41aFDdl+A==}
 
   /@polkadot-api/utils@0.0.1:
     resolution: {integrity: sha512-3j+pRmlF9SgiYDabSdZsBSsN5XHbpXOAce1lWj56IEEaFZVjsiCaxDOA7C9nCcgfVXuvnbxqqEGQvnY+QfBAUw==}
     dev: false
-
-  /@polkadot-api/utils@0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0:
-    resolution: {integrity: sha512-0CYaCjfLQJTCRCiYvZ81OncHXEKPzAexCMoVloR+v2nl/O2JRya/361MtPkeNLC6XBoaEgLAG9pWQpH3WePzsw==}
-    requiresBuild: true
-    dev: false
-    optional: true
 
   /@polkadot-api/utils@0.1.0:
     resolution: {integrity: sha512-MXzWZeuGxKizPx2Xf/47wx9sr/uxKw39bVJUptTJdsaQn/TGq+z310mHzf1RCGvC1diHM8f593KrnDgc9oNbJA==}
@@ -3646,7 +3571,7 @@ packages:
       nock: 13.5.4
       tslib: 2.6.2
     optionalDependencies:
-      '@substrate/connect': 0.8.8
+      '@substrate/connect': link:packages/connect
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -3670,7 +3595,7 @@ packages:
       nock: 13.5.4
       tslib: 2.6.2
     optionalDependencies:
-      '@substrate/connect': 0.8.10
+      '@substrate/connect': link:packages/connect
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -5392,80 +5317,6 @@ packages:
     resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
     engines: {node: '>=14.16'}
     dev: true
-
-  /@substrate/connect-extension-protocol@2.0.0:
-    resolution: {integrity: sha512-nKu8pDrE3LNCEgJjZe1iGXzaD6OSIDD4Xzz/yo4KO9mQ6LBvf49BVrt4qxBFGL6++NneLiWUZGoh+VSd4PyVIg==}
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@substrate/connect-known-chains@1.1.4:
-    resolution: {integrity: sha512-iT+BdKqvKl/uBLd8BAJysFM1BaMZXRkaXBP2B7V7ob/EyNs5h0EMhTVbO6MJxV/IEOg5OKsyl6FUqQK7pKnqyw==}
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@substrate/connect@0.8.10:
-    resolution: {integrity: sha512-DIyQ13DDlXqVFnLV+S6/JDgiGowVRRrh18kahieJxhgvzcWicw5eLc6jpfQ0moVVLBYkO7rctB5Wreldwpva8w==}
-    requiresBuild: true
-    dependencies:
-      '@substrate/connect-extension-protocol': 2.0.0
-      '@substrate/connect-known-chains': 1.1.4
-      '@substrate/light-client-extension-helpers': 0.0.6(smoldot@2.0.22)
-      smoldot: 2.0.22
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-    dev: false
-    optional: true
-
-  /@substrate/connect@0.8.8:
-    resolution: {integrity: sha512-zwaxuNEVI9bGt0rT8PEJiXOyebLIo6QN1SyiAHRPBOl6g3Sy0KKdSN8Jmyn++oXhVRD8aIe75/V8ZkS81T+BPQ==}
-    requiresBuild: true
-    dependencies:
-      '@substrate/connect-extension-protocol': 2.0.0
-      '@substrate/connect-known-chains': 1.1.4
-      '@substrate/light-client-extension-helpers': 0.0.4(smoldot@2.0.22)
-      smoldot: 2.0.22
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-    dev: false
-    optional: true
-
-  /@substrate/light-client-extension-helpers@0.0.4(smoldot@2.0.22):
-    resolution: {integrity: sha512-vfKcigzL0SpiK+u9sX6dq2lQSDtuFLOxIJx2CKPouPEHIs8C+fpsufn52r19GQn+qDhU8POMPHOVoqLktj8UEA==}
-    requiresBuild: true
-    peerDependencies:
-      smoldot: 2.x
-    dependencies:
-      '@polkadot-api/client': 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0(rxjs@7.8.1)
-      '@polkadot-api/json-rpc-provider': 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
-      '@polkadot-api/json-rpc-provider-proxy': 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
-      '@polkadot-api/substrate-client': 0.0.1-492c132563ea6b40ae1fc5470dec4cd18768d182.1.0
-      '@substrate/connect-extension-protocol': 2.0.0
-      '@substrate/connect-known-chains': 1.1.4
-      rxjs: 7.8.1
-      smoldot: 2.0.22
-    dev: false
-    optional: true
-
-  /@substrate/light-client-extension-helpers@0.0.6(smoldot@2.0.22):
-    resolution: {integrity: sha512-girltEuxQ1BvkJWmc8JJlk4ZxnlGXc/wkLcNguhY+UoDEMBK0LsdtfzQKIfrIehi4QdeSBlFEFBoI4RqPmsZzA==}
-    requiresBuild: true
-    peerDependencies:
-      smoldot: 2.x
-    dependencies:
-      '@polkadot-api/json-rpc-provider': 0.0.1
-      '@polkadot-api/json-rpc-provider-proxy': 0.0.1
-      '@polkadot-api/observable-client': 0.1.0(rxjs@7.8.1)
-      '@polkadot-api/substrate-client': 0.0.1
-      '@substrate/connect-extension-protocol': 2.0.0
-      '@substrate/connect-known-chains': 1.1.4
-      rxjs: 7.8.1
-      smoldot: 2.0.22
-    dev: false
-    optional: true
 
   /@substrate/ss58-registry@1.47.0:
     resolution: {integrity: sha512-6kuIJedRcisUJS2pgksEH2jZf3hfSIVzqtFzs/AyjTW3ETbMg5q1Bb7VWa0WYaT6dTrEXp/6UoXM5B9pSIUmcw==}
@@ -12684,15 +12535,6 @@ packages:
       ansi-styles: 6.2.1
       is-fullwidth-code-point: 5.0.0
     dev: true
-
-  /smoldot@2.0.22:
-    resolution: {integrity: sha512-B50vRgTY6v3baYH6uCgL15tfaag5tcS2o/P5q1OiXcKGv1axZDfz2dzzMuIkVpyMR2ug11F6EAtQlmYBQd292g==}
-    dependencies:
-      ws: 8.17.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-    dev: false
 
   /smoldot@2.0.26:
     resolution: {integrity: sha512-F+qYmH4z2s2FK+CxGj8moYcd1ekSIKH8ywkdqlOz88Dat35iB1DIYL11aILN46YSGMzQW/lbJNS307zBSDN5Ig==}


### PR DESCRIPTION
Polkadot JS has an optional dependecy on substrate connect that is only used as types. This is causing "older" substrate connect versions and its dependencies to leak into the lockfile which is annoying. 

This change locks the `@substrate/connect` version to the workspace version

```
➜  substrate-connect git:(main) corepack pnpm why -r @substrate/connect
Legend: production dependency, optional only, dev only

@substrate/burnr@0.0.0 /home/ryan/Documents/Repositories/substrate-connect/projects/burnr

dependencies:
@polkadot/api 10.13.1
├─┬ @polkadot/api-augment 10.13.1
│ └─┬ @polkadot/api-base 10.13.1
│   └─┬ @polkadot/rpc-core 10.13.1
│     └─┬ @polkadot/rpc-provider 10.13.1
│       └── @substrate/connect 0.8.8
├─┬ @polkadot/api-base 10.13.1
│ └─┬ @polkadot/rpc-core 10.13.1
│   └─┬ @polkadot/rpc-provider 10.13.1
│     └── @substrate/connect 0.8.8
├─┬ @polkadot/api-derive 10.13.1
│ ├─┬ @polkadot/api-augment 10.13.1
│ │ └─┬ @polkadot/api-base 10.13.1
│ │   └─┬ @polkadot/rpc-core 10.13.1
│ │     └─┬ @polkadot/rpc-provider 10.13.1
│ │       └── @substrate/connect 0.8.8
│ ├─┬ @polkadot/api-base 10.13.1
│ │ └─┬ @polkadot/rpc-core 10.13.1
│ │   └─┬ @polkadot/rpc-provider 10.13.1
│ │     └── @substrate/connect 0.8.8
│ └─┬ @polkadot/rpc-core 10.13.1
│   └─┬ @polkadot/rpc-provider 10.13.1
│     └── @substrate/connect 0.8.8
├─┬ @polkadot/rpc-core 10.13.1
│ └─┬ @polkadot/rpc-provider 10.13.1
│   └── @substrate/connect 0.8.8
└─┬ @polkadot/rpc-provider 10.13.1
  └── @substrate/connect 0.8.8
@polkadot/api-augment 10.13.1
└─┬ @polkadot/api-base 10.13.1
  └─┬ @polkadot/rpc-core 10.13.1
    └─┬ @polkadot/rpc-provider 10.13.1
      └── @substrate/connect 0.8.8
@polkadot/rpc-provider 11.0.3
└── @substrate/connect 0.8.10
@substrate/connect link:../../packages/connect

@substrate/demo@0.0.0 /home/ryan/Documents/Repositories/substrate-connect/projects/demo

dependencies:
@substrate/connect link:../../packages/connect

@substrate/wallet-template@0.0.1 /home/ryan/Documents/Repositories/substrate-connect/projects/wallet-template

dependencies:
@polkadot/extension-inject 0.46.9
├─┬ @polkadot/api 10.13.1 peer
│ ├─┬ @polkadot/api-augment 10.13.1
│ │ └─┬ @polkadot/api-base 10.13.1
│ │   └─┬ @polkadot/rpc-core 10.13.1
│ │     └─┬ @polkadot/rpc-provider 10.13.1
│ │       └── @substrate/connect 0.8.8
│ ├─┬ @polkadot/api-base 10.13.1
│ │ └─┬ @polkadot/rpc-core 10.13.1
│ │   └─┬ @polkadot/rpc-provider 10.13.1
│ │     └── @substrate/connect 0.8.8
│ ├─┬ @polkadot/api-derive 10.13.1
│ │ ├─┬ @polkadot/api-augment 10.13.1
│ │ │ └─┬ @polkadot/api-base 10.13.1
│ │ │   └─┬ @polkadot/rpc-core 10.13.1
│ │ │     └─┬ @polkadot/rpc-provider 10.13.1
│ │ │       └── @substrate/connect 0.8.8
│ │ ├─┬ @polkadot/api-base 10.13.1
│ │ │ └─┬ @polkadot/rpc-core 10.13.1
│ │ │   └─┬ @polkadot/rpc-provider 10.13.1
│ │ │     └── @substrate/connect 0.8.8
│ │ └─┬ @polkadot/rpc-core 10.13.1
│ │   └─┬ @polkadot/rpc-provider 10.13.1
│ │     └── @substrate/connect 0.8.8
│ ├─┬ @polkadot/rpc-core 10.13.1
│ │ └─┬ @polkadot/rpc-provider 10.13.1
│ │   └── @substrate/connect 0.8.8
│ └─┬ @polkadot/rpc-provider 10.13.1
│   └── @substrate/connect 0.8.8
└─┬ @polkadot/rpc-provider 10.13.1
  └── @substrate/connect 0.8.8

zombienet-tests@0.0.1 /home/ryan/Documents/Repositories/substrate-connect/zombienet-tests
```