### PR TITLE
chore(zombienet-tests): increase timeout

### DIFF
--- a/zombienet-tests/src/0002-parachain.zndsl
+++ b/zombienet-tests/src/0002-parachain.zndsl
@@ -6,4 +6,4 @@ alice: is up
 bob: is up
 alice: parachain 100 is registered within 225 seconds
 alice: parachain 100 block height is at least 3 within 200 seconds
-bob: ts-script ./0002-checkSync.ts within 140 seconds
+bob: ts-script ./0002-checkSync.ts within 280 seconds


### PR DESCRIPTION
The zombienet tests are flaky and always timeout. This increases the timeout.