### PR TITLE
fix(smoldot-discovery): peer dependencies constraint

### DIFF
--- a/.changeset/eleven-steaks-attend.md
+++ b/.changeset/eleven-steaks-attend.md
@@ -1,0 +1,5 @@
+---
+"@substrate/smoldot-discovery": patch
+---
+
+fix(smoldot-discovery): peer dependencies constraint

--- a/packages/smoldot-discovery/package.json
+++ b/packages/smoldot-discovery/package.json
@@ -47,6 +47,6 @@
     "@substrate/light-client-extension-helpers": "workspace:^"
   },
   "peerDependencies": {
-    "@substrate/light-client-extension-helpers": "^2"
+    "@substrate/light-client-extension-helpers": ">=2 && <3"
   }
 }


### PR DESCRIPTION
Update the peer dependencies constraint on "@substrate/light-client-extension-helpers since the current constraint confuses changesets and cause it to make a major version bump
