### PR TITLE
fix!: make smoldot discovery interface conform to smoldot interface

### DIFF
--- a/.changeset/friendly-toys-remember.md
+++ b/.changeset/friendly-toys-remember.md
@@ -1,0 +1,33 @@
+---
+"@substrate/connect": major
+"@substrate/smoldot-discovery": major
+"@substrate/smoldot-discovery-connector": minor
+---
+
+## Breaking Changes
+
+- Modified `addChain` and `addWellKnownChain` methods:
+  - Now accept a single `options` object parameter instead of separate `jsonRpcCallback` and `databaseContent` parameters
+  - The `jsonRpcCallback` is now passed as `options.jsonRpcCallback`
+  - The `databaseContent` is now passed as `options.databaseContent`
+
+- Removed `JsonRpcCallback` type export. Use the callback type from the `options` parameter of `addChain` and `addWellKnownChain` instead.
+
+- Updated peer dependency for `@substrate/smoldot-discovery` to "^3"
+
+## New Features
+
+- Added new methods to the Chain interface to conform with smoldot's interface:
+  - `nextJsonRpcResponse`: Returns a promise that resolves with the next JSON-RPC response
+  - `jsonRpcResponses`: Returns an async iterable of JSON-RPC responses
+
+## Other Changes
+
+- Updated internal implementation to use Effect for streaming JSON RPC responses in a Queue.
+- Updated error handling to include `QueueFullError`.
+
+## Migration Guide
+
+Users of this package will need to update their code to use the new method signatures for `addChain` and `addWellKnownChain`, and adapt to the removed `JsonRpcCallback` type export. Please refer to the updated documentation for the new usage patterns.
+
+When upgrading, ensure you're using version 3 or higher of `@substrate/smoldot-discovery` as a peer dependency.

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -14,6 +14,7 @@ module.exports = {
         devDependencies: ["**/*.test.ts", "**/*.spec.ts", "**/*.bench.ts"],
       },
     ],
+    "@typescript-eslint/no-redeclare": "off",
   },
   env: {
     browser: true,

--- a/packages/connect/src/connector/index.ts
+++ b/packages/connect/src/connector/index.ts
@@ -53,19 +53,11 @@ export const createScClient = (config?: Config): ScClient => {
     : smoldotScClient(config?.embeddedNodeConfig)
 
   return {
-    async addChain(chainSpec, jsonRpcCallback, databaseContent) {
-      return (await client).addChain(
-        chainSpec,
-        jsonRpcCallback,
-        databaseContent,
-      )
+    async addChain(chainSpec, options) {
+      return (await client).addChain(chainSpec, options)
     },
-    async addWellKnownChain(id, jsonRpcCallback, databaseContent) {
-      return (await client).addWellKnownChain(
-        id,
-        jsonRpcCallback,
-        databaseContent,
-      )
+    async addWellKnownChain(id, options) {
+      return (await client).addWellKnownChain(id, options)
     },
   }
 }

--- a/packages/connect/src/connector/types.ts
+++ b/packages/connect/src/connector/types.ts
@@ -74,10 +74,9 @@ export {
   AlreadyDestroyedError,
   CrashError,
   JsonRpcDisabledError,
-} from "@substrate/smoldot-discovery/types"
-export type {
-  Chain,
-  JsonRpcCallback,
-  AddChain,
-  AddWellKnownChain,
+  QueueFullError,
+  type Chain,
+  type AddChain,
+  type AddWellKnownChain,
+  type AddChainOptions,
 } from "@substrate/smoldot-discovery/types"

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -95,11 +95,4 @@
  * @packageDocumentation
  */
 
-export { WellKnownChain } from "@substrate/smoldot-discovery/types"
 export * from "./connector/index.js"
-export type {
-  JsonRpcCallback,
-  Chain,
-  AddChain,
-  AddWellKnownChain,
-} from "./connector/index.js"

--- a/packages/smoldot-discovery-connector/package.json
+++ b/packages/smoldot-discovery-connector/package.json
@@ -52,14 +52,15 @@
     "trailingComma": "all"
   },
   "dependencies": {
-    "@substrate/light-client-extension-helpers": "workspace:^"
+    "@substrate/light-client-extension-helpers": "workspace:^",
+    "effect": "^3.10.0"
   },
   "devDependencies": {
-    "typescript": "catalog:",
     "@substrate/smoldot-discovery": "workspace:^",
+    "typescript": "catalog:",
     "vitest": "^2.0.5"
   },
   "peerDependencies": {
-    "@substrate/smoldot-discovery": ">=1 && <2"
+    "@substrate/smoldot-discovery": "^3"
   }
 }

--- a/packages/smoldot-discovery/src/types/index.ts
+++ b/packages/smoldot-discovery/src/types/index.ts
@@ -1,28 +1,39 @@
 import type { ProviderInfo } from "@substrate/discovery"
 export type * from "@substrate/discovery"
 
-export type SmoldotExtensionAPI = {
+export type SmoldotExtensionAPI = Readonly<{
   addChain: AddChain
   addWellKnownChain: AddWellKnownChain
-}
+}>
 
-export type SmoldotExtensionProviderDetail = {
+export type SmoldotExtensionProviderDetail = Readonly<{
   kind: "smoldot-v1"
   info: ProviderInfo
   provider: Promise<SmoldotExtensionAPI>
-}
+}>
 
 /**
  * List of popular chains that are likely to be connected to.
  *
  * The values in this enum correspond to the `id` field of the relevant chain specification.
  */
-export enum WellKnownChain {
-  polkadot = "polkadot",
-  ksmcc3 = "ksmcc3",
-  rococo_v2_2 = "rococo_v2_2",
-  westend2 = "westend2",
-  paseo = "paseo",
+export const WellKnownChain = {
+  polkadot: "polkadot",
+  ksmcc3: "ksmcc3",
+  rococo_v2_2: "rococo_v2_2",
+  westend2: "westend2",
+  paseo: "paseo",
+} as const
+
+export type WellKnownChain =
+  (typeof WellKnownChain)[keyof typeof WellKnownChain]
+
+export namespace WellKnownChain {
+  export type polkadot = typeof WellKnownChain.polkadot
+  export type ksmcc3 = typeof WellKnownChain.ksmcc3
+  export type rococo_v2_2 = typeof WellKnownChain.rococo_v2_2
+  export type westend2 = typeof WellKnownChain.westend2
+  export type paseo = typeof WellKnownChain.paseo
 }
 
 /**
@@ -56,8 +67,42 @@ export interface Chain {
    * @throws {JsonRpcDisabledError} If no JSON-RPC callback was passed in the options of the chain.
    * @throws {CrashError} If the background client has crashed.
    */
-  sendJsonRpc(rpc: string): void
+  readonly sendJsonRpc: (rpc: string) => void
 
+  /**
+   * Waits for a JSON-RPC response or notification to be generated.
+   *
+   * Each chain contains a buffer of the responses waiting to be sent out. Calling this function
+   * pulls one element from the buffer. If this function is called at a slower rate than
+   * responses are generated, then the buffer will eventually become full, at which point calling
+   * {@link Chain.sendJsonRpc} will throw an exception. The size of this buffer can be configured
+   * through {@link AddChainOptions.jsonRpcMaxPendingRequests}.
+   *
+   * If this function is called multiple times "simultaneously" (generating multiple different
+   * `Promise`s), each `Promise` will return a different JSON-RPC response or notification. In
+   * that situation, there is no guarantee in the ordering in which the responses or notifications
+   * are yielded. Calling this function multiple times "simultaneously" is in general a niche
+   * corner case that you are encouraged to avoid.
+   *
+   * @throws {@link AlreadyDestroyedError} If the chain has been removed or the client has been terminated.
+   * @throws {@link JsonRpcDisabledError} If the JSON-RPC system was disabled in the options of the chain.
+   * @throws {@link CrashError} If the background client has crashed.
+   */
+  readonly nextJsonRpcResponse: () => Promise<string>
+
+  /**
+   * JSON-RPC responses or notifications async iterable.
+   *
+   * Each chain contains a buffer of the responses waiting to be sent out. Iterating over this
+   * pulls one element from the buffer. If the iteration happen at a slower rate than
+   * responses are generated, then the buffer will eventually become full, at which point calling
+   * {@link Chain.sendJsonRpc} will throw an exception. The size of this buffer can be configured
+   * through {@link AddChainOptions.jsonRpcMaxPendingRequests}.
+   *
+   * @throws {@link JsonRpcDisabledError} If the JSON-RPC system was disabled in the options of the chain.
+   * @throws {@link CrashError} If the background client has crashed.
+   */
+  readonly jsonRpcResponses: AsyncIterableIterator<string>
   /**
    * Disconnects from the blockchain.
    *
@@ -70,10 +115,10 @@ export interface Chain {
    * to track parachains and relaychains, or to destroy them in the correct order, as this is
    * handled automatically.
    *
-   * @throws {AlreadyDestroyedError} If the chain has already been removed.
-   * @throws {CrashError} If the background client has crashed.
+   * @throws {@link AlreadyDestroyedError} If the chain has already been removed.
+   * @throws {@link CrashError} If the background client has crashed.
    */
-  remove(): void
+  readonly remove: () => void
 
   /**
    * Connects to a parachain.
@@ -93,31 +138,26 @@ export interface Chain {
    * objects.
    *
    * @param chainSpec Specification of the chain to add.
-   
-   * @param jsonRpcCallback Callback invoked in response to calling {Chain.sendJsonRpc}.
-   * This field is optional. If no callback is provided, the client will save up resources by not
-   * starting the JSON-RPC endpoint, and it is forbidden to call {Chain.sendJsonRpc}.
-   * Will never be called after ̀{Chain.remove} has been called or if a {CrashError} has been
-   * generated.
    *
-   * @throws {AddChainError} If the chain can't be added.
-   * @throws {CrashError} If the background client has crashed.
+   * @throws {@link AddChainError} If the chain can't be added.
+   * @throws {@link CrashError} If the background client has crashed.
    */
-  addChain: AddChain
+  readonly addChain: AddChain
 }
 
-export type JsonRpcCallback = (response: string) => void
+export type AddChainOptions = Readonly<{
+  disableJsonRpc?: boolean
+  databaseContent?: string | undefined
+  jsonRpcMaxPendingRequests?: number
+}>
 
 export type AddChain = (
   chainSpec: string,
-  jsonRpcCallback?: JsonRpcCallback,
-  databaseContent?: string,
+  options?: AddChainOptions,
 ) => Promise<Chain>
-
 export type AddWellKnownChain = (
   id: WellKnownChain,
-  jsonRpcCallback?: JsonRpcCallback,
-  databaseContent?: string,
+  options?: AddChainOptions,
 ) => Promise<Chain>
 
 export class AlreadyDestroyedError extends Error {
@@ -138,5 +178,12 @@ export class JsonRpcDisabledError extends Error {
   constructor() {
     super()
     this.name = "JsonRpcDisabledError"
+  }
+}
+
+export class QueueFullError extends Error {
+  constructor() {
+    super()
+    this.name = "QueueFullError"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ catalogs:
     '@polkadot-api/signer':
       specifier: ~0.1.7
       version: 0.1.7
+    '@polkadot-api/sm-provider':
+      specifier: ~0.1.3
+      version: 0.1.3
     '@polkadot-api/substrate-bindings':
       specifier: ~0.9.1
       version: 0.9.1
@@ -663,6 +666,9 @@ importers:
       '@substrate/light-client-extension-helpers':
         specifier: workspace:^
         version: link:../light-client-extension-helpers
+      effect:
+        specifier: ^3.10.0
+        version: 3.10.0
     devDependencies:
       '@substrate/smoldot-discovery':
         specifier: workspace:^
@@ -764,6 +770,9 @@ importers:
       '@polkadot-api/observable-client':
         specifier: catalog:polkadot-api
         version: 0.5.8(@polkadot-api/substrate-client@0.2.2)(rxjs@7.8.1)
+      '@polkadot-api/sm-provider':
+        specifier: catalog:polkadot-api
+        version: 0.1.3(smoldot@2.0.30)
       '@polkadot-api/substrate-client':
         specifier: catalog:polkadot-api
         version: 0.2.2
@@ -5606,6 +5615,9 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  effect@3.10.0:
+    resolution: {integrity: sha512-J9rsJBXNHZxklJTbHriY8D9wIHhmvXDamExW4pPZ2kPNZ+XRfstXeHBqpXAIK+B42ASVbuDswAXyup5WHWK6jg==}
+
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
@@ -5964,6 +5976,10 @@ packages:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
     engines: {node: '>= 10.17.0'}
     hasBin: true
+
+  fast-check@3.22.0:
+    resolution: {integrity: sha512-8HKz3qXqnHYp/VCNn2qfjHdAdcI8zcSqOyX64GOMukp7SL2bfzfeDKjSd+UyECtejccaZv3LcvZTm9YDD22iCQ==}
+    engines: {node: '>=8.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -7837,6 +7853,9 @@ packages:
 
   pure-color@1.3.0:
     resolution: {integrity: sha512-QFADYnsVoBMw1srW7OVKEYjG+MbIa49s54w1MA1EDY6r2r/sTcKKYqRX1f4GYvnXP7eN/Pe9HFcX+hwzmrXRHA==}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   qrcode.react@3.1.0:
     resolution: {integrity: sha512-oyF+Urr3oAMUG/OiOuONL3HXM+53wvuH3mtIWQrYmsXoAq0DkvZp2RYUWFSMFtbdOpuS++9v+WAkzNVkMlNW6Q==}
@@ -14843,6 +14862,10 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
+  effect@3.10.0:
+    dependencies:
+      fast-check: 3.22.0
+
   ejs@3.1.10:
     dependencies:
       jake: 10.9.1
@@ -15463,6 +15486,10 @@ snapshots:
       '@types/yauzl': 2.10.3
     transitivePeerDependencies:
       - supports-color
+
+  fast-check@3.22.0:
+    dependencies:
+      pure-rand: 6.1.0
 
   fast-deep-equal@3.1.3: {}
 
@@ -17439,6 +17466,8 @@ snapshots:
       escape-goat: 4.0.0
 
   pure-color@1.3.0: {}
+
+  pure-rand@6.1.0: {}
 
   qrcode.react@3.1.0(react@18.3.1):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,7 @@ catalogs:
     "@polkadot-api/codegen": "~0.12.3"
     "@polkadot-api/metadata-builders": "~0.8.1"
     "@polkadot-api/observable-client": "~0.5.8"
+    "@polkadot-api/sm-provider": "~0.1.3"
     "@polkadot-api/substrate-bindings": "~0.9.1"
     "@polkadot-api/substrate-client": "~0.2.2"
     "@polkadot-api/json-rpc-provider": "~0.0.4"

--- a/projects/demo/package.json
+++ b/projects/demo/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@substrate/demo",
   "version": "0.0.0",
+  "type": "module",
   "private": true,
   "author": "Parity Team <admin@parity.io>",
   "license": "GPL-3.0-only",
@@ -21,14 +22,15 @@
   "dependencies": {
     "@polkadot-api/json-rpc-provider-proxy": "catalog:polkadot-api",
     "@polkadot-api/observable-client": "catalog:polkadot-api",
+    "@polkadot-api/sm-provider": "catalog:polkadot-api",
     "@polkadot-api/substrate-client": "catalog:polkadot-api",
     "@substrate/connect": "workspace:*",
     "@substrate/connect-known-chains": "workspace:*",
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
-    "typescript": "catalog:",
     "eslint": "^8.57.0",
+    "typescript": "catalog:",
     "vite": "^5.3.6",
     "vite-plugin-html": "^3.2.2",
     "vitest": "^2.0.5"


### PR DESCRIPTION
Existing smoldot interface wasnt compatible to the actual smoldot interface, so we couldnt use `smProvider`. 

This change removes the "jsonRpcCallback" from `addChain` and just exposes `nextJsonRpcResponse`and `jsonRpcResponses`, just like smoldot does. 