### PR TITLE
docs: fix Step-by-Step Guide code snippet variable name

### DIFF
--- a/projects/wallet-template/STEP-BY-STEP-GUIDE.md
+++ b/projects/wallet-template/STEP-BY-STEP-GUIDE.md
@@ -116,7 +116,7 @@ const PROVIDER_INFO = {
   rdns: "io.github.paritytech.SubstrateConnectWalletTemplate",
 }
 
-const lightClientProviderPromise = getLightClientProvider(CHANNEL_ID)
+const lightClientProvider = getLightClientProvider(CHANNEL_ID)
 
 // #region Smoldot Discovery Provider
 {


### PR DESCRIPTION
docs: correct variable name in Step-by-Step Guide

Replaced `lightClientProviderPromise` with `lightClientProvider` to match actual usage in the Smoldot Discovery Provider example.  

Was really annoying — I thought I was missing something bigger, but it was just a simple thing.