### PR TITLE
fix: `inpage.js` script variables leaking into global scope

### DIFF
--- a/.changeset/chatty-eels-taste.md
+++ b/.changeset/chatty-eels-taste.md
@@ -1,0 +1,6 @@
+---
+"@substrate/wallet-template": patch
+"@substrate/extension": patch
+---
+
+Fix `inpage.js` script variables leaking into the global scope, breaking any webpage with clashing variable names.

--- a/examples/light-client-extension-helpers-extension/src/content.ts
+++ b/examples/light-client-extension-helpers-extension/src/content.ts
@@ -6,6 +6,7 @@ register("extension-unique-id")
 // TODO: inpage script might not be needed
 try {
   const s = document.createElement("script")
+  s.type = "module"
   s.src = chrome.runtime.getURL("js/inpage.global.js")
   s.onload = function () {
     // @ts-ignore

--- a/projects/extension/src/content/index.ts
+++ b/projects/extension/src/content/index.ts
@@ -3,6 +3,7 @@ import { DOM_ELEMENT_ID } from "@substrate/connect-extension-protocol"
 
 try {
   const s = document.createElement("script")
+  s.type = "module"
   s.src = chrome.runtime.getURL("inpage/inpage.js")
   s.onload = () => s.remove()
   ;(document.head || document.documentElement).appendChild(s)

--- a/projects/wallet-template/STEP-BY-STEP-GUIDE.md
+++ b/projects/wallet-template/STEP-BY-STEP-GUIDE.md
@@ -63,6 +63,7 @@ const CHANNEL_ID = "substrate-wallet-template"
 
 try {
   const s = document.createElement("script")
+  s.type = "module"
   s.src = chrome.runtime.getURL("inpage/inpage.js")
   s.onload = () => s.remove()
   ;(document.head || document.documentElement).appendChild(s)

--- a/projects/wallet-template/src/content/index.ts
+++ b/projects/wallet-template/src/content/index.ts
@@ -4,6 +4,7 @@ import { CHANNEL_ID } from "../constants"
 
 try {
   const s = document.createElement("script")
+  s.type = "module"
   s.src = chrome.runtime.getURL("inpage/inpage.js")
   s.onload = () => s.remove()
   ;(document.head || document.documentElement).appendChild(s)


### PR DESCRIPTION
Script should be loaded as `module` to be run in isolated scope.

Fixes #2390