### PR TITLE
chore(lceh): remove papi peer deps

### DIFF
--- a/.changeset/cuddly-apricots-fly.md
+++ b/.changeset/cuddly-apricots-fly.md
@@ -1,0 +1,5 @@
+---
+"@substrate/light-client-extension-helpers": minor
+---
+
+chore: remove unnecessary papi peer dependencies

--- a/packages/light-client-extension-helpers/package.json
+++ b/packages/light-client-extension-helpers/package.json
@@ -8,6 +8,9 @@
     "url": "git+https://github.com/paritytech/polkadot-api.git"
   },
   "license": "MIT",
+  "main": "./dist/commonjs/index.js",
+  "types": "./dist/commonjs/index.d.ts",
+  "module": "./dist/esm/index.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {
@@ -203,28 +206,9 @@
     "semi": false,
     "trailingComma": "all"
   },
-  "devDependencies": {
-    "typescript": "catalog:",
+  "dependencies": {
     "@polkadot-api/json-rpc-provider": "catalog:polkadot-api",
     "@polkadot-api/polkadot-signer": "catalog:polkadot-api",
-    "@types/chrome": "^0.0.270",
-    "smoldot": "2.0.30",
-    "vitest": "^2.0.5"
-  },
-  "peerDependencies": {
-    "@polkadot-api/json-rpc-provider": "~0.0",
-    "@polkadot-api/polkadot-signer": "~0.0",
-    "smoldot": "2.x"
-  },
-  "peerDependenciesMeta": {
-    "@polkadot-api/json-rpc-provider": {
-      "optional": true
-    },
-    "@polkadot-api/polkadot-signer": {
-      "optional": true
-    }
-  },
-  "dependencies": {
     "@polkadot-api/codegen": "catalog:polkadot-api",
     "@polkadot-api/json-rpc-provider-proxy": "catalog:polkadot-api",
     "@polkadot-api/metadata-builders": "catalog:polkadot-api",
@@ -238,7 +222,15 @@
     "@substrate/connect-known-chains": "workspace:^",
     "rxjs": "^7.8.1"
   },
-  "main": "./dist/commonjs/index.js",
-  "types": "./dist/commonjs/index.d.ts",
-  "module": "./dist/esm/index.js"
+  "devDependencies": {
+    "typescript": "catalog:",
+    "@polkadot-api/json-rpc-provider": "catalog:polkadot-api",
+    "@polkadot-api/polkadot-signer": "catalog:polkadot-api",
+    "@types/chrome": "^0.0.270",
+    "smoldot": "2.0.30",
+    "vitest": "^2.0.5"
+  },
+  "peerDependencies": {
+    "smoldot": "2.x"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -592,6 +592,9 @@ importers:
       '@polkadot-api/codegen':
         specifier: catalog:polkadot-api
         version: 0.12.3
+      '@polkadot-api/json-rpc-provider':
+        specifier: catalog:polkadot-api
+        version: 0.0.4
       '@polkadot-api/json-rpc-provider-proxy':
         specifier: catalog:polkadot-api
         version: 0.2.3
@@ -604,6 +607,9 @@ importers:
       '@polkadot-api/observable-client':
         specifier: catalog:polkadot-api
         version: 0.5.8(@polkadot-api/substrate-client@0.2.2)(rxjs@7.8.1)
+      '@polkadot-api/polkadot-signer':
+        specifier: catalog:polkadot-api
+        version: 0.1.6
       '@polkadot-api/signer':
         specifier: catalog:polkadot-api
         version: 0.1.7
@@ -626,12 +632,6 @@ importers:
         specifier: ^7.8.1
         version: 7.8.1
     devDependencies:
-      '@polkadot-api/json-rpc-provider':
-        specifier: catalog:polkadot-api
-        version: 0.0.4
-      '@polkadot-api/polkadot-signer':
-        specifier: catalog:polkadot-api
-        version: 0.1.6
       '@types/chrome':
         specifier: ^0.0.270
         version: 0.0.270


### PR DESCRIPTION
Types are already re-exported, so this peer dep is useless.

https://github.com/paritytech/substrate-connect/blob/main/packages/light-client-extension-helpers/src/tx-helper/types.ts