### PR TITLE
fix: client getting stuck after smoldot restart

### DIFF
--- a/.changeset/pink-drinks-matter.md
+++ b/.changeset/pink-drinks-matter.md
@@ -1,0 +1,5 @@
+---
+"@substrate/light-client-extension-helpers": patch
+---
+
+fix: chains getting stuck after smoldot restart


### PR DESCRIPTION
Fixes an issue where chains connected from dapp would get stuck after smoldot was restarted. 