### PR TITLE
fix(smoldot-discovery): re-export missing types

### DIFF
--- a/.changeset/tame-tables-share.md
+++ b/.changeset/tame-tables-share.md
@@ -1,0 +1,5 @@
+---
+"@substrate/smoldot-discovery": patch
+---
+
+fix: re-export missing types from light client ext helpers webpage

--- a/packages/smoldot-discovery/src/connector.ts
+++ b/packages/smoldot-discovery/src/connector.ts
@@ -1,8 +1,6 @@
-import type {
+import {
   LightClientProvider,
   RawChain,
-} from "@substrate/light-client-extension-helpers/web-page"
-import {
   Chain,
   JsonRpcCallback,
   SmoldotExtensionAPI,

--- a/packages/smoldot-discovery/src/types/index.ts
+++ b/packages/smoldot-discovery/src/types/index.ts
@@ -1,4 +1,8 @@
 import { type ProviderInfo } from "@substrate/discovery"
+export type {
+  LightClientProvider,
+  RawChain,
+} from "@substrate/light-client-extension-helpers/web-page"
 
 export type SmoldotExtensionAPI = {
   addChain: AddChain


### PR DESCRIPTION
Re-exports the missing types that are exposed in the public API from @substrate/light-client-extension-helpers/web-page