### PR TITLE
chore: remove workspaces in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,14 +14,6 @@
   ],
   "license": "GPL-3.0-only",
   "private": true,
-  "workspaces": [
-    "packages/connect-extension-protocol",
-    "packages/connect-known-chains",
-    "packages/connect",
-    "projects/extension",
-    "projects/burnr",
-    "projects/demo"
-  ],
   "scripts": {
     "downloadSpecs": "node bin/downloadSpecs.js",
     "api-docs": "typedoc",


### PR DESCRIPTION
Removes the `workspaces` field in the package.json. These don't work with pnpm. It was also causing changesets to fail in CI.