### PR TITLE
feat(light-client-ext-helpers):  handle page load events

### DIFF
--- a/.changeset/silly-numbers-relate.md
+++ b/.changeset/silly-numbers-relate.md
@@ -1,0 +1,5 @@
+---
+"@substrate/light-client-extension-helpers": patch
+---
+
+feat: handle page load events to restore connectivity in content script

--- a/packages/light-client-extension-helpers/src/content-script/content-script-helper.ts
+++ b/packages/light-client-extension-helpers/src/content-script/content-script-helper.ts
@@ -107,11 +107,19 @@ export const register = (channelId: string) => {
           break
       }
   })
+
+  window.addEventListener("pageshow", (event) => {
+    if (event.persisted) {
+      extensionRelayer = undefined
+      internalRpc = undefined
+    }
+  })
 }
 
 let extensionRelayer:
   | { postMessage(msg: RpcMessage | ToExtension): void }
   | undefined
+
 const getOrCreateExtensionRelayer = (
   onMessage: (msg: any) => void,
   onDisconnect?: (port: chrome.runtime.Port) => void,


### PR DESCRIPTION
Fixes an issue where this was being reported to the console: "The page keeping the extension port is moved into back/forward cache, so the message channel is closed."

https://www.perplexity.ai/page/extension-port-message-channel-0V97bWrTTdOY7pGHxnHXEw