### PR TITLE
fix: discovery protocol - providers not being async

### DIFF
--- a/packages/connect-discovery/src/index.ts
+++ b/packages/connect-discovery/src/index.ts
@@ -65,7 +65,7 @@ export namespace Unstable {
   export type SubstrateConnectProviderDetail = {
     kind: typeof Kind
     info: ProviderInfo
-    provider: Provider
+    provider: Promise<Provider>
   }
 
   export const isSubstrateConnectExtension = (

--- a/packages/discovery/src/index.ts
+++ b/packages/discovery/src/index.ts
@@ -1,7 +1,7 @@
 export type ProviderDetail = {
   kind: string
   info: ProviderInfo
-  provider: unknown
+  provider: Promise<unknown>
 }
 
 export type OnProvider = {

--- a/packages/discovery/src/index.ts
+++ b/packages/discovery/src/index.ts
@@ -1,7 +1,7 @@
 export type ProviderDetail = {
   kind: string
   info: ProviderInfo
-  provider: Promise<unknown>
+  provider: unknown
 }
 
 export type OnProvider = {

--- a/packages/smoldot-discovery/src/types/index.ts
+++ b/packages/smoldot-discovery/src/types/index.ts
@@ -8,7 +8,7 @@ export type SmoldotExtensionAPI = {
 export type SmoldotExtensionProviderDetail = {
   kind: "smoldot-v1"
   info: ProviderInfo
-  provider: SmoldotExtensionAPI
+  provider: Promise<SmoldotExtensionAPI>
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -642,9 +642,15 @@ importers:
       '@react-rxjs/utils':
         specifier: ^0.9.7
         version: 0.9.7(@react-rxjs/core@0.10.7)(react@18.3.1)(rxjs@7.8.1)
+      '@substrate/connect-discovery':
+        specifier: workspace:^
+        version: link:../../packages/connect-discovery
       '@substrate/connect-extension-protocol':
         specifier: workspace:*
         version: link:../../packages/connect-extension-protocol
+      '@substrate/discovery':
+        specifier: workspace:^
+        version: link:../../packages/discovery
       '@substrate/light-client-extension-helpers':
         specifier: workspace:^
         version: link:../../packages/light-client-extension-helpers
@@ -733,9 +739,6 @@ importers:
       '@playwright/test':
         specifier: ^1.43.1
         version: 1.44.0
-      '@substrate/connect-discovery':
-        specifier: workspace:^
-        version: link:../../packages/connect-discovery
       '@types/node':
         specifier: ^20.13.0
         version: 20.13.0

--- a/projects/wallet-template/package.json
+++ b/projects/wallet-template/package.json
@@ -37,7 +37,6 @@
   "keywords": [],
   "devDependencies": {
     "@playwright/test": "^1.43.1",
-    "@substrate/connect-discovery": "workspace:^",
     "@types/node": "^20.13.0",
     "@vitejs/plugin-react-swc": "^3.6.0",
     "@webext-core/storage": "^1.2.0",
@@ -54,6 +53,8 @@
     "wxt": "^0.17.12"
   },
   "dependencies": {
+    "@substrate/connect-discovery": "workspace:^",
+    "@substrate/discovery": "workspace:^",
     "@headlessui/react": "^1.7.19",
     "@hookform/resolvers": "^3.4.0",
     "@noble/ciphers": "^0.5.2",

--- a/projects/wallet-template/src/inpage/index.ts
+++ b/projects/wallet-template/src/inpage/index.ts
@@ -4,79 +4,76 @@ import {
 } from "@substrate/light-client-extension-helpers/utils"
 import { getLightClientProvider } from "@substrate/light-client-extension-helpers/web-page"
 import type { Unstable } from "@substrate/connect-discovery"
+import "@substrate/discovery"
 
 import type { Account, BackgroundRpcSpec } from "../background/types"
 import { CHANNEL_ID } from "../constants"
 import { pjsInject } from "./pjsInject"
 import type { InPageRpcSpec } from "./types"
-;(async () => {
-  const PROVIDER_INFO = {
-    uuid: crypto.randomUUID(),
-    name: "Substrate Connect Wallet Template",
-    icon: "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'/>",
-    rdns: "io.github.paritytech.SubstrateConnectWalletTemplate",
-  }
 
-  type OnAccountsChangedCallback = (accounts: Account[]) => void
-  const onAccountsChangedCallbacks: OnAccountsChangedCallback[] = []
-  const subscribeOnAccountsChanged = (cb: OnAccountsChangedCallback) => {
-    onAccountsChangedCallbacks.push(cb)
-    return () => {
-      onAccountsChangedCallbacks.splice(
-        onAccountsChangedCallbacks.indexOf(cb),
-        1,
-      )
-    }
+const PROVIDER_INFO = {
+  uuid: crypto.randomUUID(),
+  name: "Substrate Connect Wallet Template",
+  icon: "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'/>",
+  rdns: "io.github.paritytech.SubstrateConnectWalletTemplate",
+}
+
+type OnAccountsChangedCallback = (accounts: Account[]) => void
+const onAccountsChangedCallbacks: OnAccountsChangedCallback[] = []
+const subscribeOnAccountsChanged = (cb: OnAccountsChangedCallback) => {
+  onAccountsChangedCallbacks.push(cb)
+  return () => {
+    onAccountsChangedCallbacks.splice(onAccountsChangedCallbacks.indexOf(cb), 1)
   }
-  const handlers: RpcMethodHandlers<InPageRpcSpec> = {
-    onAccountsChanged([accounts]) {
-      onAccountsChangedCallbacks.forEach((cb) => cb(accounts))
+}
+const handlers: RpcMethodHandlers<InPageRpcSpec> = {
+  onAccountsChanged([accounts]) {
+    onAccountsChangedCallbacks.forEach((cb) => cb(accounts))
+  },
+}
+const rpc = createRpc(
+  (msg: any) =>
+    window.postMessage({ msg, origin: "substrate-wallet-template/web" }),
+  handlers,
+).withClient<BackgroundRpcSpec>()
+window.addEventListener("message", ({ data }) => {
+  if (data?.origin !== "substrate-wallet-template/extension") return
+  rpc.handle(data.msg, undefined)
+})
+
+const provider = getLightClientProvider(CHANNEL_ID).then(
+  (lightClientProvider) => ({
+    ...lightClientProvider,
+    async getAccounts(chainId: string) {
+      return rpc.client.getAccounts(chainId)
     },
-  }
-  const rpc = createRpc(
-    (msg: any) =>
-      window.postMessage({ msg, origin: "substrate-wallet-template/web" }),
-    handlers,
-  ).withClient<BackgroundRpcSpec>()
-  window.addEventListener("message", ({ data }) => {
-    if (data?.origin !== "substrate-wallet-template/extension") return
-    rpc.handle(data.msg, undefined)
-  })
+    async createTx(chainId: string, from: string, callData: string) {
+      return rpc.client.createTx(chainId, from, callData)
+    },
+  }),
+)
 
-  const provider = await getLightClientProvider(CHANNEL_ID).then(
-    (lightClientProvider) => ({
-      ...lightClientProvider,
-      async getAccounts(chainId: string) {
-        return rpc.client.getAccounts(chainId)
-      },
-      async createTx(chainId: string, from: string, callData: string) {
-        return rpc.client.createTx(chainId, from, callData)
-      },
-    }),
-  )
+const detail: Unstable.SubstrateConnectProviderDetail = Object.freeze({
+  kind: "substrate-connect-unstable",
+  info: PROVIDER_INFO,
+  provider,
+})
 
-  const detail: Unstable.SubstrateConnectProviderDetail = Object.freeze({
-    kind: "substrate-connect-unstable",
-    info: PROVIDER_INFO,
-    provider,
-  })
+window.addEventListener(
+  "substrateDiscovery:requestProvider",
+  ({ detail: { onProvider } }) => onProvider(detail),
+)
 
-  window.addEventListener(
-    "substrateDiscovery:requestProvider",
-    ({ detail: { onProvider } }) => onProvider(detail),
-  )
+window.dispatchEvent(
+  new CustomEvent("substrateDiscovery:announceProvider", {
+    detail,
+  }),
+)
 
-  window.dispatchEvent(
-    new CustomEvent("substrateDiscovery:announceProvider", {
-      detail,
-    }),
-  )
-
-  pjsInject({
-    name: PROVIDER_INFO.name,
-    version: "0.0.1",
-    rpc: rpc.client,
-    provider,
-    subscribeOnAccountsChanged,
-  })
-})()
+pjsInject({
+  name: PROVIDER_INFO.name,
+  version: "0.0.1",
+  rpc: rpc.client,
+  providerPromise: provider,
+  subscribeOnAccountsChanged,
+})

--- a/projects/wallet-template/src/inpage/pjsInject.ts
+++ b/projects/wallet-template/src/inpage/pjsInject.ts
@@ -9,14 +9,14 @@ type PjsInjectOpts = {
   name: string
   version: string
   rpc: BackgroundRpcSpec
-  provider: Unstable.Provider
+  providerPromise: Promise<Unstable.Provider>
   subscribeOnAccountsChanged: (cb: (accounts: Account[]) => void) => () => void
 }
 export const pjsInject = ({
   name,
   version,
   rpc,
-  provider,
+  providerPromise,
   subscribeOnAccountsChanged,
 }: PjsInjectOpts) =>
   injectExtension(
@@ -27,6 +27,7 @@ export const pjsInject = ({
         accounts: {
           // TODO: use anyType
           async get(_anyType) {
+            const provider = await providerPromise
             return (
               await Promise.all(
                 Object.values(provider.getChains()).map(


### PR DESCRIPTION
While working on #2221, I discovered its actually infeasible for the provider in `ProviderDetail`l to be a not declared as a promise.

```diff
export type ProviderDetail = {
  kind: string
  info: ProviderInfo
-  provider: unknown
+  provider: Promise<unknown>
}
```

This is because the provider is created in the inpage/content-script of the extension which runs at the same time when the dapp loads. So if your only able to create the provider asynchronously, you're out of luck because discovery protocol function `getProviders` will run when the page loads, leading to a race condition.

Hence, I'm changing this back to `Promise<unknown>`, which is what we orignally had before. 

## Example

In the wallet-template we invoke `getLightClientProvider` to create the provider which always returns a promise.

We could wait for that promise to resolve and register the provider 

```ts
getLightClientProvider(DOM_ELEMENT_ID).then((provider) => {
  const detail: LightClientProviderDetail = Object.freeze({
    info: PROVIDER_INFO,
    provider,
  })

  window.addEventListener(
    "substrateDiscovery:requestProvider",
    ({ detail: { onProvider } }) => onProvider(detail),
  )
  
  window.dispatchEvent(
    new CustomEvent("substrateDiscovery:announceProvider", {
      detail,
    }),
  )
})
```

But this doesn't work because its running at the same time, the dapp is calling `getProviders`. Meaning the eventListener may not be registered __BEFORE__ getProviders is called.